### PR TITLE
Azure Bulk Import

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Anuj Shroff
+Copyright (c) 2025-2026 Anuj Shroff
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Bastet/Controllers/AzureController.cs
+++ b/src/Bastet/Controllers/AzureController.cs
@@ -1,4 +1,5 @@
 using Bastet.Data;
+using Bastet.Models;
 using Bastet.Models.ViewModels;
 using Bastet.Services.Azure;
 using Microsoft.AspNetCore.Authorization;
@@ -172,8 +173,130 @@ namespace Bastet.Controllers
 
         // Removed ImportSubnets action - we now submit directly to SubnetController.BatchCreate
 
+        // -------------------------------------------------------------------
+        // Bulk Azure Import endpoints
+        // -------------------------------------------------------------------
+
+        // GET: /Azure/BulkImport — landing page; user picks subscription and selects VNets/subnets via AJAX
+        public async Task<IActionResult> BulkImport()
+        {
+            if (!IsAzureImportEnabled())
+            {
+                return RedirectToAction("HttpStatusCodeHandler", "Error", new
+                {
+                    statusCode = 403,
+                    errorMessage = "Azure Import feature is not enabled"
+                });
+            }
+
+            BulkImportInitialViewModel viewModel = new() { IsFeatureEnabled = true };
+
+            // Initial connectivity check (mirrors the single-import flow)
+            try
+            {
+                if (!await azureService.IsCredentialValid())
+                {
+                    ModelState.AddModelError("", "Failed to authenticate with Azure. Please check your credentials.");
+                }
+            }
+            catch (Exception ex)
+            {
+                ModelState.AddModelError("", $"Error connecting to Azure: {ex.Message}");
+            }
+
+            return View(viewModel);
+        }
+
+        // AJAX: Get every IPv4 VNet+subnet in the chosen subscription
+        [HttpGet]
+        public async Task<IActionResult> BulkGetVNets(string subscriptionId)
+        {
+            if (!IsAzureImportEnabled())
+            {
+                return Json(new { success = false, error = "Azure Import feature is not enabled" });
+            }
+
+            if (string.IsNullOrWhiteSpace(subscriptionId))
+            {
+                return Json(new { success = false, error = "Subscription ID is required" });
+            }
+
+            try
+            {
+                List<BulkAzureVNetViewModel> vnets = await azureService.GetAllVNetsWithSubnets(subscriptionId);
+                return Json(new { success = true, vnets });
+            }
+            catch (Exception ex)
+            {
+                return Json(new { success = false, error = ex.Message });
+            }
+        }
+
+        // AJAX: Build a plan from a selection. Plan includes any conflict errors.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> BulkImportPreview(
+            [FromBody] BulkImportSelectionDto selection,
+            [FromServices] IAzureBulkImportPlanner planner)
+        {
+            if (!IsAzureImportEnabled())
+            {
+                return Json(new { success = false, error = "Azure Import feature is not enabled" });
+            }
+
+            if (selection is null)
+            {
+                return Json(new { success = false, error = "No selection was provided." });
+            }
+
+            try
+            {
+                IReadOnlyList<ExistingSubnetSnapshot> existing = await BuildExistingSnapshotAsync();
+                BulkImportPlanViewModel plan = planner.BuildPlan(selection, existing);
+                return Json(new { success = true, plan });
+            }
+            catch (Exception ex)
+            {
+                return Json(new { success = false, error = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// Loads every Bastet subnet (with the booleans the planner needs) into a snapshot list,
+        /// avoiding the planner having to know about EF.
+        /// </summary>
+        private async Task<IReadOnlyList<ExistingSubnetSnapshot>> BuildExistingSnapshotAsync()
+        {
+            // Pull ids and counts in a single query rather than including children/host IPs which would be expensive
+            // for large trees. We only need flags (any-children / any-host-ips), not the entities themselves.
+            List<Subnet> all = await context.Subnets
+                .AsNoTracking()
+                .ToListAsync();
+
+            // Need parent-child counts too. Compute via the in-memory list since we already loaded it.
+            HashSet<int> parentsWithChildren = [.. all.Where(s => s.ParentSubnetId.HasValue).Select(s => s.ParentSubnetId!.Value).Distinct()];
+
+            // Host IP counts: need a small DB query grouped by SubnetId.
+            HashSet<int> subnetsWithHostIps = await context.HostIpAssignments
+                .AsNoTracking()
+                .Select(h => h.SubnetId)
+                .Distinct()
+                .ToHashSetAsync();
+
+            return [.. all.Select(s => new ExistingSubnetSnapshot
+            {
+                Id = s.Id,
+                Name = s.Name,
+                NetworkAddress = s.NetworkAddress,
+                Cidr = s.Cidr,
+                HasChildSubnets = parentsWithChildren.Contains(s.Id),
+                HasHostIpAssignments = subnetsWithHostIps.Contains(s.Id),
+                IsFullyAllocated = s.IsFullyAllocated
+            })];
+        }
+
         // Helper method to check Azure Import environment variable
-        private static bool IsAzureImportEnabled() => bool.TryParse(
+        internal static bool IsAzureImportEnabled() => bool.TryParse(
                 Environment.GetEnvironmentVariable("BASTET_AZURE_IMPORT"),
                 out bool result) && result;
     }

--- a/src/Bastet/Controllers/SubnetController.BulkAzure.cs
+++ b/src/Bastet/Controllers/SubnetController.BulkAzure.cs
@@ -1,0 +1,258 @@
+using Bastet.Models;
+using Bastet.Models.ViewModels;
+using Bastet.Services.Azure;
+using Bastet.Services.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Bastet.Controllers;
+
+public partial class SubnetController : Controller
+{
+    /// <summary>
+    /// POST: Subnet/BulkCreateFromAzurePlan — commits a previously-built Bulk Azure Import plan.
+    ///
+    /// All work happens inside a single transaction. We re-run the planner (using fresh data) before
+    /// applying anything, so even if the database changed between preview and commit we won't import
+    /// a stale plan. Every Bastet subnet creation is funnelled through the same
+    /// <see cref="ValidateSubnetCreation"/> helper used by <c>BatchCreateChildSubnets</c>, ensuring
+    /// the same validation rules apply to bulk imports as to interactive creation.
+    /// </summary>
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = "RequireAdminRole")]
+    public async Task<IActionResult> BulkCreateFromAzurePlan(
+        [FromBody] BulkImportSelectionDto selection,
+        [FromServices] IAzureBulkImportPlanner planner,
+        [FromServices] IInputSanitizationService? sanitizationService = null)
+    {
+        // Feature flag guard — same as the AzureController endpoints
+        if (!AzureController.IsAzureImportEnabled())
+        {
+            return StatusCode(403, new { success = false, error = "Azure Import feature is not enabled" });
+        }
+
+        if (selection is null)
+        {
+            return BadRequest(new { success = false, error = "No selection was provided." });
+        }
+
+        // Re-build the plan against the current Bastet tree right now
+        IReadOnlyList<ExistingSubnetSnapshot> existing = await BuildExistingSnapshotForPlannerAsync();
+        BulkImportPlanViewModel plan = planner.BuildPlan(selection, existing);
+
+        if (!plan.CanCommit)
+        {
+            return BadRequest(new
+            {
+                success = false,
+                globalErrors = plan.GlobalErrors,
+                itemErrors = plan.Items
+                    .Where(i => i.Errors.Count > 0)
+                    .Select(i => new { i.VNetName, i.VNetPrefix, errors = i.Errors })
+                    .ToList()
+            });
+        }
+
+        // Begin transaction (mirror BatchCreateChildSubnets behaviour)
+        using Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction =
+            await context.Database.BeginTransactionAsync();
+
+        try
+        {
+            // Track newly-created subnets so subsequent operations within this transaction can
+            // resolve their parent-by-network/CIDR even before SaveChangesAsync has assigned IDs.
+            int totalSubnetsCreated = 0;
+            int totalTargetsRenamed = 0;
+            int totalTargetsCreated = 0;
+            int totalTargetsMarkedFullyAllocated = 0;
+
+            // Order items so any AutoCreateChild/TopLevel that may itself contain another item runs first.
+            // In practice items don't contain each other (overlap check guarantees that), so order is by CIDR ascending
+            // is a safe, deterministic order regardless.
+            List<BulkImportPlanItem> orderedItems = [.. plan.Items.OrderBy(i => i.PrefixCidr)];
+
+            foreach (BulkImportPlanItem item in orderedItems)
+            {
+                Subnet targetSubnet;
+
+                // 1) Resolve / create the target Bastet subnet for this VNet prefix
+                if (item.TargetType == BulkImportTargetType.ExactMatch)
+                {
+                    Subnet? existingSubnet = await context.Subnets.FindAsync(item.ExistingTargetSubnetId);
+                    if (existingSubnet is null)
+                    {
+                        await transaction.RollbackAsync();
+                        return Conflict(new
+                        {
+                            success = false,
+                            error = $"Matched Bastet subnet (id={item.ExistingTargetSubnetId}) for VNet '{item.VNetName}' was not found. Another user may have deleted it."
+                        });
+                    }
+                    targetSubnet = existingSubnet;
+
+                    // Apply rename if the plan calls for it
+                    if (item.WillRename && !string.IsNullOrEmpty(item.NewName))
+                    {
+                        string newName = sanitizationService?.SanitizeName(item.NewName) ?? item.NewName;
+                        if (!string.Equals(targetSubnet.Name, newName, StringComparison.Ordinal))
+                        {
+                            targetSubnet.Name = newName;
+                            targetSubnet.LastModifiedAt = DateTime.UtcNow;
+                            targetSubnet.ModifiedBy = userContextService.GetCurrentUsername();
+                            await context.SaveChangesAsync();
+                            totalTargetsRenamed++;
+                        }
+                    }
+                }
+                else
+                {
+                    // AutoCreateChild or AutoCreateTopLevel — create a fresh Bastet subnet for the VNet prefix
+                    string targetName = sanitizationService?.SanitizeName(item.AutoCreateTargetName) ?? item.AutoCreateTargetName ?? string.Empty;
+
+                    CreateSubnetViewModel targetVm = new()
+                    {
+                        Name = targetName,
+                        NetworkAddress = item.PrefixNetworkAddress,
+                        Cidr = item.PrefixCidr,
+                        Description = null,
+                        Tags = null,
+                        ParentSubnetId = item.AutoCreateParentSubnetId,
+                        FullyEncompassesVNetPrefix = false
+                    };
+
+                    if (!await ValidateSubnetCreation(targetVm))
+                    {
+                        await transaction.RollbackAsync();
+                        return BadRequest(ModelState);
+                    }
+
+                    targetSubnet = new Subnet
+                    {
+                        Name = targetVm.Name,
+                        NetworkAddress = targetVm.NetworkAddress,
+                        Cidr = targetVm.Cidr,
+                        Description = targetVm.Description,
+                        Tags = targetVm.Tags,
+                        ParentSubnetId = targetVm.ParentSubnetId,
+                        CreatedAt = DateTime.UtcNow,
+                        CreatedBy = userContextService.GetCurrentUsername()
+                    };
+                    context.Subnets.Add(targetSubnet);
+                    await context.SaveChangesAsync();
+                    totalTargetsCreated++;
+                }
+
+                // 2) If a fully-encompassing Azure subnet was selected, mark target as fully allocated and skip child creation
+                if (item.WillMarkFullyAllocated)
+                {
+                    targetSubnet.IsFullyAllocated = true;
+
+                    string azureImportInfo = $"Fully allocated by Azure subnet '{item.FullyAllocatingAzureSubnetName}' which encompasses the entire address space.";
+                    targetSubnet.Description = string.IsNullOrEmpty(targetSubnet.Description)
+                        ? azureImportInfo
+                        : $"{targetSubnet.Description}\n{azureImportInfo}";
+
+                    targetSubnet.LastModifiedAt = DateTime.UtcNow;
+                    targetSubnet.ModifiedBy = userContextService.GetCurrentUsername();
+                    await context.SaveChangesAsync();
+                    totalTargetsMarkedFullyAllocated++;
+                    continue; // do not create children
+                }
+
+                // 3) Create each planned child subnet, validating each one through the standard creation pipeline
+                foreach (BulkImportPlannedChildSubnet child in item.ChildSubnets)
+                {
+                    string childName = sanitizationService?.SanitizeName(child.Name) ?? child.Name;
+                    string childNetwork = sanitizationService?.SanitizeNetworkInput(child.NetworkAddress) ?? child.NetworkAddress;
+
+                    CreateSubnetViewModel childVm = new()
+                    {
+                        Name = childName,
+                        NetworkAddress = childNetwork,
+                        Cidr = child.Cidr,
+                        Description = null,
+                        Tags = null,
+                        ParentSubnetId = targetSubnet.Id,
+                        FullyEncompassesVNetPrefix = false
+                    };
+
+                    if (!await ValidateSubnetCreation(childVm))
+                    {
+                        await transaction.RollbackAsync();
+                        return BadRequest(ModelState);
+                    }
+
+                    Subnet newChild = new()
+                    {
+                        Name = childVm.Name,
+                        NetworkAddress = childVm.NetworkAddress,
+                        Cidr = childVm.Cidr,
+                        Description = childVm.Description,
+                        Tags = childVm.Tags,
+                        ParentSubnetId = targetSubnet.Id,
+                        CreatedAt = DateTime.UtcNow,
+                        CreatedBy = userContextService.GetCurrentUsername()
+                    };
+                    context.Subnets.Add(newChild);
+                    await context.SaveChangesAsync();
+                    totalSubnetsCreated++;
+                }
+            }
+
+            await transaction.CommitAsync();
+
+            TempData["SuccessMessage"] =
+                $"Bulk import succeeded: created {totalTargetsCreated} VNet target subnet(s), " +
+                $"created {totalSubnetsCreated} Azure child subnet(s), " +
+                $"renamed {totalTargetsRenamed} target(s), " +
+                $"and marked {totalTargetsMarkedFullyAllocated} target(s) as fully allocated.";
+
+            return Ok(new
+            {
+                success = true,
+                redirectUrl = Url.Action("Index", "Subnet"),
+                createdTargets = totalTargetsCreated,
+                createdChildSubnets = totalSubnetsCreated,
+                renamedTargets = totalTargetsRenamed,
+                fullyAllocatedTargets = totalTargetsMarkedFullyAllocated
+            });
+        }
+        catch (Exception ex)
+        {
+            await transaction.RollbackAsync();
+            return StatusCode(500, new { success = false, error = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Loads every Bastet subnet (with the booleans the planner needs) into a snapshot list.
+    /// Mirrors <c>AzureController.BuildExistingSnapshotAsync</c>.
+    /// </summary>
+    private async Task<IReadOnlyList<ExistingSubnetSnapshot>> BuildExistingSnapshotForPlannerAsync()
+    {
+        List<Subnet> all = await context.Subnets
+            .AsNoTracking()
+            .ToListAsync();
+
+        HashSet<int> parentsWithChildren = [.. all.Where(s => s.ParentSubnetId.HasValue).Select(s => s.ParentSubnetId!.Value).Distinct()];
+
+        HashSet<int> subnetsWithHostIps = await context.HostIpAssignments
+            .AsNoTracking()
+            .Select(h => h.SubnetId)
+            .Distinct()
+            .ToHashSetAsync();
+
+        return [.. all.Select(s => new ExistingSubnetSnapshot
+        {
+            Id = s.Id,
+            Name = s.Name,
+            NetworkAddress = s.NetworkAddress,
+            Cidr = s.Cidr,
+            HasChildSubnets = parentsWithChildren.Contains(s.Id),
+            HasHostIpAssignments = subnetsWithHostIps.Contains(s.Id),
+            IsFullyAllocated = s.IsFullyAllocated
+        })];
+    }
+}

--- a/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
@@ -91,15 +91,10 @@ namespace Bastet.Models.ViewModels
         public string AddressPrefix { get; set; } = string.Empty;
 
         /// <summary>
-        /// True when this VNet has more than one IPv4 address prefix selected
-        /// (used to drive auto-created target naming).
-        /// </summary>
-        public bool VNetHasMultiplePrefixes { get; set; }
-
-        /// <summary>
         /// Selected Azure subnets that fall under this VNet prefix
         /// </summary>
         public List<BulkImportSelectedSubnetDto> Subnets { get; set; } = [];
+
     }
 
     /// <summary>

--- a/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
@@ -1,0 +1,280 @@
+namespace Bastet.Models.ViewModels
+{
+    /// <summary>
+    /// Lightweight Azure subnet info used in the Bulk Azure Import flow.
+    /// IPv4-only.
+    /// </summary>
+    public class BulkAzureSubnetViewModel
+    {
+        /// <summary>
+        /// The Azure-given name of the subnet
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The IPv4 address prefix in CIDR notation (e.g. "10.0.1.0/24")
+        /// </summary>
+        public string AddressPrefix { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Lightweight Azure VNet info used in the Bulk Azure Import flow.
+    /// Only IPv4 prefixes and IPv4 subnets are reported.
+    /// </summary>
+    public class BulkAzureVNetViewModel
+    {
+        /// <summary>
+        /// Azure resource ID of the VNet
+        /// </summary>
+        public string ResourceId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Azure-given name of the VNet
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The VNet's IPv4 address prefixes (CIDR notation)
+        /// </summary>
+        public List<string> Ipv4AddressPrefixes { get; set; } = [];
+
+        /// <summary>
+        /// IPv4 subnets contained in this VNet
+        /// </summary>
+        public List<BulkAzureSubnetViewModel> Subnets { get; set; } = [];
+    }
+
+    /// <summary>
+    /// View model for the initial Bulk Azure Import landing page
+    /// </summary>
+    public class BulkImportInitialViewModel
+    {
+        /// <summary>
+        /// True when the bulk-import feature flag is enabled
+        /// </summary>
+        public bool IsFeatureEnabled { get; set; }
+    }
+
+    /// <summary>
+    /// A single Azure subnet selection submitted by the browser
+    /// </summary>
+    public class BulkImportSelectedSubnetDto
+    {
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The IPv4 address prefix in CIDR notation (e.g. "10.0.1.0/24")
+        /// </summary>
+        public string AddressPrefix { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// A single VNet IPv4 prefix selection submitted by the browser, plus its
+    /// chosen child Azure subnets.
+    /// </summary>
+    public class BulkImportSelectedVNetPrefixDto
+    {
+        /// <summary>
+        /// The Azure VNet's display name
+        /// </summary>
+        public string VNetName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The Azure VNet's resource id (used for disambiguation)
+        /// </summary>
+        public string VNetResourceId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The IPv4 prefix in CIDR notation (e.g. "10.0.0.0/16").
+        /// One Bastet subnet target is produced per prefix.
+        /// </summary>
+        public string AddressPrefix { get; set; } = string.Empty;
+
+        /// <summary>
+        /// True when this VNet has more than one IPv4 address prefix selected
+        /// (used to drive auto-created target naming).
+        /// </summary>
+        public bool VNetHasMultiplePrefixes { get; set; }
+
+        /// <summary>
+        /// Selected Azure subnets that fall under this VNet prefix
+        /// </summary>
+        public List<BulkImportSelectedSubnetDto> Subnets { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Selection submitted by the browser to Preview / Commit endpoints
+    /// </summary>
+    public class BulkImportSelectionDto
+    {
+        public string SubscriptionId { get; set; } = string.Empty;
+
+        public string? SubscriptionName { get; set; }
+
+        /// <summary>
+        /// Selected VNet IPv4 prefixes (each is an independent target)
+        /// </summary>
+        public List<BulkImportSelectedVNetPrefixDto> VNetPrefixes { get; set; } = [];
+
+        /// <summary>
+        /// Global checkbox: when true, all exact-match targets are renamed to the VNet name.
+        /// Auto-created targets are always named after their VNet (the checkbox does not affect them).
+        /// </summary>
+        public bool RenameMatchedBastetSubnets { get; set; }
+    }
+
+    /// <summary>
+    /// Snapshot of an existing Bastet subnet, used by the planner without
+    /// requiring an EF entity. Decouples the planner from the database.
+    /// </summary>
+    public class ExistingSubnetSnapshot
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string NetworkAddress { get; set; } = string.Empty;
+        public int Cidr { get; set; }
+        public bool HasChildSubnets { get; set; }
+        public bool HasHostIpAssignments { get; set; }
+        public bool IsFullyAllocated { get; set; }
+    }
+
+    /// <summary>
+    /// How the planner decided the target Bastet subnet for a VNet prefix
+    /// </summary>
+    public enum BulkImportTargetType
+    {
+        /// <summary>
+        /// An existing Bastet subnet exactly matches the VNet prefix
+        /// </summary>
+        ExactMatch,
+
+        /// <summary>
+        /// No exact match exists; we will auto-create a new Bastet subnet
+        /// as a child of the deepest existing Bastet subnet that contains the VNet prefix
+        /// </summary>
+        AutoCreateChild,
+
+        /// <summary>
+        /// No exact match and no containing Bastet subnet exists; we will auto-create
+        /// a new top-level Bastet subnet for the VNet prefix
+        /// </summary>
+        AutoCreateTopLevel
+    }
+
+    /// <summary>
+    /// Planned creation of a child Azure subnet under a target
+    /// </summary>
+    public class BulkImportPlannedChildSubnet
+    {
+        /// <summary>
+        /// The original Azure subnet name (raw)
+        /// </summary>
+        public string OriginalAzureName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Final Bastet name (truncated, sanitized, possibly disambiguated)
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
+        /// IPv4 network address
+        /// </summary>
+        public string NetworkAddress { get; set; } = string.Empty;
+
+        public int Cidr { get; set; }
+
+        /// <summary>
+        /// True when this Azure subnet's prefix exactly equals its VNet prefix.
+        /// In that case we do NOT create the child; instead the target is marked IsFullyAllocated.
+        /// </summary>
+        public bool FullyEncompassesTarget { get; set; }
+    }
+
+    /// <summary>
+    /// One row of the bulk import plan: maps a VNet prefix → target Bastet subnet → child Azure subnets
+    /// </summary>
+    public class BulkImportPlanItem
+    {
+        public string VNetName { get; set; } = string.Empty;
+        public string VNetResourceId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Original VNet IPv4 prefix in CIDR notation
+        /// </summary>
+        public string VNetPrefix { get; set; } = string.Empty;
+
+        public string PrefixNetworkAddress { get; set; } = string.Empty;
+        public int PrefixCidr { get; set; }
+
+        public BulkImportTargetType TargetType { get; set; }
+
+        // Populated when TargetType = ExactMatch
+        public int? ExistingTargetSubnetId { get; set; }
+        public string? ExistingTargetSubnetName { get; set; }
+
+        // Populated when TargetType = AutoCreateChild (the existing Bastet subnet under which we'll create the new target)
+        public int? AutoCreateParentSubnetId { get; set; }
+        public string? AutoCreateParentSubnetName { get; set; }
+
+        /// <summary>
+        /// For AutoCreate*: the planned name of the new Bastet target subnet
+        /// </summary>
+        public string? AutoCreateTargetName { get; set; }
+
+        /// <summary>
+        /// True when an exact-match target will be renamed to the VNet name
+        /// (driven by the global RenameMatchedBastetSubnets flag)
+        /// </summary>
+        public bool WillRename { get; set; }
+
+        /// <summary>
+        /// The proposed new name when WillRename is true
+        /// </summary>
+        public string? NewName { get; set; }
+
+        /// <summary>
+        /// True when one of the selected Azure subnets fully encompasses the VNet prefix.
+        /// In that case the target is marked IsFullyAllocated and no child subnets are created.
+        /// </summary>
+        public bool WillMarkFullyAllocated { get; set; }
+
+        public string? FullyAllocatingAzureSubnetName { get; set; }
+
+        /// <summary>
+        /// Planned child subnet creations (excluding any that fully-encompass the target)
+        /// </summary>
+        public List<BulkImportPlannedChildSubnet> ChildSubnets { get; set; } = [];
+
+        /// <summary>
+        /// Hard errors specific to this plan item; presence blocks commit
+        /// </summary>
+        public List<string> Errors { get; set; } = [];
+
+        /// <summary>
+        /// Informational messages (currently unused — every issue is a hard error per design)
+        /// </summary>
+        public List<string> Warnings { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Full output of the planner, also used by the preview view and posted back on commit
+    /// </summary>
+    public class BulkImportPlanViewModel
+    {
+        public string SubscriptionId { get; set; } = string.Empty;
+        public string? SubscriptionName { get; set; }
+        public bool RenameMatchedBastetSubnets { get; set; }
+
+        public List<BulkImportPlanItem> Items { get; set; } = [];
+
+        /// <summary>
+        /// Hard errors that span multiple items (overlap detection, etc.)
+        /// </summary>
+        public List<string> GlobalErrors { get; set; } = [];
+
+        /// <summary>
+        /// True only when there are no global errors and no per-item errors
+        /// </summary>
+        public bool CanCommit => GlobalErrors.Count == 0 && Items.All(i => i.Errors.Count == 0);
+    }
+}

--- a/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
@@ -94,7 +94,6 @@ namespace Bastet.Models.ViewModels
         /// Selected Azure subnets that fall under this VNet prefix
         /// </summary>
         public List<BulkImportSelectedSubnetDto> Subnets { get; set; } = [];
-
     }
 
     /// <summary>

--- a/src/Bastet/Program.cs
+++ b/src/Bastet/Program.cs
@@ -26,6 +26,12 @@ builder.Services.AddOpenApi();
 // Add MVC with global sanitization filter
 builder.Services.AddControllersWithViews(options => options.Filters.Add<GlobalSanitizationFilter>());
 
+// Allow antiforgery tokens to be sent via the "RequestVerificationToken" header in addition to
+// the default form field. Required by AJAX endpoints that POST application/json (e.g. the
+// Bulk Azure Import preview/commit endpoints).
+builder.Services.AddAntiforgery(options => options.HeaderName = "RequestVerificationToken");
+
+
 // Get connection string (used by both DbContexts)
 string? connectionString = Environment.GetEnvironmentVariable("BASTET_CONNECTION_STRING")
     ?? (builder.Environment.IsDevelopment()
@@ -96,6 +102,8 @@ builder.Services.AddScoped<Bastet.Services.Validation.ISubnetValidationService, 
 builder.Services.AddScoped<Bastet.Services.Validation.IHostIpValidationService, Bastet.Services.Validation.HostIpValidationService>();
 builder.Services.AddScoped<Bastet.Services.Division.ISubnetDivisionService, Bastet.Services.Division.SubnetDivisionService>();
 builder.Services.AddScoped<Bastet.Services.Azure.IAzureService, Bastet.Services.Azure.AzureService>();
+builder.Services.AddScoped<Bastet.Services.Azure.IAzureBulkImportPlanner, Bastet.Services.Azure.AzureBulkImportPlanner>();
+
 builder.Services.AddScoped<Bastet.Services.Security.IInputSanitizationService, Bastet.Services.Security.InputSanitizationService>();
 builder.Services.AddSingleton<IVersionService, VersionService>();
 

--- a/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
+++ b/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
@@ -1,0 +1,532 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services.Security;
+
+namespace Bastet.Services.Azure
+{
+    /// <summary>
+    /// Default <see cref="IAzureBulkImportPlanner"/> implementation. Pure (no DB),
+    /// uses <see cref="IIpUtilityService"/> for IP math and <see cref="IInputSanitizationService"/>
+    /// for safe naming. All decisions and conflict checks are made here so the
+    /// preview UI shows exactly what commit will do.
+    /// </summary>
+    public class AzureBulkImportPlanner(
+        IIpUtilityService ipUtilityService,
+        IInputSanitizationService sanitizationService) : IAzureBulkImportPlanner
+    {
+        /// <summary>
+        /// Maximum length for <see cref="Models.Subnet.Name"/>; matches the [MaxLength(50)] attribute on the entity.
+        /// </summary>
+        private const int MaxSubnetNameLength = 50;
+
+        /// <inheritdoc/>
+        public BulkImportPlanViewModel BuildPlan(
+            BulkImportSelectionDto selection,
+            IReadOnlyList<ExistingSubnetSnapshot> existingSubnets)
+        {
+            ArgumentNullException.ThrowIfNull(selection);
+            ArgumentNullException.ThrowIfNull(existingSubnets);
+
+            BulkImportPlanViewModel plan = new()
+            {
+                SubscriptionId = selection.SubscriptionId,
+                SubscriptionName = selection.SubscriptionName,
+                RenameMatchedBastetSubnets = selection.RenameMatchedBastetSubnets
+            };
+
+            if (selection.VNetPrefixes.Count == 0)
+            {
+                plan.GlobalErrors.Add("No VNet address prefixes were selected.");
+                return plan;
+            }
+
+            // -------------------------------------------------------------
+            // Step 1: parse and validate every selected VNet prefix and Azure subnet up front
+            // -------------------------------------------------------------
+            List<ParsedPrefixSelection> parsed = [];
+            foreach (BulkImportSelectedVNetPrefixDto sel in selection.VNetPrefixes)
+            {
+                if (!TryParseCidr(sel.AddressPrefix, out string prefixNetwork, out int prefixCidr))
+                {
+                    plan.GlobalErrors.Add($"VNet '{sel.VNetName}' has an invalid address prefix '{sel.AddressPrefix}'.");
+                    continue;
+                }
+
+                if (!ipUtilityService.IsValidSubnet(prefixNetwork, prefixCidr))
+                {
+                    plan.GlobalErrors.Add(
+                        $"VNet '{sel.VNetName}' prefix '{sel.AddressPrefix}' is not aligned to its CIDR boundary and cannot be imported.");
+                    continue;
+                }
+
+                ParsedPrefixSelection p = new()
+                {
+                    Source = sel,
+                    PrefixNetwork = prefixNetwork,
+                    PrefixCidr = prefixCidr
+                };
+
+                foreach (BulkImportSelectedSubnetDto sub in sel.Subnets)
+                {
+                    if (!TryParseCidr(sub.AddressPrefix, out string subNet, out int subCidr))
+                    {
+                        plan.GlobalErrors.Add(
+                            $"Azure subnet '{sub.Name}' under VNet '{sel.VNetName}' has an invalid address prefix '{sub.AddressPrefix}'.");
+                        continue;
+                    }
+
+                    if (!ipUtilityService.IsValidSubnet(subNet, subCidr))
+                    {
+                        plan.GlobalErrors.Add(
+                            $"Azure subnet '{sub.Name}' ({sub.AddressPrefix}) is not aligned to its CIDR boundary.");
+                        continue;
+                    }
+
+                    // Each Azure subnet must be contained in (or equal to) its VNet prefix.
+                    bool isContained = ipUtilityService.IsSubnetContainedInParent(subNet, subCidr, prefixNetwork, prefixCidr);
+                    bool isEqual = subCidr == prefixCidr
+                        && string.Equals(subNet, prefixNetwork, StringComparison.OrdinalIgnoreCase);
+                    if (!isContained && !isEqual)
+                    {
+                        plan.GlobalErrors.Add(
+                            $"Azure subnet '{sub.Name}' ({sub.AddressPrefix}) is not contained in VNet prefix {sel.AddressPrefix}.");
+                        continue;
+                    }
+
+                    p.Subnets.Add(new ParsedSubnetSelection
+                    {
+                        Source = sub,
+                        Network = subNet,
+                        Cidr = subCidr,
+                        FullyEncompasses = isEqual
+                    });
+                }
+
+                parsed.Add(p);
+            }
+
+            if (plan.GlobalErrors.Count > 0)
+            {
+                // Don't bother computing the rest — input is malformed
+                return plan;
+            }
+
+            // -------------------------------------------------------------
+            // Step 2: cross-prefix overlap detection (selection-vs-selection)
+            // -------------------------------------------------------------
+            DetectVNetPrefixOverlaps(parsed, plan);
+            DetectAzureSubnetOverlaps(parsed, plan);
+
+            // -------------------------------------------------------------
+            // Step 3: determine target Bastet subnet for each VNet prefix and check Bastet conflicts
+            // -------------------------------------------------------------
+            foreach (ParsedPrefixSelection p in parsed)
+            {
+                BulkImportPlanItem item = BuildPlanItem(p, existingSubnets, selection.RenameMatchedBastetSubnets);
+                plan.Items.Add(item);
+            }
+
+            // -------------------------------------------------------------
+            // Step 4: cross-checks involving existing Bastet tree
+            // -------------------------------------------------------------
+            DetectExistingBastetSubnetConflicts(parsed, existingSubnets, plan);
+            DetectVNetPrefixWouldContainExistingSubnet(parsed, existingSubnets, plan);
+
+            return plan;
+        }
+
+        // -------------------------------------------------------------------
+        // Plan item construction
+        // -------------------------------------------------------------------
+        private BulkImportPlanItem BuildPlanItem(
+            ParsedPrefixSelection p,
+            IReadOnlyList<ExistingSubnetSnapshot> existingSubnets,
+            bool renameMatched)
+        {
+            BulkImportPlanItem item = new()
+            {
+                VNetName = p.Source.VNetName,
+                VNetResourceId = p.Source.VNetResourceId,
+                VNetPrefix = p.Source.AddressPrefix,
+                PrefixNetworkAddress = p.PrefixNetwork,
+                PrefixCidr = p.PrefixCidr
+            };
+
+            // 1) Exact match?
+            ExistingSubnetSnapshot? exact = existingSubnets.FirstOrDefault(s =>
+                s.Cidr == p.PrefixCidr && string.Equals(s.NetworkAddress, p.PrefixNetwork, StringComparison.OrdinalIgnoreCase));
+
+            if (exact is not null)
+            {
+                item.TargetType = BulkImportTargetType.ExactMatch;
+                item.ExistingTargetSubnetId = exact.Id;
+                item.ExistingTargetSubnetName = exact.Name;
+
+                // Hard fail (5b) if the matched Bastet subnet is non-empty.
+                if (exact.HasChildSubnets)
+                {
+                    item.Errors.Add(
+                        $"Cannot import VNet prefix {p.Source.AddressPrefix}: matched Bastet subnet '{exact.Name}' ({exact.NetworkAddress}/{exact.Cidr}) already has child subnets.");
+                }
+                if (exact.HasHostIpAssignments)
+                {
+                    item.Errors.Add(
+                        $"Cannot import VNet prefix {p.Source.AddressPrefix}: matched Bastet subnet '{exact.Name}' ({exact.NetworkAddress}/{exact.Cidr}) already has host IP assignments.");
+                }
+                if (exact.IsFullyAllocated)
+                {
+                    item.Errors.Add(
+                        $"Cannot import VNet prefix {p.Source.AddressPrefix}: matched Bastet subnet '{exact.Name}' ({exact.NetworkAddress}/{exact.Cidr}) is marked as fully allocated.");
+                }
+
+                if (renameMatched)
+                {
+                    string proposed = TruncateAndSanitizeName(p.Source.VNetName);
+                    if (!string.Equals(proposed, exact.Name, StringComparison.Ordinal))
+                    {
+                        item.WillRename = true;
+                        item.NewName = proposed;
+                    }
+                }
+            }
+            else
+            {
+                // 2) Find deepest containing Bastet subnet (strictly larger CIDR than the prefix? no — smaller CIDR number = larger network)
+                ExistingSubnetSnapshot? deepest = null;
+                foreach (ExistingSubnetSnapshot candidate in existingSubnets)
+                {
+                    if (ipUtilityService.IsSubnetContainedInParent(
+                        p.PrefixNetwork, p.PrefixCidr,
+                        candidate.NetworkAddress, candidate.Cidr))
+                    {
+                        if (deepest is null || candidate.Cidr > deepest.Cidr)
+                        {
+                            deepest = candidate;
+                        }
+                    }
+                }
+
+                if (deepest is not null)
+                {
+                    item.TargetType = BulkImportTargetType.AutoCreateChild;
+                    item.AutoCreateParentSubnetId = deepest.Id;
+                    item.AutoCreateParentSubnetName = deepest.Name;
+                    item.AutoCreateTargetName = TruncateAndSanitizeName(p.Source.VNetName);
+
+                    // The auto-created target's parent must be eligible to receive children
+                    if (deepest.HasHostIpAssignments)
+                    {
+                        item.Errors.Add(
+                            $"Cannot import VNet prefix {p.Source.AddressPrefix}: containing Bastet subnet '{deepest.Name}' ({deepest.NetworkAddress}/{deepest.Cidr}) has host IP assignments and cannot have child subnets.");
+                    }
+                    if (deepest.IsFullyAllocated)
+                    {
+                        item.Errors.Add(
+                            $"Cannot import VNet prefix {p.Source.AddressPrefix}: containing Bastet subnet '{deepest.Name}' ({deepest.NetworkAddress}/{deepest.Cidr}) is marked as fully allocated.");
+                    }
+                }
+                else
+                {
+                    item.TargetType = BulkImportTargetType.AutoCreateTopLevel;
+                    item.AutoCreateTargetName = TruncateAndSanitizeName(p.Source.VNetName);
+                }
+            }
+
+            // 3) Determine fully-encompassing child (if any)
+            ParsedSubnetSelection? fullyEncompassing = p.Subnets.FirstOrDefault(s => s.FullyEncompasses);
+            if (fullyEncompassing is not null)
+            {
+                item.WillMarkFullyAllocated = true;
+                item.FullyAllocatingAzureSubnetName = fullyEncompassing.Source.Name;
+            }
+
+            // 4) Build planned child subnets (excluding the fully-encompassing one)
+            HashSet<string> usedNames = new(StringComparer.OrdinalIgnoreCase);
+            string? targetExistingName = exact?.Name;
+            string? targetAutoCreatedName = item.AutoCreateTargetName;
+
+            // Reserve the target's own name so child subnets don't collide with it visually
+            if (!string.IsNullOrEmpty(targetExistingName))
+            {
+                usedNames.Add(targetExistingName);
+            }
+            if (item.WillRename && !string.IsNullOrEmpty(item.NewName))
+            {
+                usedNames.Add(item.NewName);
+            }
+            if (!string.IsNullOrEmpty(targetAutoCreatedName))
+            {
+                usedNames.Add(targetAutoCreatedName);
+            }
+
+            foreach (ParsedSubnetSelection sub in p.Subnets)
+            {
+                if (sub.FullyEncompasses)
+                {
+                    continue; // do not create as child; instead mark target fully allocated
+                }
+
+                string baseName = TruncateAndSanitizeName(sub.Source.Name);
+                if (string.IsNullOrEmpty(baseName))
+                {
+                    baseName = $"{sub.Network}_{sub.Cidr}";
+                }
+
+                string finalName = DisambiguateName(baseName, usedNames, p.Source.VNetName);
+                usedNames.Add(finalName);
+
+                item.ChildSubnets.Add(new BulkImportPlannedChildSubnet
+                {
+                    OriginalAzureName = sub.Source.Name,
+                    Name = finalName,
+                    NetworkAddress = sub.Network,
+                    Cidr = sub.Cidr,
+                    FullyEncompassesTarget = false
+                });
+            }
+
+            return item;
+        }
+
+        // -------------------------------------------------------------------
+        // Conflict detection helpers
+        // -------------------------------------------------------------------
+
+        /// <summary>
+        /// Detect overlaps between any two selected VNet IPv4 prefixes.
+        /// Equal prefixes from different VNets and one-contains-the-other both qualify.
+        /// </summary>
+        private void DetectVNetPrefixOverlaps(IReadOnlyList<ParsedPrefixSelection> parsed, BulkImportPlanViewModel plan)
+        {
+            for (int i = 0; i < parsed.Count; i++)
+            {
+                for (int j = i + 1; j < parsed.Count; j++)
+                {
+                    ParsedPrefixSelection a = parsed[i];
+                    ParsedPrefixSelection b = parsed[j];
+
+                    if (PrefixesOverlap(a.PrefixNetwork, a.PrefixCidr, b.PrefixNetwork, b.PrefixCidr))
+                    {
+                        plan.GlobalErrors.Add(
+                            $"Selected VNet prefix {b.Source.AddressPrefix} (VNet '{b.Source.VNetName}') overlaps with {a.Source.AddressPrefix} (VNet '{a.Source.VNetName}').");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Detect overlaps between any two selected Azure subnets, even across VNets.
+        /// </summary>
+        private void DetectAzureSubnetOverlaps(IReadOnlyList<ParsedPrefixSelection> parsed, BulkImportPlanViewModel plan)
+        {
+            // Flatten everything so each comparison is straightforward.
+            List<(ParsedPrefixSelection prefix, ParsedSubnetSelection subnet)> all = [];
+            foreach (ParsedPrefixSelection p in parsed)
+            {
+                foreach (ParsedSubnetSelection s in p.Subnets)
+                {
+                    if (s.FullyEncompasses)
+                    {
+                        continue; // these are not created; only mark the target fully allocated
+                    }
+                    all.Add((p, s));
+                }
+            }
+
+            for (int i = 0; i < all.Count; i++)
+            {
+                for (int j = i + 1; j < all.Count; j++)
+                {
+                    (ParsedPrefixSelection pa, ParsedSubnetSelection a) = all[i];
+                    (ParsedPrefixSelection pb, ParsedSubnetSelection b) = all[j];
+
+                    if (PrefixesOverlap(a.Network, a.Cidr, b.Network, b.Cidr))
+                    {
+                        plan.GlobalErrors.Add(
+                            $"Selected Azure subnet '{b.Source.Name}' ({b.Source.AddressPrefix}, VNet '{pb.Source.VNetName}') overlaps with '{a.Source.Name}' ({a.Source.AddressPrefix}, VNet '{pa.Source.VNetName}').");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Hard-fail if any selected Azure subnet's network/CIDR already exists in Bastet (anywhere in the tree).
+        /// Bastet enforces global uniqueness of network/CIDR; importing a duplicate would fail at commit anyway,
+        /// so we surface it during preview.
+        /// </summary>
+        private static void DetectExistingBastetSubnetConflicts(
+            IReadOnlyList<ParsedPrefixSelection> parsed,
+            IReadOnlyList<ExistingSubnetSnapshot> existingSubnets,
+            BulkImportPlanViewModel plan)
+        {
+            foreach (ParsedPrefixSelection p in parsed)
+            {
+                foreach (ParsedSubnetSelection s in p.Subnets)
+                {
+                    if (s.FullyEncompasses)
+                    {
+                        continue; // these don't get created
+                    }
+
+                    bool exists = existingSubnets.Any(e =>
+                        e.Cidr == s.Cidr &&
+                        string.Equals(e.NetworkAddress, s.Network, StringComparison.OrdinalIgnoreCase));
+
+                    if (exists)
+                    {
+                        plan.GlobalErrors.Add(
+                            $"Azure subnet '{s.Source.Name}' ({s.Source.AddressPrefix}, VNet '{p.Source.VNetName}') already exists in Bastet.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Hard-fail if any VNet prefix would, when created in Bastet, contain an existing Bastet subnet
+        /// (which would create an invalid hierarchy, e.g. importing 10.0.0.0/16 when 10.0.0.0/24 already exists
+        /// without 10.0.0.0/16 also existing).
+        /// </summary>
+        private void DetectVNetPrefixWouldContainExistingSubnet(
+            IReadOnlyList<ParsedPrefixSelection> parsed,
+            IReadOnlyList<ExistingSubnetSnapshot> existingSubnets,
+            BulkImportPlanViewModel plan)
+        {
+            // Only matters when the prefix is being *created* (not when it's an exact match).
+            foreach (ParsedPrefixSelection p in parsed)
+            {
+                bool exactExists = existingSubnets.Any(e =>
+                    e.Cidr == p.PrefixCidr &&
+                    string.Equals(e.NetworkAddress, p.PrefixNetwork, StringComparison.OrdinalIgnoreCase));
+                if (exactExists)
+                {
+                    continue;
+                }
+
+                foreach (ExistingSubnetSnapshot e in existingSubnets)
+                {
+                    // Would the new VNet target contain this existing subnet?
+                    if (ipUtilityService.IsSubnetContainedInParent(
+                        e.NetworkAddress, e.Cidr,
+                        p.PrefixNetwork, p.PrefixCidr))
+                    {
+                        plan.GlobalErrors.Add(
+                            $"VNet prefix {p.Source.AddressPrefix} (VNet '{p.Source.VNetName}') would contain existing Bastet subnet '{e.Name}' ({e.NetworkAddress}/{e.Cidr}). " +
+                            "Importing it would create an invalid hierarchy.");
+                    }
+                }
+            }
+        }
+
+        // -------------------------------------------------------------------
+        // Utility helpers
+        // -------------------------------------------------------------------
+
+        /// <summary>Returns true when two IPv4 CIDR prefixes overlap (one contains the other, or they are equal).</summary>
+        private bool PrefixesOverlap(string aNetwork, int aCidr, string bNetwork, int bCidr)
+        {
+            if (aCidr == bCidr && string.Equals(aNetwork, bNetwork, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // Either a contains b, or b contains a.
+            return ipUtilityService.IsSubnetContainedInParent(bNetwork, bCidr, aNetwork, aCidr)
+                || ipUtilityService.IsSubnetContainedInParent(aNetwork, aCidr, bNetwork, bCidr);
+        }
+
+        private static bool TryParseCidr(string addressPrefix, out string network, out int cidr)
+        {
+            network = string.Empty;
+            cidr = 0;
+            if (string.IsNullOrWhiteSpace(addressPrefix))
+            {
+                return false;
+            }
+
+            string[] parts = addressPrefix.Split('/');
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            if (!int.TryParse(parts[1], out int parsedCidr) || parsedCidr is < 0 or > 32)
+            {
+                return false;
+            }
+
+            network = parts[0];
+            cidr = parsedCidr;
+            return true;
+        }
+
+        private string TruncateAndSanitizeName(string? rawName)
+        {
+            string sanitized = sanitizationService.SanitizeName(rawName);
+            if (sanitized.Length > MaxSubnetNameLength)
+            {
+                sanitized = sanitized[..MaxSubnetNameLength];
+            }
+            return sanitized;
+        }
+
+        /// <summary>
+        /// If <paramref name="baseName"/> is already used, append a VNet suffix to disambiguate,
+        /// preserving the 50-character limit. Falls back to numeric suffixes if even the suffixed
+        /// name collides.
+        /// </summary>
+        private static string DisambiguateName(string baseName, HashSet<string> usedNames, string vnetName)
+        {
+            if (!usedNames.Contains(baseName))
+            {
+                return baseName;
+            }
+
+            // Trim VNet name to a short suffix
+            string vnetSuffix = vnetName ?? string.Empty;
+            if (vnetSuffix.Length > 20)
+            {
+                vnetSuffix = vnetSuffix[..20];
+            }
+
+            string candidate = TruncateForName($"{baseName} ({vnetSuffix})");
+            if (!usedNames.Contains(candidate))
+            {
+                return candidate;
+            }
+
+            // Fall back to numeric suffix
+            for (int i = 2; i < int.MaxValue; i++)
+            {
+                string numbered = TruncateForName($"{baseName} ({vnetSuffix} {i})");
+                if (!usedNames.Contains(numbered))
+                {
+                    return numbered;
+                }
+            }
+
+            // Practically unreachable
+            return baseName;
+        }
+
+        private static string TruncateForName(string s) =>
+            s.Length > MaxSubnetNameLength ? s[..MaxSubnetNameLength] : s;
+
+        // -------------------------------------------------------------------
+        // Internal scratch types — keep them private so the planner's surface area is just BuildPlan().
+        // -------------------------------------------------------------------
+        private sealed class ParsedPrefixSelection
+        {
+            public BulkImportSelectedVNetPrefixDto Source { get; init; } = null!;
+            public string PrefixNetwork { get; init; } = string.Empty;
+            public int PrefixCidr { get; init; }
+            public List<ParsedSubnetSelection> Subnets { get; } = [];
+        }
+
+        private sealed class ParsedSubnetSelection
+        {
+            public BulkImportSelectedSubnetDto Source { get; init; } = null!;
+            public string Network { get; init; } = string.Empty;
+            public int Cidr { get; init; }
+            public bool FullyEncompasses { get; init; }
+        }
+    }
+}

--- a/src/Bastet/Services/Azure/AzureService.cs
+++ b/src/Bastet/Services/Azure/AzureService.cs
@@ -278,6 +278,101 @@ namespace Bastet.Services.Azure
             }
         }
 
+        /// <inheritdoc/>
+        public async Task<List<BulkAzureVNetViewModel>> GetAllVNetsWithSubnets(string subscriptionId)
+        {
+            if (_armClient == null || string.IsNullOrEmpty(subscriptionId))
+            {
+                return [];
+            }
+
+            List<BulkAzureVNetViewModel> result = [];
+
+            try
+            {
+                ResourceIdentifier resourceIdentifier = SubscriptionResource.CreateResourceIdentifier(subscriptionId);
+                SubscriptionResource selectedSubscription = _armClient.GetSubscriptionResource(resourceIdentifier);
+
+                await foreach (VirtualNetworkResource vnet in selectedSubscription.GetVirtualNetworksAsync())
+                {
+                    BulkAzureVNetViewModel vnetVm = new()
+                    {
+                        ResourceId = vnet.Id.ToString(),
+                        Name = vnet.Data.Name
+                    };
+
+                    // Collect IPv4 prefixes only
+                    if (vnet.Data.AddressSpace?.AddressPrefixes != null)
+                    {
+                        foreach (string? prefix in vnet.Data.AddressSpace.AddressPrefixes)
+                        {
+                            if (!string.IsNullOrEmpty(prefix) && IsIpv4AddressPrefix(prefix))
+                            {
+                                vnetVm.Ipv4AddressPrefixes.Add(prefix);
+                            }
+                        }
+                    }
+
+                    // Skip VNets that have no IPv4 prefixes (IPv6-only is out of scope)
+                    if (vnetVm.Ipv4AddressPrefixes.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    // Enumerate subnets in the VNet (IPv4 only)
+                    await foreach (SubnetResource? subnet in vnet.GetSubnets())
+                    {
+                        string? ipv4Prefix = ExtractIpv4Prefix(subnet);
+                        if (string.IsNullOrEmpty(ipv4Prefix))
+                        {
+                            continue;
+                        }
+
+                        vnetVm.Subnets.Add(new BulkAzureSubnetViewModel
+                        {
+                            Name = subnet.Data.Name ?? string.Empty,
+                            AddressPrefix = ipv4Prefix
+                        });
+                    }
+
+                    result.Add(vnetVm);
+                }
+
+                return result;
+            }
+            catch (Exception)
+            {
+                return [];
+            }
+        }
+
+        /// <summary>
+        /// Returns the first IPv4 prefix associated with the given Azure subnet, or null if none exists.
+        /// Handles both single-prefix subnets and dual-stack subnets.
+        /// </summary>
+        private static string? ExtractIpv4Prefix(SubnetResource subnet)
+        {
+            // Case 1: Single address prefix
+            if (subnet.Data.AddressPrefix is not null && IsIpv4AddressPrefix(subnet.Data.AddressPrefix))
+            {
+                return subnet.Data.AddressPrefix;
+            }
+
+            // Case 2: Multiple address prefixes (dual-stack)
+            if (subnet.Data.AddressPrefixes?.Any() == true)
+            {
+                foreach (string? prefix in subnet.Data.AddressPrefixes)
+                {
+                    if (!string.IsNullOrEmpty(prefix) && IsIpv4AddressPrefix(prefix))
+                    {
+                        return prefix;
+                    }
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Tries to add a subnet to the result list if it's a valid child of the specified parent subnet
         /// </summary>
@@ -290,6 +385,7 @@ namespace Bastet.Services.Azure
             int parentCidr)
         {
             string networkAddress = GetNetworkAddressFromCidr(addressPrefix);
+
             int subnetCidr = GetCidrFromAddressPrefix(addressPrefix);
 
             // Check if this subnet would be a valid child of our Bastet subnet

--- a/src/Bastet/Services/Azure/IAzureBulkImportPlanner.cs
+++ b/src/Bastet/Services/Azure/IAzureBulkImportPlanner.cs
@@ -1,0 +1,23 @@
+using Bastet.Models.ViewModels;
+
+namespace Bastet.Services.Azure
+{
+    /// <summary>
+    /// Computes a Bulk Azure Import plan from a user's selection plus the
+    /// current Bastet subnet tree, performing all overlap/conflict detection
+    /// up front so the commit step does not surface surprises.
+    /// </summary>
+    public interface IAzureBulkImportPlanner
+    {
+        /// <summary>
+        /// Build a plan for the given selection. The returned plan is always
+        /// well-formed; check <see cref="BulkImportPlanViewModel.CanCommit"/>
+        /// to determine whether it can be safely executed.
+        /// </summary>
+        /// <param name="selection">The user's selection from the Bulk Azure Import UI</param>
+        /// <param name="existingSubnets">Snapshot of every Bastet subnet currently in the database</param>
+        BulkImportPlanViewModel BuildPlan(
+            BulkImportSelectionDto selection,
+            IReadOnlyList<ExistingSubnetSnapshot> existingSubnets);
+    }
+}

--- a/src/Bastet/Services/Azure/IAzureService.cs
+++ b/src/Bastet/Services/Azure/IAzureService.cs
@@ -42,5 +42,17 @@ namespace Bastet.Services.Azure
             string vnetResourceId,
             string networkAddress,
             int cidr);
+
+        /// <summary>
+        /// Gets every VNet in a subscription with its IPv4 prefixes and IPv4 subnets.
+        /// Intended for the Bulk Azure Import flow where the user picks across the whole subscription.
+        /// IPv6 prefixes/subnets are filtered out. Subnets that have only IPv6 prefixes are excluded;
+        /// subnets that have both IPv4 and IPv6 prefixes return only their IPv4 prefix.
+        /// </summary>
+        /// <param name="subscriptionId">The Azure subscription ID</param>
+        /// <returns>List of VNets with their IPv4 prefixes and IPv4 subnets</returns>
+        Task<List<BulkAzureVNetViewModel>> GetAllVNetsWithSubnets(string subscriptionId);
     }
 }
+
+

--- a/src/Bastet/Views/Azure/BulkImport.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport.cshtml
@@ -1,0 +1,72 @@
+@model Bastet.Models.ViewModels.BulkImportInitialViewModel
+
+@{
+    ViewData["Title"] = "Bulk Azure Import";
+}
+
+<div class="container mt-4">
+    <div class="row">
+        <div class="col-md-10 offset-md-1">
+            <div class="card">
+                <div class="card-header bg-primary text-white">
+                    @await Html.PartialAsync("BulkImport/_Header", Model)
+                </div>
+                <div class="card-body">
+                    @if (!ViewData.ModelState.IsValid)
+                    {
+                        @await Html.PartialAsync("BulkImport/_ErrorAlert", Model)
+                    }
+
+                    @Html.AntiForgeryToken()
+
+                    <ul class="nav nav-pills nav-justified mb-3" id="bulk-import-tabs" role="tablist">
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link active" id="step1-tab" data-bs-toggle="pill" data-bs-target="#step1" type="button" role="tab" aria-controls="step1" aria-selected="true">
+                                <span class="badge rounded-pill bg-primary">1</span> Subscription
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link disabled" id="step2-tab" data-bs-toggle="pill" data-bs-target="#step2" type="button" role="tab" aria-controls="step2" aria-selected="false">
+                                <span class="badge rounded-pill bg-primary">2</span> Select VNets &amp; Subnets
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link disabled" id="step3-tab" data-bs-toggle="pill" data-bs-target="#step3" type="button" role="tab" aria-controls="step3" aria-selected="false">
+                                <span class="badge rounded-pill bg-primary">3</span> Preview
+                            </button>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <button class="nav-link disabled" id="step4-tab" data-bs-toggle="pill" data-bs-target="#step4" type="button" role="tab" aria-controls="step4" aria-selected="false">
+                                <span class="badge rounded-pill bg-primary">4</span> Commit
+                            </button>
+                        </li>
+                    </ul>
+
+                    <div class="tab-content" id="bulk-import-tab-content">
+                        <div class="tab-pane fade show active" id="step1" role="tabpanel" aria-labelledby="step1-tab">
+                            @await Html.PartialAsync("BulkImport/_StepSubscription", Model)
+                        </div>
+                        <div class="tab-pane fade" id="step2" role="tabpanel" aria-labelledby="step2-tab">
+                            @await Html.PartialAsync("BulkImport/_StepSelection", Model)
+                        </div>
+                        <div class="tab-pane fade" id="step3" role="tabpanel" aria-labelledby="step3-tab">
+                            @await Html.PartialAsync("BulkImport/_StepPreview", Model)
+                        </div>
+                        <div class="tab-pane fade" id="step4" role="tabpanel" aria-labelledby="step4-tab">
+                            @await Html.PartialAsync("BulkImport/_StepCommit", Model)
+                        </div>
+                    </div>
+                </div>
+                <div class="card-footer">
+                    <a asp-controller="Subnet" asp-action="Index" class="btn btn-outline-secondary">
+                        <i class="bi bi-arrow-left"></i> Back to Subnets
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @await Html.PartialAsync("BulkImport/_BulkScripts", Model)
+}

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -9,7 +9,6 @@
         let selectedSubscriptionName = "";
         let vnets = []; // [{ resourceId, name, ipv4AddressPrefixes:[], subnets:[{name, addressPrefix}] }]
         let lastSelection = null; // last BulkImportSelectionDto submitted
-        let lastPlan = null;      // last plan returned from preview
 
         // ---------------------------------------------------------------
         // Step navigation helpers
@@ -285,7 +284,6 @@
                     subnets: []
                 };
 
-
                 $(`.bulk-subnet-checkbox[data-vnet-idx='${vIdx}'][data-prefix='${prefix}']:checked`).each(function () {
                     prefixDto.subnets.push({
                         name: $(this).attr('data-name'),
@@ -322,7 +320,6 @@
                         $("#bulk-preview-error").removeClass("d-none");
                         return;
                     }
-                    lastPlan = result.plan;
                     renderPlan(result.plan);
                     $("#bulk-preview-content").removeClass("d-none");
                 },

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -1,0 +1,503 @@
+@model Bastet.Models.ViewModels.BulkImportInitialViewModel
+
+<script>
+    $(document).ready(function () {
+        // ---------------------------------------------------------------
+        // State
+        // ---------------------------------------------------------------
+        let selectedSubscriptionId = "";
+        let selectedSubscriptionName = "";
+        let vnets = []; // [{ resourceId, name, ipv4AddressPrefixes:[], subnets:[{name, addressPrefix}] }]
+        let lastSelection = null; // last BulkImportSelectionDto submitted
+        let lastPlan = null;      // last plan returned from preview
+
+        // ---------------------------------------------------------------
+        // Step navigation helpers
+        // ---------------------------------------------------------------
+        function activateTab(tabId) {
+            $("#bulk-import-tabs .nav-link").removeClass("active");
+            $("#bulk-import-tab-content .tab-pane").removeClass("show active");
+
+            $("#" + tabId + "-tab").removeClass("disabled").addClass("active");
+            $("#" + tabId).addClass("show active");
+        }
+
+        function escapeHtml(s) {
+            if (s === null || s === undefined) {
+                return "";
+            }
+            return String(s)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
+        }
+
+        function getAntiForgeryToken() {
+            return $("input[name='__RequestVerificationToken']").first().val();
+        }
+
+        // ---------------------------------------------------------------
+        // Step 1: Subscriptions
+        // ---------------------------------------------------------------
+        loadAzureSubscriptions();
+
+        function loadAzureSubscriptions() {
+            $.ajax({
+                url: '@Url.Action("GetSubscriptions", "Azure")',
+                type: "GET",
+                dataType: "json",
+                beforeSend: function () {
+                    $("#bulk-subscription-loading").show();
+                    $("#bulk-subscription-selection").addClass("d-none");
+                    $("#bulk-subscription-error").addClass("d-none");
+                    $("#bulk-no-subscriptions").addClass("d-none");
+                },
+                success: function (result) {
+                    if (result.success && result.subscriptions && result.subscriptions.length > 0) {
+                        const $dropdown = $("#bulk-subscription-select");
+                        $dropdown.empty();
+                        $dropdown.append('<option value="" disabled selected>-- Select a subscription --</option>');
+                        $.each(result.subscriptions, function (i, s) {
+                            $dropdown.append($('<option></option>')
+                                .attr('value', s.subscriptionId)
+                                .attr('data-name', s.displayName)
+                                .text(s.displayName + ' (' + s.subscriptionId + ')'));
+                        });
+                        $("#bulk-subscription-selection").removeClass("d-none");
+                    } else if (result.success) {
+                        $("#bulk-no-subscriptions").removeClass("d-none");
+                    } else {
+                        $("#bulk-subscription-error-message").text(result.error || "Failed to load subscriptions");
+                        $("#bulk-subscription-error").removeClass("d-none");
+                    }
+                },
+                error: function (xhr, status, error) {
+                    $("#bulk-subscription-error-message").text("Error connecting to server: " + error);
+                    $("#bulk-subscription-error").removeClass("d-none");
+                },
+                complete: function () {
+                    $("#bulk-subscription-loading").hide();
+                }
+            });
+        }
+
+        $("#bulk-subscription-select").on("change", function () {
+            $("#bulk-select-subscription-btn").prop("disabled", !$(this).val());
+        });
+
+        $("#bulk-select-subscription-btn").on("click", function () {
+            const $opt = $("#bulk-subscription-select option:selected");
+            selectedSubscriptionId = $opt.val();
+            selectedSubscriptionName = $opt.attr("data-name") || "";
+            if (!selectedSubscriptionId) return;
+
+            activateTab("step2");
+            loadVNets();
+        });
+
+        // ---------------------------------------------------------------
+        // Step 2: Selection tree
+        // ---------------------------------------------------------------
+        function loadVNets() {
+            $.ajax({
+                url: '@Url.Action("BulkGetVNets", "Azure")',
+                type: "GET",
+                data: { subscriptionId: selectedSubscriptionId },
+                dataType: "json",
+                beforeSend: function () {
+                    $("#bulk-vnet-loading").removeClass("d-none");
+                    $("#bulk-vnet-selection").addClass("d-none");
+                    $("#bulk-vnet-error").addClass("d-none");
+                    $("#bulk-no-vnets").addClass("d-none");
+                },
+                success: function (result) {
+                    if (!result.success) {
+                        $("#bulk-vnet-error-message").text(result.error || "Failed to load VNets");
+                        $("#bulk-vnet-error").removeClass("d-none");
+                        return;
+                    }
+                    vnets = result.vnets || [];
+                    if (vnets.length === 0) {
+                        $("#bulk-no-vnets").removeClass("d-none");
+                        return;
+                    }
+                    renderVNetTree();
+                    $("#bulk-vnet-selection").removeClass("d-none");
+                    updateGoPreviewBtn();
+                },
+                error: function (xhr, status, error) {
+                    $("#bulk-vnet-error-message").text("Error connecting to server: " + error);
+                    $("#bulk-vnet-error").removeClass("d-none");
+                },
+                complete: function () {
+                    $("#bulk-vnet-loading").addClass("d-none");
+                }
+            });
+        }
+
+        function renderVNetTree() {
+            const $tree = $("#bulk-vnet-tree").empty();
+
+            $.each(vnets, function (vIdx, vnet) {
+                const $card = $('<div class="card mb-2"></div>');
+                const $body = $('<div class="card-body p-2"></div>');
+
+                $.each(vnet.ipv4AddressPrefixes, function (pIdx, prefix) {
+                    const prefixId = `bulk-prefix-${vIdx}-${pIdx}`;
+                    const $prefixDiv = $('<div class="form-check border-bottom pb-2 mb-2"></div>');
+                    const $prefixCheckbox = $('<input type="checkbox" class="form-check-input bulk-prefix-checkbox">')
+                        .attr('id', prefixId)
+                        .attr('data-vnet-idx', vIdx)
+                        .attr('data-prefix', prefix);
+                    const $prefixLabel = $('<label class="form-check-label"></label>')
+                        .attr('for', prefixId)
+                        .html(`<strong>${escapeHtml(vnet.name)}</strong> <span class="badge bg-secondary">${escapeHtml(prefix)}</span>`);
+
+                    $prefixDiv.append($prefixCheckbox).append($prefixLabel);
+
+                    // Filter Azure subnets that are contained in this prefix only
+                    const containedSubnets = vnet.subnets.filter(function (s) { return prefixContainsCidr(prefix, s.addressPrefix); });
+
+                    if (containedSubnets.length > 0) {
+                        const $subList = $('<div class="ms-4 mt-2"></div>');
+                        $.each(containedSubnets, function (sIdx, subnet) {
+                            const subnetId = `bulk-subnet-${vIdx}-${pIdx}-${sIdx}`;
+                            const $subnetDiv = $('<div class="form-check"></div>');
+                            const $subnetCheckbox = $('<input type="checkbox" class="form-check-input bulk-subnet-checkbox">')
+                                .attr('id', subnetId)
+                                .attr('data-vnet-idx', vIdx)
+                                .attr('data-prefix', prefix)
+                                .attr('data-name', subnet.name)
+                                .attr('data-address-prefix', subnet.addressPrefix);
+                            const $subnetLabel = $('<label class="form-check-label"></label>')
+                                .attr('for', subnetId)
+                                .html(`${escapeHtml(subnet.name)} <span class="text-muted">${escapeHtml(subnet.addressPrefix)}</span>`);
+                            $subnetDiv.append($subnetCheckbox).append($subnetLabel);
+                            $subList.append($subnetDiv);
+                        });
+                        $prefixDiv.append($subList);
+                    } else {
+                        $prefixDiv.append('<div class="ms-4 mt-1 text-muted small"><em>No IPv4 subnets in this prefix.</em></div>');
+                    }
+
+                    $body.append($prefixDiv);
+                });
+
+                $card.append($body);
+                $tree.append($card);
+            });
+
+            // Subnet checked → check its prefix
+            $(".bulk-subnet-checkbox").on("change", function () {
+                if ($(this).is(":checked")) {
+                    const vIdx = $(this).attr('data-vnet-idx');
+                    const prefix = $(this).attr('data-prefix');
+                    $(`.bulk-prefix-checkbox[data-vnet-idx='${vIdx}'][data-prefix='${prefix}']`).prop("checked", true);
+                }
+                updateGoPreviewBtn();
+            });
+
+            // Prefix unchecked → uncheck its subnets
+            $(".bulk-prefix-checkbox").on("change", function () {
+                if (!$(this).is(":checked")) {
+                    const vIdx = $(this).attr('data-vnet-idx');
+                    const prefix = $(this).attr('data-prefix');
+                    $(`.bulk-subnet-checkbox[data-vnet-idx='${vIdx}'][data-prefix='${prefix}']`).prop("checked", false);
+                }
+                updateGoPreviewBtn();
+            });
+        }
+
+        function updateGoPreviewBtn() {
+            const anyPrefix = $(".bulk-prefix-checkbox:checked").length > 0;
+            $("#bulk-go-preview-btn").prop("disabled", !anyPrefix);
+        }
+
+        $("#bulk-select-all-btn").on("click", function () {
+            $(".bulk-prefix-checkbox, .bulk-subnet-checkbox").prop("checked", true);
+            updateGoPreviewBtn();
+        });
+
+        $("#bulk-deselect-all-btn").on("click", function () {
+            $(".bulk-prefix-checkbox, .bulk-subnet-checkbox").prop("checked", false);
+            updateGoPreviewBtn();
+        });
+
+        $("#bulk-back-to-subscription-btn").on("click", function () {
+            activateTab("step1");
+        });
+
+        // Quick CIDR-contains check used only for *display grouping* in step 2.
+        // Server-side checks are still authoritative; this is best-effort.
+        function ipToInt(ip) {
+            const parts = ip.split('.');
+            if (parts.length !== 4) return null;
+            let n = 0;
+            for (let i = 0; i < 4; i++) {
+                const octet = parseInt(parts[i], 10);
+                if (isNaN(octet) || octet < 0 || octet > 255) return null;
+                n = (n * 256) + octet;
+            }
+            return n >>> 0;
+        }
+
+        function prefixContainsCidr(parentCidr, childCidr) {
+            const pp = parentCidr.split('/');
+            const cp = childCidr.split('/');
+            if (pp.length !== 2 || cp.length !== 2) return false;
+            const pc = parseInt(pp[1], 10);
+            const cc = parseInt(cp[1], 10);
+            if (isNaN(pc) || isNaN(cc)) return false;
+            // Equal prefix counts as contained for our purposes (fully encompassing case)
+            if (cc < pc) return false;
+            const pInt = ipToInt(pp[0]);
+            const cInt = ipToInt(cp[0]);
+            if (pInt === null || cInt === null) return false;
+            const mask = pc === 0 ? 0 : (~((1 << (32 - pc)) - 1)) >>> 0;
+            return ((pInt & mask) >>> 0) === ((cInt & mask) >>> 0);
+        }
+
+        // ---------------------------------------------------------------
+        // Step 3: Preview
+        // ---------------------------------------------------------------
+        $("#bulk-go-preview-btn").on("click", function () {
+            const selection = buildSelectionFromUI();
+            lastSelection = selection;
+            activateTab("step3");
+            loadPreview(selection);
+        });
+
+        function buildSelectionFromUI() {
+            const renameMatched = $("#bulk-rename-matched").is(":checked");
+            const prefixSelections = [];
+
+            $(".bulk-prefix-checkbox:checked").each(function () {
+                const vIdx = parseInt($(this).attr('data-vnet-idx'), 10);
+                const prefix = $(this).attr('data-prefix');
+                const vnet = vnets[vIdx];
+
+                const prefixDto = {
+                    vNetName: vnet.name,
+                    vNetResourceId: vnet.resourceId,
+                    addressPrefix: prefix,
+                    vNetHasMultiplePrefixes: vnet.ipv4AddressPrefixes.length > 1,
+                    subnets: []
+                };
+
+                $(`.bulk-subnet-checkbox[data-vnet-idx='${vIdx}'][data-prefix='${prefix}']:checked`).each(function () {
+                    prefixDto.subnets.push({
+                        name: $(this).attr('data-name'),
+                        addressPrefix: $(this).attr('data-address-prefix')
+                    });
+                });
+
+                prefixSelections.push(prefixDto);
+            });
+
+            return {
+                subscriptionId: selectedSubscriptionId,
+                subscriptionName: selectedSubscriptionName,
+                vNetPrefixes: prefixSelections,
+                renameMatchedBastetSubnets: renameMatched
+            };
+        }
+
+        function loadPreview(selection) {
+            $.ajax({
+                url: '@Url.Action("BulkImportPreview", "Azure")',
+                type: "POST",
+                contentType: "application/json",
+                data: JSON.stringify(selection),
+                headers: { "RequestVerificationToken": getAntiForgeryToken() },
+                beforeSend: function () {
+                    $("#bulk-preview-loading").removeClass("d-none");
+                    $("#bulk-preview-content").addClass("d-none");
+                    $("#bulk-preview-error").addClass("d-none");
+                },
+                success: function (result) {
+                    if (!result.success) {
+                        $("#bulk-preview-error-message").text(result.error || "Failed to build plan");
+                        $("#bulk-preview-error").removeClass("d-none");
+                        return;
+                    }
+                    lastPlan = result.plan;
+                    renderPlan(result.plan);
+                    $("#bulk-preview-content").removeClass("d-none");
+                },
+                error: function (xhr, status, error) {
+                    $("#bulk-preview-error-message").text("Error connecting to server: " + error);
+                    $("#bulk-preview-error").removeClass("d-none");
+                },
+                complete: function () {
+                    $("#bulk-preview-loading").addClass("d-none");
+                }
+            });
+        }
+
+        function renderPlan(plan) {
+            // Global errors
+            const $globalErrorsList = $("#bulk-global-errors-list").empty();
+            if (plan.globalErrors && plan.globalErrors.length > 0) {
+                $.each(plan.globalErrors, function (i, e) {
+                    $globalErrorsList.append($('<li></li>').text(e));
+                });
+                $("#bulk-global-errors").removeClass("d-none");
+            } else {
+                $("#bulk-global-errors").addClass("d-none");
+            }
+
+            const $tree = $("#bulk-plan-tree").empty();
+
+            $.each(plan.items || [], function (i, item) {
+                const $card = $('<div class="card mb-2"></div>');
+                const headerCss = item.errors && item.errors.length > 0 ? "card-header bg-danger text-white" : "card-header bg-light";
+                const $header = $('<div></div>').addClass(headerCss);
+
+                let targetText = "";
+                switch (item.targetType) {
+                    case 0: // ExactMatch
+                        targetText = `<span class="badge bg-success">Exact match</span> Bastet subnet "${escapeHtml(item.existingTargetSubnetName)}" (${escapeHtml(item.prefixNetworkAddress)}/${item.prefixCidr})`;
+                        if (item.willRename) {
+                            targetText += ` &rarr; will rename to <strong>${escapeHtml(item.newName)}</strong>`;
+                        }
+                        break;
+                    case 1: // AutoCreateChild
+                        targetText = `<span class="badge bg-info">New child</span> create <strong>${escapeHtml(item.autoCreateTargetName)}</strong> (${escapeHtml(item.prefixNetworkAddress)}/${item.prefixCidr}) under "${escapeHtml(item.autoCreateParentSubnetName)}"`;
+                        break;
+                    case 2: // AutoCreateTopLevel
+                        targetText = `<span class="badge bg-warning text-dark">New top-level</span> create <strong>${escapeHtml(item.autoCreateTargetName)}</strong> (${escapeHtml(item.prefixNetworkAddress)}/${item.prefixCidr})`;
+                        break;
+                }
+
+                if (item.willMarkFullyAllocated) {
+                    targetText += ` &mdash; will be marked <strong>fully allocated</strong> (Azure subnet "${escapeHtml(item.fullyAllocatingAzureSubnetName)}" encompasses entire address space)`;
+                }
+
+                $header.html(`<strong>VNet "${escapeHtml(item.vNetName)}"</strong> &mdash; prefix <code>${escapeHtml(item.vNetPrefix)}</code><br>${targetText}`);
+                $card.append($header);
+
+                const $body = $('<div class="card-body p-2"></div>');
+
+                if (item.errors && item.errors.length > 0) {
+                    const $errs = $('<div class="alert alert-danger mb-2"><strong>Errors</strong><ul class="mb-0"></ul></div>');
+                    $.each(item.errors, function (j, msg) {
+                        $errs.find('ul').append($('<li></li>').text(msg));
+                    });
+                    $body.append($errs);
+                }
+
+                if (item.warnings && item.warnings.length > 0) {
+                    const $warns = $('<div class="alert alert-warning mb-2"><strong>Warnings</strong><ul class="mb-0"></ul></div>');
+                    $.each(item.warnings, function (j, msg) {
+                        $warns.find('ul').append($('<li></li>').text(msg));
+                    });
+                    $body.append($warns);
+                }
+
+                if (item.childSubnets && item.childSubnets.length > 0) {
+                    const $childList = $('<ul class="list-unstyled ms-3 mb-0"></ul>');
+                    $.each(item.childSubnets, function (j, c) {
+                        $childList.append($('<li></li>').html(
+                            `<i class="bi bi-plus-circle text-success"></i> Create <strong>${escapeHtml(c.name)}</strong> <code>${escapeHtml(c.networkAddress)}/${c.cidr}</code>` +
+                            (c.originalAzureName !== c.name ? ` <small class="text-muted">(was "${escapeHtml(c.originalAzureName)}")</small>` : "")
+                        ));
+                    });
+                    $body.append('<div class="text-muted small">Child Azure subnets:</div>');
+                    $body.append($childList);
+                } else if (!item.willMarkFullyAllocated) {
+                    $body.append('<div class="text-muted small"><em>No child subnets selected.</em></div>');
+                }
+
+                $card.append($body);
+                $tree.append($card);
+            });
+
+            $("#bulk-go-commit-btn").prop("disabled", !plan.canCommit);
+        }
+
+        $("#bulk-back-to-selection-btn").on("click", function () {
+            activateTab("step2");
+        });
+
+        // ---------------------------------------------------------------
+        // Step 4: Commit
+        // ---------------------------------------------------------------
+        $("#bulk-go-commit-btn").on("click", function () {
+            activateTab("step4");
+            // reset commit-step state
+            $("#bulk-commit-success").addClass("d-none");
+            $("#bulk-commit-error").addClass("d-none");
+            $("#bulk-confirm-commit-btn").prop("disabled", false).show();
+        });
+
+        $("#bulk-back-to-preview-btn").on("click", function () {
+            activateTab("step3");
+        });
+
+        $("#bulk-confirm-commit-btn").on("click", function () {
+            if (!lastSelection) {
+                return;
+            }
+            commitImport(lastSelection);
+        });
+
+        function commitImport(selection) {
+            $.ajax({
+                url: '@Url.Action("BulkCreateFromAzurePlan", "Subnet")',
+                type: "POST",
+                contentType: "application/json",
+                data: JSON.stringify(selection),
+                headers: { "RequestVerificationToken": getAntiForgeryToken() },
+                beforeSend: function () {
+                    $("#bulk-commit-progress").removeClass("d-none");
+                    $("#bulk-commit-success").addClass("d-none");
+                    $("#bulk-commit-error").addClass("d-none");
+                    $("#bulk-confirm-commit-btn").prop("disabled", true);
+                },
+                success: function (result) {
+                    if (result && result.success) {
+                        $("#bulk-commit-success-message").text(
+                            ` Created ${result.createdTargets} VNet target(s), ${result.createdChildSubnets} child subnet(s), renamed ${result.renamedTargets} target(s), marked ${result.fullyAllocatedTargets} target(s) as fully allocated.`
+                        );
+                        $("#bulk-commit-success").removeClass("d-none");
+                        $("#bulk-confirm-commit-btn").hide();
+                        if (result.redirectUrl) {
+                            setTimeout(function () { window.location.href = result.redirectUrl; }, 2000);
+                        }
+                    } else {
+                        showCommitError(result);
+                    }
+                },
+                error: function (xhr) {
+                    let payload = null;
+                    try { payload = JSON.parse(xhr.responseText); } catch { payload = null; }
+                    showCommitError(payload || { error: "Server error: " + xhr.status });
+                },
+                complete: function () {
+                    $("#bulk-commit-progress").addClass("d-none");
+                }
+            });
+        }
+
+        function showCommitError(payload) {
+            $("#bulk-commit-error-message").text(payload && payload.error ? payload.error : "");
+            const $list = $("#bulk-commit-error-list").empty();
+            if (payload && payload.globalErrors && payload.globalErrors.length > 0) {
+                $.each(payload.globalErrors, function (i, e) { $list.append($('<li></li>').text(e)); });
+            }
+            if (payload && payload.itemErrors && payload.itemErrors.length > 0) {
+                $.each(payload.itemErrors, function (i, ie) {
+                    if (ie.errors && ie.errors.length > 0) {
+                        $.each(ie.errors, function (j, msg) {
+                            $list.append($('<li></li>').text(`[${ie.vNetName} ${ie.vNetPrefix}] ${msg}`));
+                        });
+                    }
+                });
+            }
+            $("#bulk-commit-error").removeClass("d-none");
+            $("#bulk-confirm-commit-btn").prop("disabled", false);
+        }
+    });
+</script>

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -282,9 +282,9 @@
                     vNetName: vnet.name,
                     vNetResourceId: vnet.resourceId,
                     addressPrefix: prefix,
-                    vNetHasMultiplePrefixes: vnet.ipv4AddressPrefixes.length > 1,
                     subnets: []
                 };
+
 
                 $(`.bulk-subnet-checkbox[data-vnet-idx='${vIdx}'][data-prefix='${prefix}']:checked`).each(function () {
                     prefixDto.subnets.push({

--- a/src/Bastet/Views/Azure/BulkImport/_ErrorAlert.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_ErrorAlert.cshtml
@@ -1,0 +1,14 @@
+@model Bastet.Models.ViewModels.BulkImportInitialViewModel
+
+<div class="alert alert-danger">
+    <i class="bi bi-exclamation-triangle"></i>
+    <ul class="mb-0">
+        @foreach (Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateEntry entry in ViewData.ModelState.Values)
+        {
+            foreach (Microsoft.AspNetCore.Mvc.ModelBinding.ModelError error in entry.Errors)
+            {
+                <li>@error.ErrorMessage</li>
+            }
+        }
+    </ul>
+</div>

--- a/src/Bastet/Views/Azure/BulkImport/_Header.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_Header.cshtml
@@ -1,0 +1,6 @@
+@model Bastet.Models.ViewModels.BulkImportInitialViewModel
+
+<h3 class="mb-0">
+    <i class="bi bi-cloud-download"></i> Bulk Azure Import
+</h3>
+<small>Import VNets and subnets across an entire Azure subscription into Bastet.</small>

--- a/src/Bastet/Views/Azure/BulkImport/_StepCommit.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_StepCommit.cshtml
@@ -1,0 +1,36 @@
+@model Bastet.Models.ViewModels.BulkImportInitialViewModel
+
+<div class="alert alert-warning">
+    <i class="bi bi-exclamation-triangle"></i>
+    Click the button below to apply the plan to Bastet. This is performed in a single transaction;
+    if anything fails, no changes are saved.
+</div>
+
+<div id="bulk-commit-progress" class="text-center py-3 d-none">
+    <div class="spinner-border text-success" role="status">
+        <span class="visually-hidden">Committing...</span>
+    </div>
+    <p class="mt-2">Committing import...</p>
+</div>
+
+<div id="bulk-commit-error" class="alert alert-danger d-none">
+    <i class="bi bi-exclamation-triangle"></i>
+    <strong>Commit failed:</strong>
+    <span id="bulk-commit-error-message"></span>
+    <ul id="bulk-commit-error-list" class="mb-0 mt-2"></ul>
+</div>
+
+<div id="bulk-commit-success" class="alert alert-success d-none">
+    <i class="bi bi-check-circle"></i>
+    <strong>Bulk import completed.</strong>
+    <span id="bulk-commit-success-message"></span>
+</div>
+
+<div class="d-grid gap-2 mt-3">
+    <button type="button" id="bulk-confirm-commit-btn" class="btn btn-success btn-lg">
+        <i class="bi bi-cloud-upload"></i> Confirm Import
+    </button>
+    <button type="button" id="bulk-back-to-preview-btn" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> Back to Preview
+    </button>
+</div>

--- a/src/Bastet/Views/Azure/BulkImport/_StepPreview.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_StepPreview.cshtml
@@ -1,0 +1,38 @@
+@model Bastet.Models.ViewModels.BulkImportInitialViewModel
+
+<div class="alert alert-info">
+    <i class="bi bi-info-circle"></i>
+    Review the import plan below. Errors must be resolved before you can commit.
+</div>
+
+<div id="bulk-preview-loading" class="text-center py-3 d-none">
+    <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Building plan...</span>
+    </div>
+    <p class="mt-2">Building import plan...</p>
+</div>
+
+<div id="bulk-preview-error" class="alert alert-danger d-none">
+    <i class="bi bi-exclamation-triangle"></i>
+    <span id="bulk-preview-error-message"></span>
+</div>
+
+<div id="bulk-preview-content" class="d-none">
+    <div id="bulk-global-errors" class="alert alert-danger d-none">
+        <strong><i class="bi bi-exclamation-octagon"></i> Cannot import:</strong>
+        <ul id="bulk-global-errors-list" class="mb-0"></ul>
+    </div>
+
+    <div id="bulk-plan-tree" class="mb-3">
+        <!-- Populated dynamically -->
+    </div>
+
+    <div class="d-grid gap-2">
+        <button type="button" id="bulk-go-commit-btn" class="btn btn-success" disabled>
+            <i class="bi bi-check-circle"></i> Continue to Commit
+        </button>
+        <button type="button" id="bulk-back-to-selection-btn" class="btn btn-secondary">
+            <i class="bi bi-arrow-left"></i> Back to Selection
+        </button>
+    </div>
+</div>

--- a/src/Bastet/Views/Azure/BulkImport/_StepSelection.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_StepSelection.cshtml
@@ -1,0 +1,57 @@
+@model Bastet.Models.ViewModels.BulkImportInitialViewModel
+
+<div class="alert alert-info">
+    <i class="bi bi-info-circle"></i>
+    Pick the VNets and subnets you want to import. Each selected VNet IPv4 prefix becomes a Bastet subnet target. Selected Azure subnets are placed under it.
+    <br />
+    <small>IPv6 prefixes and IPv6-only subnets are not shown.</small>
+</div>
+
+<div id="bulk-vnet-loading" class="text-center py-3 d-none">
+    <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading VNets...</span>
+    </div>
+    <p class="mt-2">Loading VNets and subnets from Azure...</p>
+</div>
+
+<div id="bulk-vnet-error" class="alert alert-danger d-none">
+    <i class="bi bi-exclamation-triangle"></i>
+    <span id="bulk-vnet-error-message"></span>
+</div>
+
+<div id="bulk-no-vnets" class="alert alert-warning d-none">
+    <i class="bi bi-exclamation-triangle"></i>
+    No IPv4 VNets were found in this subscription.
+</div>
+
+<div id="bulk-vnet-selection" class="d-none">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <div>
+            <button type="button" id="bulk-select-all-btn" class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-check-all"></i> Select all
+            </button>
+            <button type="button" id="bulk-deselect-all-btn" class="btn btn-sm btn-outline-secondary">
+                <i class="bi bi-x-circle"></i> Deselect all
+            </button>
+        </div>
+        <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" id="bulk-rename-matched">
+            <label class="form-check-label" for="bulk-rename-matched">
+                Rename matched Bastet subnets to VNet names
+            </label>
+        </div>
+    </div>
+
+    <div id="bulk-vnet-tree" class="mb-3">
+        <!-- Populated dynamically -->
+    </div>
+
+    <div class="d-grid gap-2">
+        <button type="button" id="bulk-go-preview-btn" class="btn btn-primary" disabled>
+            Next: Preview <i class="bi bi-arrow-right"></i>
+        </button>
+        <button type="button" id="bulk-back-to-subscription-btn" class="btn btn-secondary">
+            <i class="bi bi-arrow-left"></i> Back to Subscription
+        </button>
+    </div>
+</div>

--- a/src/Bastet/Views/Azure/BulkImport/_StepSubscription.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_StepSubscription.cshtml
@@ -1,0 +1,38 @@
+@model Bastet.Models.ViewModels.BulkImportInitialViewModel
+
+<div class="alert alert-info">
+    <i class="bi bi-info-circle"></i>
+    Pick the Azure subscription you want to import from. The next step will load every IPv4 VNet in that subscription.
+</div>
+
+<div id="bulk-subscription-loading" class="text-center py-3">
+    <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading subscriptions...</span>
+    </div>
+    <p class="mt-2">Loading subscriptions...</p>
+</div>
+
+<div id="bulk-subscription-error" class="alert alert-danger d-none">
+    <i class="bi bi-exclamation-triangle"></i>
+    <span id="bulk-subscription-error-message"></span>
+</div>
+
+<div id="bulk-subscription-selection" class="d-none">
+    <div class="form-group mb-3">
+        <label for="bulk-subscription-select" class="form-label">Subscription</label>
+        <select id="bulk-subscription-select" class="form-select">
+            <option value="" disabled selected>-- Select a subscription --</option>
+        </select>
+    </div>
+
+    <div class="d-grid gap-2">
+        <button id="bulk-select-subscription-btn" class="btn btn-primary" disabled>
+            Next: Select VNets &amp; Subnets <i class="bi bi-arrow-right"></i>
+        </button>
+    </div>
+</div>
+
+<div id="bulk-no-subscriptions" class="alert alert-warning d-none">
+    <i class="bi bi-exclamation-triangle"></i>
+    No subscriptions found. Please check your Azure credentials.
+</div>

--- a/src/Bastet/Views/Azure/Import.cshtml
+++ b/src/Bastet/Views/Azure/Import.cshtml
@@ -1,7 +1,8 @@
 @model Bastet.Models.ViewModels.AzureImportViewModel
 
 @{
-    ViewData["Title"] = "Import from Azure";
+    ViewData["Title"] = "Subnet Azure Import";
+
 }
 
 <div class="container mt-4">

--- a/src/Bastet/Views/Azure/Import/_Header.cshtml
+++ b/src/Bastet/Views/Azure/Import/_Header.cshtml
@@ -1,3 +1,5 @@
 @model Bastet.Models.ViewModels.AzureImportViewModel
 
-<h2><i class="bi bi-cloud-download"></i> Import Subnets from Azure</h2>
+<h2><i class="bi bi-cloud-download"></i> Subnet Azure Import</h2>
+
+

--- a/src/Bastet/Views/Shared/_Layout.cshtml
+++ b/src/Bastet/Views/Shared/_Layout.cshtml
@@ -34,7 +34,20 @@
                                 <li><a class="dropdown-item" asp-controller="HostIp" asp-action="AllDeletedHostIps">All Deleted Host IPs</a></li>
                             </ul>
                         </li>
+                        @{
+                            // Bulk Azure Import is only shown when the feature flag is enabled and the user is an admin.
+                            bool bulkAzureImportEnabled = bool.TryParse(Environment.GetEnvironmentVariable("BASTET_AZURE_IMPORT"), out bool _enabled) && _enabled;
+                        }
+                        @if (bulkAzureImportEnabled && UserContextService.UserHasRole(Bastet.Models.ApplicationRoles.Admin))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" asp-controller="Azure" asp-action="BulkImport">
+                                    <i class="bi bi-cloud-download"></i> Bulk Azure Import
+                                </a>
+                            </li>
+                        }
                     </ul>
+
                     
                     @if (User.Identity?.IsAuthenticated == true)
                     {

--- a/src/Bastet/Views/Shared/_Layout.cshtml
+++ b/src/Bastet/Views/Shared/_Layout.cshtml
@@ -80,7 +80,7 @@
 
 <footer class="border-top footer text-muted">
         <div class="container-fluid">
-            &copy; 2025 Anuj Shroff - 
+            &copy; 2025-2026 Anuj Shroff - 
             <a href="https://bastet.anujshroff.com" target="_blank">BASTET</a>
             (Badass Subnetting Tools for Enhanced Transmission)
             <span class="float-end">Version: @VersionService.GetVersion()</span>

--- a/src/Bastet/Views/Shared/_RoleBasedActions.cshtml
+++ b/src/Bastet/Views/Shared/_RoleBasedActions.cshtml
@@ -26,8 +26,9 @@
     {
         <a asp-controller="Azure" asp-action="Import" asp-route-id="@ViewBag.EntityId" 
            class="btn btn-info ms-2">
-            <i class="bi bi-cloud-download"></i> Azure Import
+            <i class="bi bi-cloud-download"></i> Subnet Azure Import
         </a>
+
     }
 
     <a asp-action="Index" class="btn btn-outline-secondary ms-2">Back to List</a>

--- a/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
@@ -266,7 +266,17 @@ public class AzureBulkImportPlannerTests
         Assert.True(plan.CanCommit);
         Assert.Equal(2, plan.Items.Count);
         Assert.All(plan.Items, i => Assert.Equal(BulkImportTargetType.AutoCreateTopLevel, i.TargetType));
+
+        // Each plan item is for a distinct prefix.
+        Assert.Contains(plan.Items, i => i.PrefixNetworkAddress == "10.0.0.0" && i.PrefixCidr == 16);
+        Assert.Contains(plan.Items, i => i.PrefixNetworkAddress == "10.1.0.0" && i.PrefixCidr == 16);
+
+        // Both auto-created targets keep the unmodified VNet name (intentional — Bastet
+        // allows duplicate Subnet.Name; only NetworkAddress+Cidr is unique). If a future
+        // change introduces auto-disambiguation of these names, this assertion will catch it.
+        Assert.All(plan.Items, i => Assert.Equal("vnet-multi", i.AutoCreateTargetName));
     }
+
 
     // -------------------------------------------------------------------------
     // Conflict detection — VNet vs VNet
@@ -324,10 +334,16 @@ public class AzureBulkImportPlannerTests
     [Fact]
     public void AzureSubnetAlreadyInBastet_HardFails()
     {
+        // Plan attempts to import 10.2.5.0/24 from VNet 10.2.0.0/16. Bastet has
+        // 10.0.0.0/8 + 10.2.5.0/24 (no /16 between them), so the planner will
+        // simultaneously trip two distinct hard fails — both correct, both expected:
+        //   * the Azure subnet 10.2.5.0/24 already exists in Bastet (the case under test)
+        //   * the auto-created /16 target would contain the existing /24
+        // We assert the duplicate-existence error is present; the would-contain
+        // error is exercised independently by VNetPrefixWouldContainExistingSubnet_HardFails.
         BulkImportSelectionDto sel = Sel(false,
             Pref("vnet-x", "10.2.0.0/16", Sub("default", "10.2.5.0/24")));
 
-        // Existing Bastet tree contains 10.2.5.0/24 already (somewhere unrelated)
         List<ExistingSubnetSnapshot> existing =
         [
             Existing(1, "RootSlash8", "10.0.0.0", 8),
@@ -339,6 +355,7 @@ public class AzureBulkImportPlannerTests
         Assert.False(plan.CanCommit);
         Assert.Contains(plan.GlobalErrors, e => e.Contains("already exists in Bastet"));
     }
+
 
     // -------------------------------------------------------------------------
     // Conflict detection — VNet prefix would contain existing Bastet subnet

--- a/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
@@ -1,0 +1,532 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Security;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// Unit tests for the bulk Azure import planner. The planner has no DB dependency,
+/// so these tests construct it directly with the real <see cref="IpUtilityService"/>
+/// and <see cref="InputSanitizationService"/>.
+/// </summary>
+public class AzureBulkImportPlannerTests
+{
+    private readonly AzureBulkImportPlanner _planner;
+
+    public AzureBulkImportPlannerTests()
+    {
+        IIpUtilityService ip = new IpUtilityService();
+        IInputSanitizationService san = new InputSanitizationService();
+        _planner = new AzureBulkImportPlanner(ip, san);
+    }
+
+    private static BulkImportSelectedSubnetDto Sub(string name, string prefix) =>
+        new() { Name = name, AddressPrefix = prefix };
+
+    private static BulkImportSelectedVNetPrefixDto Pref(
+        string vnetName, string prefix, params BulkImportSelectedSubnetDto[] subs) =>
+        new()
+        {
+            VNetName = vnetName,
+            VNetResourceId = $"/subscriptions/test/providers/Microsoft.Network/virtualNetworks/{vnetName}",
+            AddressPrefix = prefix,
+            Subnets = [.. subs]
+        };
+
+    private static BulkImportSelectionDto Sel(
+        bool rename = false,
+        params BulkImportSelectedVNetPrefixDto[] prefixes) =>
+        new()
+        {
+            SubscriptionId = "sub-1",
+            SubscriptionName = "Test Sub",
+            RenameMatchedBastetSubnets = rename,
+            VNetPrefixes = [.. prefixes]
+        };
+
+    private static ExistingSubnetSnapshot Existing(
+        int id, string name, string network, int cidr,
+        bool hasChildren = false, bool hasHostIps = false, bool fullyAllocated = false) =>
+        new()
+        {
+            Id = id,
+            Name = name,
+            NetworkAddress = network,
+            Cidr = cidr,
+            HasChildSubnets = hasChildren,
+            HasHostIpAssignments = hasHostIps,
+            IsFullyAllocated = fullyAllocated
+        };
+
+    // -------------------------------------------------------------------------
+    // Exact-match target
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ExactMatch_EmptyTarget_PlansChildCreations()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-prod", "10.0.0.0/16",
+                Sub("web", "10.0.1.0/24"),
+                Sub("app", "10.0.2.0/24")));
+
+        List<ExistingSubnetSnapshot> existing = [Existing(1, "Existing", "10.0.0.0", 16)];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        Assert.Single(plan.Items);
+        BulkImportPlanItem item = plan.Items[0];
+        Assert.Equal(BulkImportTargetType.ExactMatch, item.TargetType);
+        Assert.Equal(1, item.ExistingTargetSubnetId);
+        Assert.False(item.WillRename);
+        Assert.False(item.WillMarkFullyAllocated);
+        Assert.Equal(2, item.ChildSubnets.Count);
+        Assert.Contains(item.ChildSubnets, c => c.Name == "web" && c.NetworkAddress == "10.0.1.0" && c.Cidr == 24);
+        Assert.Contains(item.ChildSubnets, c => c.Name == "app" && c.NetworkAddress == "10.0.2.0" && c.Cidr == 24);
+    }
+
+    [Fact]
+    public void ExactMatch_TargetHasChildren_HardFails()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-prod", "10.0.0.0/16", Sub("web", "10.0.1.0/24")));
+
+        List<ExistingSubnetSnapshot> existing = [Existing(1, "Existing", "10.0.0.0", 16, hasChildren: true)];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.False(plan.CanCommit);
+        Assert.Single(plan.Items);
+        Assert.Contains(plan.Items[0].Errors, e => e.Contains("already has child subnets"));
+    }
+
+    [Fact]
+    public void ExactMatch_TargetHasHostIps_HardFails()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-prod", "10.0.0.0/16", Sub("web", "10.0.1.0/24")));
+
+        List<ExistingSubnetSnapshot> existing = [Existing(1, "Existing", "10.0.0.0", 16, hasHostIps: true)];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.Items[0].Errors, e => e.Contains("host IP assignments"));
+    }
+
+    [Fact]
+    public void ExactMatch_TargetIsFullyAllocated_HardFails()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-prod", "10.0.0.0/16", Sub("web", "10.0.1.0/24")));
+
+        List<ExistingSubnetSnapshot> existing = [Existing(1, "Existing", "10.0.0.0", 16, fullyAllocated: true)];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.Items[0].Errors, e => e.Contains("fully allocated"));
+    }
+
+    [Fact]
+    public void ExactMatch_RenameRequested_AndNameDiffers_PlansRename()
+    {
+        BulkImportSelectionDto sel = Sel(true,
+            Pref("vnet-prod", "10.0.0.0/16", Sub("web", "10.0.1.0/24")));
+
+        List<ExistingSubnetSnapshot> existing = [Existing(1, "OldName", "10.0.0.0", 16)];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        Assert.True(plan.Items[0].WillRename);
+        Assert.Equal("vnet-prod", plan.Items[0].NewName);
+    }
+
+    [Fact]
+    public void ExactMatch_RenameRequested_AndNamesEqual_DoesNotPlanRename()
+    {
+        BulkImportSelectionDto sel = Sel(true,
+            Pref("vnet-prod", "10.0.0.0/16", Sub("web", "10.0.1.0/24")));
+
+        List<ExistingSubnetSnapshot> existing = [Existing(1, "vnet-prod", "10.0.0.0", 16)];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        Assert.False(plan.Items[0].WillRename);
+    }
+
+    // -------------------------------------------------------------------------
+    // Auto-create child target
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AutoCreateChild_WhenContainerExists()
+    {
+        // Bastet has 10.0.0.0/8 and 10.1.0.0/16. We import VNet 10.2.0.0/16. Container is /8.
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-x", "10.2.0.0/16", Sub("default", "10.2.5.0/24")));
+
+        List<ExistingSubnetSnapshot> existing =
+        [
+            Existing(1, "RootSlash8", "10.0.0.0", 8),
+            Existing(2, "OtherVnet", "10.1.0.0", 16)
+        ];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        BulkImportPlanItem item = plan.Items[0];
+        Assert.Equal(BulkImportTargetType.AutoCreateChild, item.TargetType);
+        Assert.Equal(1, item.AutoCreateParentSubnetId);
+        Assert.Equal("vnet-x", item.AutoCreateTargetName);
+        Assert.Single(item.ChildSubnets);
+    }
+
+    [Fact]
+    public void AutoCreateChild_PicksDeepestContainer()
+    {
+        // Existing: 10.0.0.0/8 contains 10.0.0.0/16 contains 10.0.0.0/20.
+        // We import 10.0.1.0/24. Deepest container is 10.0.0.0/20.
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-deep", "10.0.1.0/24", Sub("a", "10.0.1.0/25")));
+
+        List<ExistingSubnetSnapshot> existing =
+        [
+            Existing(1, "S8", "10.0.0.0", 8),
+            Existing(2, "S16", "10.0.0.0", 16),
+            Existing(3, "S20", "10.0.0.0", 20)
+        ];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        Assert.Equal(BulkImportTargetType.AutoCreateChild, plan.Items[0].TargetType);
+        Assert.Equal(3, plan.Items[0].AutoCreateParentSubnetId);
+    }
+
+    [Fact]
+    public void AutoCreateChild_ContainerHasHostIps_HardFails()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-x", "10.2.0.0/16", Sub("default", "10.2.5.0/24")));
+
+        List<ExistingSubnetSnapshot> existing =
+        [
+            Existing(1, "RootSlash8", "10.0.0.0", 8, hasHostIps: true)
+        ];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.Items[0].Errors, e => e.Contains("host IP assignments"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Auto-create top-level target
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AutoCreateTopLevel_WhenNoContainerAndNoExactMatch()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-iso", "192.168.0.0/16", Sub("default", "192.168.1.0/24")));
+
+        List<ExistingSubnetSnapshot> existing = [Existing(1, "RFC1918-10", "10.0.0.0", 8)];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        BulkImportPlanItem item = plan.Items[0];
+        Assert.Equal(BulkImportTargetType.AutoCreateTopLevel, item.TargetType);
+        Assert.Null(item.AutoCreateParentSubnetId);
+        Assert.Equal("vnet-iso", item.AutoCreateTargetName);
+        Assert.Single(item.ChildSubnets);
+    }
+
+    // -------------------------------------------------------------------------
+    // Multiple VNet prefixes
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void MultipleVNetPrefixes_EachIsIndependentTarget()
+    {
+        // One VNet with two non-overlapping IPv4 prefixes.
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-multi", "10.0.0.0/16", Sub("a", "10.0.1.0/24")),
+            Pref("vnet-multi", "10.1.0.0/16", Sub("b", "10.1.1.0/24")));
+
+        List<ExistingSubnetSnapshot> existing = [];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        Assert.Equal(2, plan.Items.Count);
+        Assert.All(plan.Items, i => Assert.Equal(BulkImportTargetType.AutoCreateTopLevel, i.TargetType));
+    }
+
+    // -------------------------------------------------------------------------
+    // Conflict detection — VNet vs VNet
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void VNetPrefixOverlap_HardFails()
+    {
+        // 10.0.0.0/16 and 10.0.0.0/24 overlap.
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-a", "10.0.0.0/16"),
+            Pref("vnet-b", "10.0.0.0/24"));
+
+        List<ExistingSubnetSnapshot> existing = [];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("overlaps"));
+    }
+
+    [Fact]
+    public void IdenticalVNetPrefixesAcrossVNets_HardFails()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-a", "10.0.0.0/16"),
+            Pref("vnet-b", "10.0.0.0/16"));
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, []);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("overlaps"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Conflict detection — Azure subnets across VNets
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AzureSubnetsAcrossVNets_DontOverlap_OK()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-a", "10.0.0.0/16", Sub("default", "10.0.1.0/24")),
+            Pref("vnet-b", "10.1.0.0/16", Sub("default", "10.1.1.0/24")));
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, []);
+
+        Assert.True(plan.CanCommit);
+    }
+
+    // -------------------------------------------------------------------------
+    // Conflict detection — Azure subnet already in Bastet
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AzureSubnetAlreadyInBastet_HardFails()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-x", "10.2.0.0/16", Sub("default", "10.2.5.0/24")));
+
+        // Existing Bastet tree contains 10.2.5.0/24 already (somewhere unrelated)
+        List<ExistingSubnetSnapshot> existing =
+        [
+            Existing(1, "RootSlash8", "10.0.0.0", 8),
+            Existing(2, "Conflict", "10.2.5.0", 24)
+        ];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("already exists in Bastet"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Conflict detection — VNet prefix would contain existing Bastet subnet
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void VNetPrefixWouldContainExistingSubnet_HardFails()
+    {
+        // Bastet has 10.0.5.0/24. We import 10.0.0.0/16 with no exact match. Would create invalid hierarchy.
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-broad", "10.0.0.0/16", Sub("a", "10.0.1.0/24")));
+
+        List<ExistingSubnetSnapshot> existing =
+        [
+            Existing(1, "Existing24", "10.0.5.0", 24)
+        ];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("would contain existing"));
+    }
+
+    [Fact]
+    public void VNetPrefixContainedByExisting_DoesNotTriggerWouldContainError()
+    {
+        // Importing 10.0.5.0/24, existing 10.0.0.0/16 contains it. This is the normal AutoCreateChild case.
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-narrow", "10.0.5.0/24", Sub("a", "10.0.5.0/25")));
+
+        List<ExistingSubnetSnapshot> existing =
+        [
+            Existing(1, "Existing16", "10.0.0.0", 16)
+        ];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        Assert.Equal(BulkImportTargetType.AutoCreateChild, plan.Items[0].TargetType);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fully encompassing Azure subnet
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AzureSubnetEqualsVNetPrefix_MarksTargetFullyAllocated_AndNoChildren()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-full", "10.0.0.0/16",
+                Sub("everything", "10.0.0.0/16")));
+
+        List<ExistingSubnetSnapshot> existing = [];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        BulkImportPlanItem item = plan.Items[0];
+        Assert.True(item.WillMarkFullyAllocated);
+        Assert.Equal("everything", item.FullyAllocatingAzureSubnetName);
+        Assert.Empty(item.ChildSubnets);
+    }
+
+    [Fact]
+    public void AzureSubnetEqualsVNetPrefix_OnExactMatchTarget_MarksFullyAllocated()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-full", "10.0.0.0/16",
+                Sub("everything", "10.0.0.0/16")));
+
+        List<ExistingSubnetSnapshot> existing = [Existing(1, "Existing", "10.0.0.0", 16)];
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, existing);
+
+        Assert.True(plan.CanCommit);
+        BulkImportPlanItem item = plan.Items[0];
+        Assert.Equal(BulkImportTargetType.ExactMatch, item.TargetType);
+        Assert.True(item.WillMarkFullyAllocated);
+        Assert.Empty(item.ChildSubnets);
+    }
+
+    // -------------------------------------------------------------------------
+    // Naming
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void IdenticalChildNamesInDifferentTargets_AreNotDisambiguated()
+    {
+        // Disambiguation is only needed when names collide *within the same target*.
+        // Two VNets in non-overlapping space land in different targets, so each can
+        // keep the name "default" without conflict.
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-a", "10.0.0.0/16", Sub("default", "10.0.1.0/24")),
+            Pref("vnet-b", "10.1.0.0/16", Sub("default", "10.1.1.0/24"))
+        );
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, []);
+
+        Assert.True(plan.CanCommit);
+        Assert.Equal(2, plan.Items.Count);
+        Assert.Equal("default", plan.Items[0].ChildSubnets[0].Name);
+        Assert.Equal("default", plan.Items[1].ChildSubnets[0].Name);
+    }
+
+
+    [Fact]
+    public void NameCollisionWithinSameTarget_GetsDisambiguated()
+    {
+        // Test specifically within one target. We can't really get duplicate names in real Azure,
+        // but the planner should still defensively disambiguate.
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-x", "10.0.0.0/16",
+                Sub("dup", "10.0.1.0/24"),
+                Sub("dup", "10.0.2.0/24"))
+        );
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, []);
+
+        Assert.True(plan.CanCommit);
+        BulkImportPlanItem item = plan.Items[0];
+        Assert.Equal(2, item.ChildSubnets.Count);
+        // Names are unique within the target
+        Assert.NotEqual(item.ChildSubnets[0].Name, item.ChildSubnets[1].Name);
+        Assert.Equal("dup", item.ChildSubnets[0].Name);
+        Assert.Contains("vnet-x", item.ChildSubnets[1].Name);
+    }
+
+    [Fact]
+    public void LongAzureName_IsTruncatedTo50Chars()
+    {
+        string longName = new('a', 200);
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-x", "10.0.0.0/16", Sub(longName, "10.0.1.0/24")));
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, []);
+
+        Assert.True(plan.CanCommit);
+        Assert.True(plan.Items[0].ChildSubnets[0].Name.Length <= 50);
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation of inputs
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void InvalidVNetPrefix_HardFails()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("bad", "not-a-cidr"));
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, []);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("invalid"));
+    }
+
+    [Fact]
+    public void MisalignedVNetPrefix_HardFails()
+    {
+        // 10.0.0.5/16 — host bits are set
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("misaligned", "10.0.0.5/16"));
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, []);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("aligned"));
+    }
+
+    [Fact]
+    public void AzureSubnetNotInVNet_HardFails()
+    {
+        BulkImportSelectionDto sel = Sel(false,
+            Pref("vnet-x", "10.0.0.0/16",
+                Sub("foreign", "172.16.0.0/24")));
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(sel, []);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("not contained in VNet prefix"));
+    }
+
+    [Fact]
+    public void NoSelections_HardFails()
+    {
+        BulkImportPlanViewModel plan = _planner.BuildPlan(Sel(false), []);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("No VNet"));
+    }
+}

--- a/test/Bastet.Tests/TestHelpers/MockAzureService.cs
+++ b/test/Bastet.Tests/TestHelpers/MockAzureService.cs
@@ -141,9 +141,67 @@ public class MockAzureService : IAzureService
     }
 
     /// <summary>
+    /// Mock implementation of bulk-import enumeration. Returns every VNet in the test corpus,
+    /// with their IPv4 prefixes and IPv4 subnets. The single-import tests don't exercise this
+    /// path, so it just returns an empty list when no VNets are configured.
+    /// </summary>
+    public Task<List<BulkAzureVNetViewModel>> GetAllVNetsWithSubnets(string subscriptionId)
+    {
+        if (string.IsNullOrEmpty(subscriptionId))
+        {
+            return Task.FromResult(new List<BulkAzureVNetViewModel>());
+        }
+
+        List<BulkAzureVNetViewModel> result = [];
+        foreach (AzureVNetViewModel vnet in _vnets)
+        {
+            BulkAzureVNetViewModel bulkVnet = new()
+            {
+                ResourceId = vnet.ResourceId,
+                Name = vnet.Name,
+                Ipv4AddressPrefixes = [.. vnet.AddressPrefixes.Where(p => !string.IsNullOrEmpty(p) && p.Split('/')[0].Split('.').Length == 4)]
+            };
+
+            if (bulkVnet.Ipv4AddressPrefixes.Count == 0)
+            {
+                continue;
+            }
+
+            // Include any subnet whose prefix is contained in any of this VNet's prefixes
+            foreach (AzureSubnetViewModel sub in _subnets)
+            {
+                if (string.IsNullOrEmpty(sub.AddressPrefix))
+                {
+                    continue;
+                }
+                bool contained = bulkVnet.Ipv4AddressPrefixes.Any(p =>
+                {
+                    string[] parts = p.Split('/');
+                    return parts.Length == 2
+                        && int.TryParse(parts[1], out int pCidr)
+                        && IsSubnetWithinParent(sub.AddressPrefix, parts[0], pCidr);
+                });
+                if (contained || bulkVnet.Ipv4AddressPrefixes.Any(p => string.Equals(p, sub.AddressPrefix, StringComparison.OrdinalIgnoreCase)))
+                {
+                    bulkVnet.Subnets.Add(new BulkAzureSubnetViewModel
+                    {
+                        Name = sub.Name,
+                        AddressPrefix = sub.AddressPrefix
+                    });
+                }
+            }
+
+            result.Add(bulkVnet);
+        }
+
+        return Task.FromResult(result);
+    }
+
+    /// <summary>
     /// Helper method to check if an address prefix is compatible with parent network
     /// </summary>
     private bool IsAddressCompatible(string addressPrefix, string parentAddress, int parentCidr)
+
     {
         if (string.IsNullOrEmpty(addressPrefix))
         {


### PR DESCRIPTION
# Bulk Azure Import — Context Primer

> **Purpose of this doc**: Drop this into a fresh AI session as the first message
> ("Read this and the files it references, then ask me what I want to change")
> to bootstrap the assistant on the design and decisions behind the Bulk Azure
> Import feature without re-litigating any of it.

---

## 1. Feature summary

Bastet has **two** Azure import flows (both gated by env var `BASTET_AZURE_IMPORT=true`
and the `RequireAdminRole` policy):

| Flow | Where | What it does |
|---|---|---|
| **Subnet Azure Import** *(pre-existing)* | "Subnet Azure Import" button on a Bastet subnet's Details page | Standing on a single empty Bastet subnet, find a VNet whose address space exactly matches it, pick which child Azure subnets to import as children. One subnet at a time. |
| **Bulk Azure Import** *(this work)* | "Bulk Azure Import" link in the top nav | Pick a subscription → tree-select VNets and IPv4 subnets → preview the server-computed plan with all conflicts surfaced → commit in a single transaction. Operates across the entire Bastet tree. |

The two flows coexist; the per-subnet button on Details pages was kept and merely
relabeled.

---

## 2. Decisions log

These were settled during planning. A fresh AI should *not* revisit these without
the user's explicit say-so.

| Topic | Decision |
|---|---|
| Existing feature name | **Subnet Azure Import** |
| New feature name | **Bulk Azure Import** |
| Entry point for new flow | New top-level nav link "Bulk Azure Import" in `_Layout.cshtml`, gated by `BASTET_AZURE_IMPORT` + admin role |
| Existing button | Stays on subnet Details page, label changed to "Subnet Azure Import" |
| Scope per session | One subscription, IPv4 only, all-or-nothing transaction |
| Matching algorithm | exact Bastet match → deepest containing Bastet subnet (auto-create) → top-level (auto-create) |
| Fully-encompasses behavior | Azure subnet whose prefix equals its VNet prefix marks the target as `IsFullyAllocated` instead of becoming a child |
| Rename UX | One global checkbox: "Rename matched Bastet subnets to VNet names" — applies only to exact-match targets, no-op rename suppressed |
| Naming | Truncate + sanitize to 50 chars; auto-disambiguate on collision *within the same target* |
| Multi-prefix VNet | Each IPv4 prefix becomes an independent target; auto-created targets all keep the unmodified VNet name (Bastet allows duplicate names) |
| Conflict handling | All hard-fails. Caught at preview, blocking commit |
| Validation | Reuses existing `ValidateSubnetCreation` helper at commit time — no reinvented validation |
| Tags / provenance / extra description | Out of scope |

### The 7 hard-fail conditions (all caught at preview)

1. Exact-match target Bastet subnet has children → fail.
2. Exact-match target Bastet subnet has host IPs → fail.
3. Exact-match target Bastet subnet is fully allocated → fail.
4. AutoCreateChild parent has host IPs → fail (parent can't have children).
5. AutoCreateChild parent is fully allocated → fail.
6. Two selected VNet prefixes overlap each other → fail.
7. A selected Azure subnet's network/CIDR already exists anywhere in Bastet → fail.

Plus an additional structural check: a VNet prefix that would, when created,
*contain* an existing unrelated Bastet subnet → fail (would create invalid hierarchy).

---

## 3. Architecture map

### New files
- `src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs` — All DTOs and view
  models for the bulk flow: `BulkAzureSubnetViewModel`, `BulkAzureVNetViewModel`,
  `BulkImportInitialViewModel`, selection DTOs, `ExistingSubnetSnapshot`,
  `BulkImportTargetType` enum, plan view models.
- `src/Bastet/Services/Azure/IAzureBulkImportPlanner.cs` — Single-method interface.
- `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs` — Pure (no DB) planner.
  Takes a `BulkImportSelectionDto` + a list of `ExistingSubnetSnapshot` and returns
  a `BulkImportPlanViewModel`. All matching logic and conflict detection live here.
- `src/Bastet/Controllers/SubnetController.BulkAzure.cs` — Partial class adding
  `BulkCreateFromAzurePlan`. Mirrors `BatchCreateChildSubnets`'s transaction
  pattern; reuses `ValidateSubnetCreation` for every creation.
- `src/Bastet/Views/Azure/BulkImport.cshtml` — Main 4-tab view.
- `src/Bastet/Views/Azure/BulkImport/_Header.cshtml`
- `src/Bastet/Views/Azure/BulkImport/_ErrorAlert.cshtml`
- `src/Bastet/Views/Azure/BulkImport/_StepSubscription.cshtml` — step 1
- `src/Bastet/Views/Azure/BulkImport/_StepSelection.cshtml` — step 2
- `src/Bastet/Views/Azure/BulkImport/_StepPreview.cshtml` — step 3
- `src/Bastet/Views/Azure/BulkImport/_StepCommit.cshtml` — step 4
- `src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml` — All jQuery driving
  the tabs, AJAX calls, plan rendering, and commit submit.
- `test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs` — 26 unit tests for
  the planner (see §5).

### Modified files
- `src/Bastet/Services/Azure/IAzureService.cs` — added
  `Task<List<BulkAzureVNetViewModel>> GetAllVNetsWithSubnets(string subscriptionId)`.
- `src/Bastet/Services/Azure/AzureService.cs` — implementation of above; IPv4-only
  filtering, dual-stack subnets return only their IPv4 prefix.
- `src/Bastet/Controllers/AzureController.cs` — added 3 endpoints
  (`GET BulkImport`, `GET BulkGetVNets`, `POST BulkImportPreview`) + private
  helper `BuildExistingSnapshotAsync`. Made `IsAzureImportEnabled` `internal`
  so the partial in `SubnetController` can call it.
- `src/Bastet/Views/Shared/_Layout.cshtml` — added top-level nav link, gated.
- `src/Bastet/Views/Shared/_RoleBasedActions.cshtml` — relabeled button
  "Azure Import" → "Subnet Azure Import".
- `src/Bastet/Views/Azure/Import/_Header.cshtml` and `Import.cshtml` —
  relabeled headers / page title.
- `src/Bastet/Program.cs` — registered `IAzureBulkImportPlanner` in DI;
  configured `AddAntiforgery(o => o.HeaderName = "RequestVerificationToken")`
  so the AJAX preview/commit posts can pass the token via header.
- `test/Bastet.Tests/TestHelpers/MockAzureService.cs` — implements the new
  interface method.

### Endpoints (all gated by `BASTET_AZURE_IMPORT=true` + admin)

| Method | Route | Returns | Purpose |
|---|---|---|---|
| GET | `/Azure/BulkImport` | View | Landing page |
| GET | `/Azure/BulkGetVNets?subscriptionId=...` | JSON | All IPv4 VNets+subnets in subscription |
| POST | `/Azure/BulkImportPreview` | JSON `{success, plan}` | Body is `BulkImportSelectionDto`. Returns `BulkImportPlanViewModel` with errors populated. |
| POST | `/Subnet/BulkCreateFromAzurePlan` | JSON `{success, redirectUrl, counts}` | Body is `BulkImportSelectionDto`. Re-runs planner, then applies in a single transaction. |

---

## 4. Algorithm spec

### Inputs
- `selection: BulkImportSelectionDto` — subscription id + list of selected
  `(VNet, IPv4 prefix, [Azure subnets])` triples + `RenameMatchedBastetSubnets` bool.
- `existingSubnets: List<ExistingSubnetSnapshot>` — every Bastet subnet with
  flags (`HasChildSubnets`, `HasHostIpAssignments`, `IsFullyAllocated`).

### Output
- `BulkImportPlanViewModel` with `Items`, `GlobalErrors`, `CanCommit`.

### Steps

1. **Parse + validate every selection up front.** Each VNet prefix and Azure
   subnet must be valid CIDR, properly aligned, and each Azure subnet must be
   contained in (or equal to) its VNet prefix. Failures land in `GlobalErrors`.
   If any global error, short-circuit — don't bother with the rest.

2. **Cross-selection overlap detection.**
   - VNet-prefix vs VNet-prefix: any pair overlapping (including equal) → error.
   - Azure-subnet vs Azure-subnet (across or within VNets): any pair
     overlapping → error.

3. **Per VNet prefix, build a plan item.**
   - **If exact Bastet match exists** (same network + cidr): `TargetType =
     ExactMatch`. Hard-fail if matched subnet has children, host IPs, or is
     fully allocated. If global rename flag is on and names differ, plan a
     rename (`WillRename = true`).
   - **Else, find deepest containing Bastet subnet** (largest cidr number that
     contains the prefix): `TargetType = AutoCreateChild`, parent recorded.
     Hard-fail if container has host IPs or is fully allocated.
   - **Else**: `TargetType = AutoCreateTopLevel`, no parent.

4. **Check fully-encompassing Azure subnet.** If any selected Azure subnet's
   prefix equals the VNet prefix, set `WillMarkFullyAllocated = true` and
   record the Azure subnet's name. The fully-encompassing subnet is **not**
   created as a child.

5. **Plan child subnets.** All non-fully-encompassing selected Azure subnets
   become `BulkImportPlannedChildSubnet` entries under the target. Names are
   truncated/sanitized; collisions within the same target get a `(vnet-name)`
   suffix; further collisions get a numeric suffix.

6. **Cross-existing-tree checks.**
   - For each Azure subnet to be created, fail if its network/CIDR already
     exists anywhere in Bastet.
   - For each non-exact-match VNet prefix, fail if it would, when created,
     contain any existing Bastet subnet.

`CanCommit == true` iff `GlobalErrors.Count == 0` and every item has empty
`Errors`.

### Commit (separate from planner)

`SubnetController.BulkCreateFromAzurePlan`:
1. Re-run the planner with fresh DB snapshot (defends against TOCTOU).
2. Open transaction.
3. Process items ordered by ascending `PrefixCidr` (so containers are created
   before contained subnets if any cross-item nesting happens — defensive,
   even though overlap checks prevent the nasty cases).
4. For each item:
   - ExactMatch: load by id; apply rename if planned.
   - AutoCreate*: build a `CreateSubnetViewModel`, run `ValidateSubnetCreation`,
     create.
   - If `WillMarkFullyAllocated`: set flag + append description note + skip
     children.
   - Else: for each child, build `CreateSubnetViewModel`, run
     `ValidateSubnetCreation`, create.
5. Commit transaction. Any failure → rollback, return `BadRequest` with errors.

---

## 5. Test inventory (26 tests in `AzureBulkImportPlannerTests.cs`)

### Exact-match target
- `ExactMatch_EmptyTarget_PlansChildCreations` — happy path; existing empty `/16` plus 2 child subnets → ExactMatch + 2 children queued.
- `ExactMatch_TargetHasChildren_HardFails`
- `ExactMatch_TargetHasHostIps_HardFails`
- `ExactMatch_TargetIsFullyAllocated_HardFails`
- `ExactMatch_RenameRequested_AndNameDiffers_PlansRename` — rename flag + different existing name → `WillRename=true`, `NewName=VNet name`.
- `ExactMatch_RenameRequested_AndNamesEqual_DoesNotPlanRename` — no-op rename suppressed.

### Auto-create child target
- `AutoCreateChild_WhenContainerExists` — Bastet has `/8` and unrelated `/16`; import `10.2.0.0/16` → AutoCreateChild under `/8`.
- `AutoCreateChild_PicksDeepestContainer` — Among `/8`, `/16`, `/20` all containing the prefix, picks the `/20`.
- `AutoCreateChild_ContainerHasHostIps_HardFails`

### Auto-create top-level target
- `AutoCreateTopLevel_WhenNoContainerAndNoExactMatch` — `192.168.0.0/16` with only `10/8` in Bastet.

### Multi-prefix VNet
- `MultipleVNetPrefixes_EachIsIndependentTarget` — 2 prefixes from same VNet → 2 independent top-level targets, both keep VNet name unchanged, each maps to its own prefix.

### Conflict detection — VNet vs VNet
- `VNetPrefixOverlap_HardFails` — `10.0.0.0/16` + `10.0.0.0/24` → fail.
- `IdenticalVNetPrefixesAcrossVNets_HardFails` — same prefix from two VNets → fail.

### Conflict detection — Azure subnets across VNets
- `AzureSubnetsAcrossVNets_DontOverlap_OK` — disjoint VNets, OK.

### Conflict detection — Azure subnet already in Bastet
- `AzureSubnetAlreadyInBastet_HardFails` — Azure subnet `10.2.5.0/24` and Bastet already has `10.2.5.0/24` somewhere → fail. **Note**: this test setup also trips the would-contain check; both errors fire correctly. The would-contain branch is exercised in isolation by the next test.

### Conflict detection — VNet prefix would contain existing Bastet subnet
- `VNetPrefixWouldContainExistingSubnet_HardFails` — Importing `/16` when `/24` already exists → fail.
- `VNetPrefixContainedByExisting_DoesNotTriggerWouldContainError` — Inverse: `/24` into existing `/16` → AutoCreateChild, OK.

### Fully-encompassing Azure subnet
- `AzureSubnetEqualsVNetPrefix_MarksTargetFullyAllocated_AndNoChildren` — auto-created top-level target.
- `AzureSubnetEqualsVNetPrefix_OnExactMatchTarget_MarksFullyAllocated` — same on exact-match target.

### Naming
- `IdenticalChildNamesInDifferentTargets_AreNotDisambiguated` — same Azure subnet name in two different VNets/targets → both keep the name.
- `NameCollisionWithinSameTarget_GetsDisambiguated` — duplicate names in same target → first stays, second gets `(vnet-name)` suffix.
- `LongAzureName_IsTruncatedTo50Chars`

### Input validation
- `InvalidVNetPrefix_HardFails` — garbage CIDR.
- `MisalignedVNetPrefix_HardFails` — host bits set.
- `AzureSubnetNotInVNet_HardFails` — Azure subnet outside its VNet's prefix.
- `NoSelections_HardFails`

---

## 6. Known accepted behaviors (don't "fix" these without asking)

- **Duplicate auto-created target names are allowed.** When a VNet has multiple
  selected IPv4 prefixes, the auto-created Bastet targets all carry the
  unmodified VNet name. Bastet's `Subnet.Name` has no uniqueness constraint
  (only `(NetworkAddress, Cidr)` is unique). The
  `MultipleVNetPrefixes_EachIsIndependentTarget` test pins this with an
  assertion so any change has to break it on the way in.
- **`AzureSubnetAlreadyInBastet_HardFails` test trips two error paths
  simultaneously.** Both are correct. The would-contain path is exercised in
  isolation by `VNetPrefixWouldContainExistingSubnet_HardFails`. There is a
  comment in the test explaining this.
- **Rename-Bastet-to-VNet-name** only applies to `ExactMatch` targets.
  Auto-created targets are always named after the VNet anyway, so the rename
  flag is meaningless for them.
- **Renames that are no-ops are suppressed** — `WillRename` is only `true` if
  the names actually differ. This avoids generating useless audit log entries.

---

## 7. Out of scope (intentionally not implemented)

- Tags / Azure resource id provenance written to imported Bastet subnets.
- IPv6 address spaces (filtered out at the Azure-service layer).
- Multi-subscription per session (one subscription at a time).
- Async/background commit (sync POST → wait → redirect is fine for the
  expected scale).
- Auto-disambiguating duplicate auto-created target names (see §6).

---

## 8. How to resume in a fresh AI session

Paste this at the start of the new conversation:

> I'm working on the Bastet IPAM project (.NET 10 ASP.NET MVC). It has two
> Azure import features: a per-subnet "Subnet Azure Import" and a top-level
> "Bulk Azure Import". Read `docs/bulk-azure-import.md` first — that doc
> captures every design decision and the architecture. After reading it, also
> read these key files to load context:
>
> - `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs` (the heart of the matching algorithm)
> - `src/Bastet/Services/Azure/IAzureBulkImportPlanner.cs`
> - `src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs`
> - `src/Bastet/Controllers/AzureController.cs` (look for the `BulkImport*` methods)
> - `src/Bastet/Controllers/SubnetController.BulkAzure.cs`
> - `test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs`
> - `src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml` (the JS driving the UI)
>
> Once you've loaded that context, ask me what I want to change. Do not
> revisit any decision listed in §2 of the doc unless I explicitly ask you to.
> Honor the §6 "accepted behaviors" — those exist as written deliberately.
