### PR TITLE
Admin Purge All for deleted records + nav and confirmation cleanup

### DIFF
--- a/src/Bastet/Controllers/HostIpController.cs
+++ b/src/Bastet/Controllers/HostIpController.cs
@@ -326,8 +326,14 @@ public class HostIpController(
     [HttpPost, ActionName("Delete")]
     [ValidateAntiForgeryToken]
     [Authorize(Policy = "RequireDeleteRole")]
-    public async Task<IActionResult> DeleteConfirmed(string ip)
+    public async Task<IActionResult> DeleteConfirmed(string ip, string confirmation)
     {
+        if (confirmation != "approved")
+        {
+            TempData["ErrorMessage"] = "You must type 'approved' to confirm deletion.";
+            return RedirectToAction(nameof(Delete), new { ip });
+        }
+
         // Validate host IP deletion
         ValidationResult validationResult = hostIpValidationService.ValidateHostIpDeletion(ip);
         if (!validationResult.IsValid)

--- a/src/Bastet/Controllers/HostIpController.cs
+++ b/src/Bastet/Controllers/HostIpController.cs
@@ -541,6 +541,37 @@ public class HostIpController(
         return View(allDeletedHostIpsViewModel);
     }
 
+    // GET: HostIp/PurgeAllDeletedHostIps
+    [Authorize(Policy = "RequireAdminRole")]
+    public async Task<IActionResult> PurgeAllDeletedHostIps()
+    {
+        int count = await context.DeletedHostIpAssignments.CountAsync();
+        if (count == 0)
+        {
+            TempData["ErrorMessage"] = "There are no deleted host IP records to purge.";
+            return RedirectToAction(nameof(AllDeletedHostIps));
+        }
+
+        return View(new PurgeAllDeletedHostIpsViewModel { Count = count });
+    }
+
+    // POST: HostIp/PurgeAllDeletedHostIps
+    [HttpPost, ActionName("PurgeAllDeletedHostIps")]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = "RequireAdminRole")]
+    public async Task<IActionResult> PurgeAllDeletedHostIpsConfirmed(string confirmation)
+    {
+        if (confirmation != "approved")
+        {
+            TempData["ErrorMessage"] = "You must type 'approved' to confirm purge.";
+            return RedirectToAction(nameof(PurgeAllDeletedHostIps));
+        }
+
+        int removed = await context.DeletedHostIpAssignments.ExecuteDeleteAsync();
+        TempData["SuccessMessage"] = $"Permanently purged {removed} deleted host IP record(s).";
+        return RedirectToAction(nameof(AllDeletedHostIps));
+    }
+
     // GET: HostIp/DeletedHostIps/{subnetId}
     [Authorize(Policy = "RequireViewRole")]
     public async Task<IActionResult> DeletedHostIps(int subnetId)

--- a/src/Bastet/Controllers/SubnetController.Delete.cs
+++ b/src/Bastet/Controllers/SubnetController.Delete.cs
@@ -254,4 +254,35 @@ public partial class SubnetController : Controller
 
         return View(model);
     }
+
+    // GET: Subnet/PurgeAllDeletedSubnets
+    [Authorize(Policy = "RequireAdminRole")]
+    public async Task<IActionResult> PurgeAllDeletedSubnets()
+    {
+        int count = await context.DeletedSubnets.CountAsync();
+        if (count == 0)
+        {
+            TempData["ErrorMessage"] = "There are no deleted subnet records to purge.";
+            return RedirectToAction(nameof(DeletedSubnets));
+        }
+
+        return View(new PurgeAllDeletedSubnetsViewModel { Count = count });
+    }
+
+    // POST: Subnet/PurgeAllDeletedSubnets
+    [HttpPost, ActionName("PurgeAllDeletedSubnets")]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = "RequireAdminRole")]
+    public async Task<IActionResult> PurgeAllDeletedSubnetsConfirmed(string confirmation)
+    {
+        if (confirmation != "approved")
+        {
+            TempData["ErrorMessage"] = "You must type 'approved' to confirm purge.";
+            return RedirectToAction(nameof(PurgeAllDeletedSubnets));
+        }
+
+        int removed = await context.DeletedSubnets.ExecuteDeleteAsync();
+        TempData["SuccessMessage"] = $"Permanently purged {removed} deleted subnet record(s).";
+        return RedirectToAction(nameof(DeletedSubnets));
+    }
 }

--- a/src/Bastet/Models/ViewModels/PurgeAllViewModels.cs
+++ b/src/Bastet/Models/ViewModels/PurgeAllViewModels.cs
@@ -1,0 +1,11 @@
+namespace Bastet.Models.ViewModels;
+
+public class PurgeAllDeletedSubnetsViewModel
+{
+    public int Count { get; set; }
+}
+
+public class PurgeAllDeletedHostIpsViewModel
+{
+    public int Count { get; set; }
+}

--- a/src/Bastet/Views/HostIp/AllDeletedHostIps.cshtml
+++ b/src/Bastet/Views/HostIp/AllDeletedHostIps.cshtml
@@ -1,13 +1,38 @@
 @model AllDeletedHostIpsViewModel
+@inject Bastet.Services.IUserContextService UserContextService
 
 @{
     ViewData["Title"] = "All Deleted Host IP Assignments";
 }
 
 <div class="mb-4">
-    <h1>All Deleted Host IP Assignments</h1>
+    <div class="d-flex justify-content-between align-items-center">
+        <h1>All Deleted Host IP Assignments</h1>
+        @if (Model.TotalCount > 0 && UserContextService.UserHasRole(Bastet.Models.ApplicationRoles.Admin))
+        {
+            <a asp-action="PurgeAllDeletedHostIps" class="btn btn-danger">
+                <i class="bi bi-trash"></i> Purge All
+            </a>
+        }
+    </div>
     <p class="lead">View all deleted host IP assignments across all subnets</p>
 </div>
+
+@if (TempData["SuccessMessage"] != null)
+{
+    <div class="alert alert-success alert-dismissible fade show mb-4" role="alert">
+        @TempData["SuccessMessage"]
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+
+@if (TempData["ErrorMessage"] != null)
+{
+    <div class="alert alert-danger alert-dismissible fade show mb-4" role="alert">
+        @TempData["ErrorMessage"]
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
 
 @if (Model.TotalCount == 0)
 {

--- a/src/Bastet/Views/HostIp/Delete/_DeleteConfirmationForm.cshtml
+++ b/src/Bastet/Views/HostIp/Delete/_DeleteConfirmationForm.cshtml
@@ -9,8 +9,8 @@
             <input type="hidden" name="ip" value="@Model.IP" />
             
             <div class="mb-3">
-                <div class="form-text mb-2">This action cannot be undone. Type <strong>delete</strong> to confirm.</div>
-                <input type="text" name="confirmation" class="form-control" placeholder="Type 'delete' here" 
+                <div class="form-text mb-2">This action cannot be undone. Type <strong>approved</strong> to confirm.</div>
+                <input type="text" name="confirmation" class="form-control" placeholder="Type 'approved' here"
                        required autocomplete="off" />
             </div>
             

--- a/src/Bastet/Views/HostIp/PurgeAllDeletedHostIps.cshtml
+++ b/src/Bastet/Views/HostIp/PurgeAllDeletedHostIps.cshtml
@@ -1,0 +1,42 @@
+@model PurgeAllDeletedHostIpsViewModel
+
+@{
+    ViewData["Title"] = "Purge All Deleted Host IPs";
+}
+
+<div class="mb-4">
+    <h1>Purge All Deleted Host IPs</h1>
+    <p class="lead">Permanently remove all archived host IP assignment records.</p>
+</div>
+
+@if (TempData["ErrorMessage"] != null)
+{
+    <div class="alert alert-danger alert-dismissible fade show mb-4" role="alert">
+        @TempData["ErrorMessage"]
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+
+<div class="alert alert-danger">
+    <h5 class="alert-heading"><i class="bi bi-exclamation-triangle"></i> This cannot be undone</h5>
+    <p class="mb-0">
+        You are about to permanently delete <strong>@Model.Count</strong> archived host IP record(s).
+        After purging, these records will be gone forever &mdash; there is no recovery.
+    </p>
+</div>
+
+<form asp-action="PurgeAllDeletedHostIps" method="post">
+    @Html.AntiForgeryToken()
+
+    <div class="mb-4">
+        <label for="confirmation" class="form-label fw-bold">Type "approved" to confirm purge:</label>
+        <input type="text" class="form-control form-control-lg" id="confirmation" name="confirmation" required autocomplete="off" />
+    </div>
+
+    <div class="mb-4">
+        <button type="submit" class="btn btn-danger btn-lg">
+            <i class="bi bi-trash"></i> Purge All
+        </button>
+        <a asp-action="AllDeletedHostIps" class="btn btn-outline-secondary btn-lg ms-2">Cancel</a>
+    </div>
+</form>

--- a/src/Bastet/Views/Shared/_Layout.cshtml
+++ b/src/Bastet/Views/Shared/_Layout.cshtml
@@ -22,8 +22,14 @@
                 </button>
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
                     <ul class="navbar-nav flex-grow-1">
-                        <li class="nav-item">
-                            <a class="nav-link" asp-controller="Subnet" asp-action="Index">Subnets</a>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                Subnets
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li><a class="dropdown-item" asp-controller="Subnet" asp-action="Index">Subnets</a></li>
+                                <li><a class="dropdown-item" asp-controller="Subnet" asp-action="DeletedSubnets">Deleted Subnets</a></li>
+                            </ul>
                         </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/src/Bastet/Views/Subnet/DeletedSubnets.cshtml
+++ b/src/Bastet/Views/Subnet/DeletedSubnets.cshtml
@@ -5,6 +5,23 @@
 }
 
 @await Html.PartialAsync("DeletedSubnets/_Header")
+
+@if (TempData["SuccessMessage"] != null)
+{
+    <div class="alert alert-success alert-dismissible fade show mb-4" role="alert">
+        @TempData["SuccessMessage"]
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+
+@if (TempData["ErrorMessage"] != null)
+{
+    <div class="alert alert-danger alert-dismissible fade show mb-4" role="alert">
+        @TempData["ErrorMessage"]
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+
 @await Html.PartialAsync("DeletedSubnets/_CountInfo", Model)
 @await Html.PartialAsync("DeletedSubnets/_EmptyState", Model)
 @await Html.PartialAsync("DeletedSubnets/_SubnetTable", Model)

--- a/src/Bastet/Views/Subnet/DeletedSubnets/_Header.cshtml
+++ b/src/Bastet/Views/Subnet/DeletedSubnets/_Header.cshtml
@@ -1,6 +1,14 @@
+@inject Bastet.Services.IUserContextService UserContextService
+
 <div class="mb-4">
     <div class="d-flex justify-content-between align-items-center">
         <h1>Deleted Subnets</h1>
+        @if (UserContextService.UserHasRole(Bastet.Models.ApplicationRoles.Admin))
+        {
+            <a asp-action="PurgeAllDeletedSubnets" class="btn btn-danger">
+                <i class="bi bi-trash"></i> Purge All
+            </a>
+        }
     </div>
     <p class="lead">View previously deleted subnet records</p>
 </div>

--- a/src/Bastet/Views/Subnet/Index.cshtml
+++ b/src/Bastet/Views/Subnet/Index.cshtml
@@ -9,18 +9,6 @@
         <h1>Subnet Hierarchy</h1>
         <div>
             @inject Bastet.Services.IUserContextService IndexUserContext
-            @if (IndexUserContext.UserHasRole(Bastet.Models.ApplicationRoles.View))
-            {
-                <a asp-action="DeletedSubnets" class="btn btn-outline-secondary me-2">
-                    <i class="bi bi-archive"></i> View Deleted Subnets
-                </a>
-                <a asp-controller="HostIp" asp-action="AllHostIps" class="btn btn-outline-secondary me-2">
-                    <i class="bi bi-ethernet"></i> View All Host IPs
-                </a>
-                <a asp-controller="HostIp" asp-action="AllDeletedHostIps" class="btn btn-outline-secondary me-2">
-                    <i class="bi bi-trash"></i> View All Deleted Host IPs
-                </a>
-            }
             @if (IndexUserContext.UserHasRole(Bastet.Models.ApplicationRoles.Edit))
             {
                 <a asp-action="Create" class="btn btn-primary">

--- a/src/Bastet/Views/Subnet/PurgeAllDeletedSubnets.cshtml
+++ b/src/Bastet/Views/Subnet/PurgeAllDeletedSubnets.cshtml
@@ -1,0 +1,42 @@
+@model PurgeAllDeletedSubnetsViewModel
+
+@{
+    ViewData["Title"] = "Purge All Deleted Subnets";
+}
+
+<div class="mb-4">
+    <h1>Purge All Deleted Subnets</h1>
+    <p class="lead">Permanently remove all archived subnet records.</p>
+</div>
+
+@if (TempData["ErrorMessage"] != null)
+{
+    <div class="alert alert-danger alert-dismissible fade show mb-4" role="alert">
+        @TempData["ErrorMessage"]
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+}
+
+<div class="alert alert-danger">
+    <h5 class="alert-heading"><i class="bi bi-exclamation-triangle"></i> This cannot be undone</h5>
+    <p class="mb-0">
+        You are about to permanently delete <strong>@Model.Count</strong> archived subnet record(s).
+        After purging, these records will be gone forever &mdash; there is no recovery.
+    </p>
+</div>
+
+<form asp-action="PurgeAllDeletedSubnets" method="post">
+    @Html.AntiForgeryToken()
+
+    <div class="mb-4">
+        <label for="confirmation" class="form-label fw-bold">Type "approved" to confirm purge:</label>
+        <input type="text" class="form-control form-control-lg" id="confirmation" name="confirmation" required autocomplete="off" />
+    </div>
+
+    <div class="mb-4">
+        <button type="submit" class="btn btn-danger btn-lg">
+            <i class="bi bi-trash"></i> Purge All
+        </button>
+        <a asp-action="DeletedSubnets" class="btn btn-outline-secondary btn-lg ms-2">Cancel</a>
+    </div>
+</form>


### PR DESCRIPTION
### New Features
- Admin-gated **Purge All** on Deleted Subnets — typed-`approved` confirmation, hard-deletes archived rows
- Admin-gated **Purge All** on Deleted Host IPs — same flow

### Improvements
- Top-bar **Subnets** is now a dropdown (Subnets / Deleted Subnets), matching the existing Host IPs dropdown
- Dropped the redundant "View …" buttons next to **Create Subnet** on the hierarchy page
- All destructive confirmations now require the same word (`approved`) — Host IP Delete prompt updated to match

### Bug Fixes
- Host IP Delete now actually validates the typed confirmation server-side (the field was previously ignored)
