### PR TITLE
Audit 5 Cleanup

### DIFF
--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -264,35 +264,44 @@ _Tests 599 → 603 (+4). Build clean, 0 warnings._
 
 ## E6. Concurrency-conflict handler displays a Last Modified time that was never saved `[×2]`
 
-**Confidence: confirmed.** The EF behaviour was measured, not assumed.
+_E6 is fixed and committed. Both re-queries — the one in the `DbUpdateConcurrencyException` handler
+and the fall-through repopulation that runs last — now use `AsNoTracking()`. Both were needed: the
+fall-through query is what actually reaches the view, so fixing only the handler would have changed
+nothing on screen._
 
-**Where:** [SubnetController.Edit.cs:179-181](../src/Bastet/Controllers/SubnetController.Edit.cs#L179-L181)
-(the re-query under the comment "reload current data"),
-[:190](../src/Bastet/Controllers/SubnetController.Edit.cs#L190),
-[:218](../src/Bastet/Controllers/SubnetController.Edit.cs#L218) and
-[:247](../src/Bastet/Controllers/SubnetController.Edit.cs#L247) (the fall-through repopulation, which
-runs last and is what reaches the view),
-[_NetworkInformation.cshtml:24-27](../src/Bastet/Views/Subnet/Edit/_NetworkInformation.cshtml#L24-L27).
+_Reproduced against a real SQL Server 2022 container, because the defect is unreachable on the SQLite
+the suite runs on: `[Timestamp] byte[] RowVersion` is only DB-generated on SQL Server, so
+`DbUpdateConcurrencyException` never fires under the test provider. Driving Bastet's own
+`BastetDbContext` through the exact handler sequence — load tracked, mutate, lose the optimistic
+concurrency race — gives:_
 
-The re-query is a **tracking** query on a context where the entity is still tracked in `Modified` state,
-so EF returns that same instance and discards the row it read. Measured on EF Core 10.0.10: the tracking
-re-query returned `ReferenceEquals == True` with the in-memory values, while `AsNoTracking()` on the same
-context returned the real row.
+```
+loaded            LastModifiedAt=10:05  (this is user B's saved value)
+SaveChanges threw DbUpdateConcurrencyException - handler entered
+tracking re-query LastModifiedAt=01:35  Name=webA
+                  same object as the dirty entity? True
+AsNoTracking      LastModifiedAt=10:05  Name=web
+```
 
-**Failure scenario.** Subnet 5 last modified 10:05 by user B. User A submits a stale edit at 10:10;
-`subnet.LastModifiedAt` is set to 10:10 before the save, which then throws
-`DbUpdateConcurrencyException`. The page renders "Last Modified 1/1/2026 10:10 AM" directly above the
-banner "This subnet was modified by another user… review the current values before saving." The one
-current value on the screen is user A's own rejected attempt.
+_`ReferenceEquals` being true is the mechanism: identity resolution hands back the tracked instance
+and discards the row it just read. **The measurement corrected the finding on one point.** The audit
+expected the screen to show the submitting user's own timestamp; it actually shows `01:35`, the wall
+clock at the moment of the failed save, because `BastetDbContext.UpdateAuditFields` re-stamps
+`LastModifiedAt = UtcNow` on every `SaveChangesAsync` attempt including the one that fails. So the
+value displayed as "current" was never anyone's edit — it is simply *now_.
 
-**Bounded, deliberately:** `RowVersion` is *not* corrupted — line 72 loads the fresh row inside the lock,
-so only `OriginalValues` was rewound. Concurrency control and the retry work correctly; this is
-display-only. The view renders no username, so only the timestamp is wrong.
+_No permanent test ships with this one, deliberately. Reaching the defect requires a real
+`rowversion`, and the suite has no SQL Server; a SQLite test would either not compile the scenario or
+pass vacuously. The rig was ephemeral and is deleted. The audit's cheaper interim —
+`ex.Entries[0].GetDatabaseValues()` — was not taken: it would fix only the handler and leave the
+fall-through query, which is the one that wins._
 
-**Fix.** `await context.Entry(subnet).ReloadAsync()` in the handler, or read the display fields with
-`.AsNoTracking()`. **The fall-through query at :218 needs the same treatment** — it runs last, so fixing
-:179 alone changes nothing on screen. Cheapest correct option: read from
-`ex.Entries[0].GetDatabaseValues()`, which EF already fetched for the failed UPDATE.
+_Confirmed display-only, as the finding said: `RowVersion` was never corrupted, because the entity is
+loaded fresh inside the lock and only `OriginalValues` is rewound, so the retry keeps working._
+
+_Tests 603 → 603 (unchanged). Build clean, 0 warnings._
+
+---
 
 ## E7. Every leaf subnet's toggle becomes an inert "+" expander after any tree interaction `[×2]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -329,26 +329,31 @@ affordance is the icon only, not the cursor.
 
 ## E8. The Create form calls `/api/subnets/calculate-mask`, a route that has never existed `[×1]`
 
-**Confidence: confirmed.** Found twice in pass 1 (UI and dead-code beats), by neither beat in pass 2 —
-so treat the absence as weak, per the tagging rule.
+_E8 is fixed and committed. The `$.get(...).fail(...)` wrapper is deleted and `updateSubnetInfo` now
+calls the local `calculateSubnetMask(cidrValue)` directly — which is what the `.fail` handler already
+did on every single keystroke, since the request could never succeed._
 
-**Where:** [_SubnetFormScripts.cshtml:46](../src/Bastet/Views/Subnet/Create/_SubnetFormScripts.cshtml#L46).
+_**Taken out of numeric order, ahead of E7**, which is recorded here rather than left implicit: E7 is
+a client-side jQuery defect needing a browser rig, and this one needed nothing but a grep. E7 follows
+immediately._
 
-A repo-wide grep for `calculate-mask` returns exactly one line: this one. There is no `Api` controller
-and the only `[Route]` attributes in the tree are `ErrorController.cs:16` and `:61`. So the request
-404s, is re-executed through `UseStatusCodePagesWithReExecute("/Error/{0}")` — registered in both the
-dev and non-dev branches — and renders a full server-side Razor error page that jQuery then discards,
-because a 404 sends it to `.fail()`, which computes the mask locally anyway.
+_Verified the route genuinely does not exist rather than trusting the finding: a repo-wide grep for
+`api/subnets` and `calculate-mask` across `.cs`, `.cshtml` and `.js` returned exactly one line — the
+call itself — and the only `[Route]` attributes in the entire application are `ErrorController`'s two.
+After the fix the only remaining mention anywhere is the comment explaining what used to be there._
 
-**Failure scenario.** Every keystroke in the CIDR field costs a wasted round-trip plus a discarded
-multi-KB error render. And because `CreateSubnetViewModel.Cidr` is a non-nullable int, `asp-for` renders
-`value="0"` and `initializeForm()` fires one on **every** page load before the user types anything.
+_No fallback behaviour is lost. The guard immediately above the call already constrains the value to
+0–32, so `calculateSubnetMask` is never handed anything it reports as invalid, and the server renders
+the initial value into the span independently. Being a `[×1]` this was re-derived rather than assumed;
+it was found twice within pass 1 (by both the UI and dead-code beats) and missed entirely by pass 2._
 
-The success callback at line 47 is unreachable code that has never executed.
+_No test ships: there is no JS harness in the repo, and the change removes a network call rather than
+altering a computed value. The definitive check is the absence of a 404 for that URL when the Create
+page is exercised, which is folded into the closing sweep._
 
-**Fix.** Delete the `$.get`/`.fail` wrapper and call the local helper directly:
-`$('#subnetMaskDisplay').text(calculateSubnetMask(cidrValue));`. It is already the fallback, already
-covers /0 through /32, and being synchronous removes the ordering hazard between concurrent responses.
+_Tests 603 → 603 (unchanged). Build clean, 0 warnings._
+
+---
 
 ## E9. `BatchCreateChildSubnets` discards every selected child when an encompassing entry is present `[×2]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -62,72 +62,50 @@ was off, it is corrected here and noted.
 
 ## E1. Reconcile silently discards every prefix-drift row, and explains it with a false statement `[×2]`
 
-**Confidence: confirmed (live).** Reproduced end to end against a real Azure subscription.
+_E1 is fixed and committed, and it is the finding this round turned on. The fix partitions on what a
+row **claims** rather than applying one rule to every proposed row: a confirmation answers "is the
+resource gone?", which is a question only `VNetDeleted` and `SubnetDeleted` ask. A drift row exists
+precisely because the resource **was** found in the listing, so reading it back can only ever answer
+`Live`._
 
-**Where:** [AzureReconciler.cs:126-148](../src/Bastet/Services/Azure/AzureReconciler.cs#L126-L148) —
-the `switch` at 134-145 and `plan.Items = keep` at 148.
-Also [AzureReconciler.cs:197](../src/Bastet/Services/Azure/AzureReconciler.cs#L197) (`VNetPrefixRemoved`),
-[:233](../src/Bastet/Services/Azure/AzureReconciler.cs#L233) (`SubnetPrefixChanged`),
-[:87-94](../src/Bastet/Services/Azure/AzureReconciler.cs#L87-L94) (only `FullyAllocatingSubnetDeleted`
-is diverted to `ReviewItems`; every other status lands in the deletable `Items`),
-[:162-164](../src/Bastet/Services/Azure/AzureReconciler.cs#L162-L164) (the false warning),
-[AzureController.cs:382](../src/Bastet/Controllers/AzureController.cs#L382) (submits every row, no
-status filter), [SubnetController.AzureReconcile.cs:70](../src/Bastet/Controllers/SubnetController.AzureReconcile.cs#L70)
-(the commit path applies the same filter).
+_Both halves of the audit's suggested fix were applied — the guard in `ApplyConfirmations` and the
+filter in `ConfirmProposedDeletionsAsync` — but **not as the audit worded them**. Writing the status
+list out at both call sites would have created exactly the drift-prone duplication these rounds keep
+finding, so the rule is extracted once as `AzureReconciler.IsAbsenceStatus` and both sites call it.
+The controller now reads back only absence rows, so a scan whose drift is healthy makes **no ARM
+calls at all** rather than one per row._
 
-`ApplyConfirmations` partitions purely on the ARM verdict with no reference to `item.Status`. But
-`VNetPrefixRemoved` and `SubnetPrefixChanged` are produced *only* when the resource was found in the
-listing — their reason strings literally say "still exists". So `ConfirmOneAsync` returns `Live` for
-them by construction, every time, and they are routed to `stillLive` and stripped from `plan.Items`.
+_Proven before it was fixed, in that order. Eight regression tests were written first and all eight
+failed against the unfixed code with `Assert.Single() Failure: The collection was empty` — the drift
+row being dropped, which is the defect itself and not an unrelated failure. They cover both drift
+statuses against all three non-`Deleted` verdicts, a drift row absent from the map entirely (the
+shape the new controller filter actually produces), and a mixed plan where an absence row and a drift
+row must be judged differently in the same pass._
 
-**Failure scenario, run for real.** Against resource group `bastet`, `vnet-visible` genuinely exists at
-`10.10.0.0/16` and its subnet `snet-vnet-visible-a` at `10.10.1.0/24`. Feeding the reconciler linked
-rows recording `10.10.0.0/17` and `10.10.5.0/24` — i.e. prefix drift — produced:
+_Then re-measured against live ARM, both directions, because a unit test cannot prove ARM's answers.
+With the drifted prefixes recorded against resources that genuinely exist, the plan now reports
+`PROPOSED FOR DELETION: 2  CanCommit=True` carrying `VNetPrefixRemoved` and `SubnetPrefixChanged`,
+where before the fix it reported `0  CanCommit=False`. The counter-test matters as much and was run
+on the same build: a credential that cannot see the other resource group still withholds all 10 rows
+with the warning naming each one. The reconciler discriminates rather than merely blocking — checking
+only the first of those two would have let an over-blocking regression pass silently. Note the rig
+feeds `ApplyConfirmations` **unfiltered** input, so it proves the guard holds even without the
+controller's filter, which is a superset of the shipped path._
 
-```
---- BuildPlan (listing only) ---
-PROPOSED FOR DELETION: 2
-  #4 vnet-visible 10.10.0.0/17  [VNetPrefixRemoved]  VNet 'vnet-visible' still exists but no longer has the address prefix 10.10.0.0/17.
-  #5 snet-vnet-visible-a 10.10.5.0/24  [SubnetPrefixChanged]  ... its address prefix is now 10.10.1.0/24, not 10.10.5.0/24.
+_The audit's second complaint — that the withheld warning states rows "were missing from the
+subscription listing" when they were not — needed **no text change** and was deliberately not given
+one. After the fix, `stillLive` can only hold absence rows, for which that sentence is exactly
+accurate: they really were missing from the listing and a direct read really did find them. The
+sentence was only ever wrong about the drift rows, which no longer reach it._
 
---- ConfirmResourcesAsync (2 ids read directly from ARM) ---
-  Live  .../virtualNetworks/vnet-visible
-  Live  .../virtualNetworks/vnet-visible/subnets/snet-vnet-visible-a
+_Left alone deliberately, as the finding itself scoped: the `VNetDeleted` status is overloaded and
+also fires for "VNet exists but has no IPv4 address space left", where the direct read answers `Live`
+and the row is withheld. That withhold is defensible rather than clearly wrong — the VNet does still
+exist — and changing it means re-labelling the row, not archiving it. Untouched._
 
---- FINAL PLAN ---
-PROPOSED FOR DELETION: 0   CanCommit=False
-  WARN 2 Azure-linked subnet(s) were missing from the subscription listing but still exist in Azure,
-       so they have been withheld from deletion: 'vnet-visible', 'snet-vnet-visible-a'.
-```
+_Tests 576 → 584 (+8). Build clean, 0 warnings._
 
-The operator sees zero actionable rows, the green "nothing to clean up" banner (E11), and a warning
-asserting the rows were *missing from the listing* — which is false; they were present and matched.
-Both statuses render "Prefix removed" / "Prefix changed" badges with checkboxes in
-[_ReconcileScripts.cshtml:186-188](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L186-L188),
-so they are actionable by design. Every re-scan repeats it: the drift can never be cleaned up here.
-
-No test catches it because `MockAzureService.DefaultConfirmation` is `Deleted`
-([MockAzureService.cs:226](../test/Bastet.Tests/TestHelpers/MockAzureService.cs#L226)), and
-`VNetLiveButPrefixRemoved_Flagged` / `SubnetPrefixChanged_Flagged` exercise `BuildPlan` only, never the
-controller's confirmation step.
-
-**Fix.** Confirmation is only meaningful for statuses that assert *absence*. In
-`ConfirmProposedDeletionsAsync`, submit only
-`plan.Items.Where(i => i.Status is AzureReconcileStatus.VNetDeleted or AzureReconcileStatus.SubnetDeleted)`,
-and have `ApplyConfirmations` leave any item it was given no verdict for untouched rather than treating
-absence as `Unknown`. A healthy drift scan then makes no extra ARM calls at all.
-
-**Cheaper interim:** at the top of the `foreach`, `if (item.Status is not (VNetDeleted or SubnetDeleted)) { keep.Add(item); continue; }`.
-That restores pre-D3 behaviour for exactly those rows and leaves D3's protection intact everywhere else.
-
-Any regression test **must** set `MockAzureService.Confirmations[id] = AzureResourceConfirmation.Live`
-explicitly; the mock's `Deleted` default hides this defect.
-
-*Not in scope of this finding:* the `VNetDeleted` status is overloaded — it also fires for "VNet exists
-but has no IPv4 address space left", where `GetVNetInventory` drops the VNet
-([AzureService.cs:337-341](../src/Bastet/Services/Azure/AzureService.cs#L337-L341)) and the direct read
-then answers `Live`. Withholding there is defensible rather than clearly wrong, so it is left alone.
-If it is ever addressed, the answer is to re-label the row, not to archive it.
+---
 
 ## E2. Subnet Edit silently destroys names, descriptions and tags that Create rejects `[×2]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -147,43 +147,43 @@ _Tests 584 → 590 (+6). Build clean, 0 warnings._
 
 ## E3. A CIDR decrease from /31 or /32 strands a host IP on the new network address `[×1]`
 
-**Confidence: confirmed.** Reproduced by a verifier driving the real controller and services.
+_E3 is fixed and committed, and being a `[×1]` it was re-derived from scratch rather than taken on
+trust. It holds. Both halves of the finding's fix were needed and both were applied: the controller
+gate now reads `viewModel.Cidr != subnet.Cidr` so a decrease reaches the validator at all, and
+`ValidateSubnetCidrChangeWithHostIps` gained a decrease arm rejecting an assignment that equals the
+network address when the new CIDR is below /31. Verified that the controller change alone is
+insufficient, exactly as the finding warned — the service's own `newCidr > originalCidr` gate would
+still have skipped it._
 
-**Where:** [SubnetController.Edit.cs:121](../src/Bastet/Controllers/SubnetController.Edit.cs#L121)
-(`if (viewModel.Cidr > subnet.Cidr)`, with the justifying comment at
-[:136-137](../src/Bastet/Controllers/SubnetController.Edit.cs#L136-L137)),
-[HostIpValidationService.cs:316](../src/Bastet/Services/Validation/HostIpValidationService.cs#L316)
-(`if (newCidr > originalCidr)` — the second gate),
-[HostIpValidationService.cs:70](../src/Bastet/Services/Validation/HostIpValidationService.cs#L70)
-(`if (subnet.Cidr < 31)` — what permits the assignment in the first place).
+_One refinement the finding did not have. It compares the host IP against the recorded
+`networkAddress` directly, which silently assumes the subnet is aligned to the new CIDR. It is not
+always: widening `10.0.0.2/31` to `/30` moves the network address down to `10.0.0.0`, so `10.0.0.2`
+becomes an ordinary host and there is no collision. The arm is therefore guarded with
+`ipUtilityService.IsValidSubnet(networkAddress, newCidr)`, which establishes that the recorded
+address really is the new network address before comparing. An unaligned decrease is rejected before
+it reaches here, so this is belt-and-braces rather than a behaviour change — but it means the rule
+is stated in terms of what is true rather than what happens to be true._
 
-The comment says a CIDR decrease needs no host-IP validation "since making a subnet larger cannot cause
-host IPs to fall outside its range". That is true about the *range* and false about *reservation*.
+_The comment at the old call site — "For CIDR decreases (subnet expansion), no host IP validation is
+needed since making a subnet larger cannot cause host IPs to fall outside its range" — was deleted
+rather than amended. It is the reasoning that produced the bug: true about the *range* and silent
+about *reservation*._
 
-**Failure scenario.** Parent `10.0.0.0/24`, child `10.0.0.0/31`. Assign host IP `10.0.0.0` — accepted,
-correctly, because RFC 3021 exempts /31 from the network/broadcast reservation. Now edit the child to
-`/30`. Host-IP validation is skipped entirely on both gates. Result:
+_Six tests written first. The two defect cases (`/31`→`/30` and `/32`→`/24`, host IP on the network
+address) failed against the unfixed code; the three guards passed throughout, which is the point of
+them — the other address of a `/31` must stay assignable once widened, an ordinary widening between
+two CIDRs that both already reserve the network address cannot create a new collision, and
+**widening a `/32` to a `/31` must reserve nothing**, since RFC 3021 applies to the destination too.
+That last one is what a fix written without the `newCidr < 31` guard would break._
 
-```
-PERSISTED: 10.0.0.0/30 with host IPs: 10.0.0.0
-ValidateNewHostIp('10.0.0.0', subnet) valid=False :: NETWORK_ADDRESS_RESERVED
-unallocated row: 10.0.0.1 - 10.0.0.2 count=2
-```
+_The sixth test is a controller test, added because the service tests do not pin the gate: reverting
+`!=` back to `>` leaves all five service tests green. Proven by doing exactly that in a scratch copy
+— and the first attempt at that probe was **wrong and had to be redone**, because a careless `sed`
+rewrote both `!=` comparisons in the file rather than the one under test, including a pre-existing
+and correct one ten lines above. Re-run against line 124 alone, the controller test is the single
+failure._
 
-The row now in the database is one the validated create path refuses — delete it and it cannot be
-re-created. The Details page simultaneously lists `10.0.0.0` as assigned and shows 2 free addresses, so
-it accounts for 3 addresses in a subnet whose `UsableIpAddresses` is 2. Same from `/32` → `/24`.
-
-**Fix.** Change the controller gate to `if (viewModel.Cidr != subnet.Cidr)` **and** add a decrease arm
-to `ValidateSubnetCidrChangeWithHostIps`: when `newCidr < originalCidr && newCidr < 31`, reject any
-assignment whose IP equals the network address. Both halves are required — the service's own
-`newCidr > originalCidr` gate at :316 means relaxing the controller alone changes nothing.
-
-Only the network address needs checking on a decrease: widening leaves it fixed and moves the broadcast
-strictly upward past every address the old range held, which is why only a /31 or /32 origin collides.
-
-This is the mirror image of D4, the broadcast-side defect at the same call site, which round 4 filed
-medium and fixed.
+_Tests 590 → 596 (+6). Build clean, 0 warnings._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -4,6 +4,46 @@
 **Test baseline:** 576 passing, 0 failed. `dotnet build --no-incremental` clean, 0 warnings.
 **Date:** 2026-07-26
 
+## Reconciliation — complete
+
+**All 14 findings fixed, none refuted on re-verification.** One commit each, on `task/audit-5`.
+
+**Final state:** 603 passing (576 → 603, +27), 0 failed. Clean rebuild from deleted `bin`/`obj`,
+0 warnings. Working tree clean, no scaffolding committed.
+
+**Closing sweep.** Every major area was requested from the real application running against a real
+SQL Server, asserting titles and content rather than status codes: home, subnet hierarchy, create,
+details, edit, delete, deleted subnets, purge, host IP create, all-deleted-host-IPs, both Azure
+wizards, the reconcile wizard, and the 404/500/access-denied pages. Two redirects were classified
+rather than glossed: `/Azure/Import` 404s without a subnet id, and the purge page redirects when
+there is nothing to purge — both by design. Security headers ride on both a normal 200 and the error
+page. Three fixes were confirmed live through HTTP: E2 (markup name rejected, stored value
+untouched), E5 (out-of-range CIDR renders the form, not a 500), and E10 (the 409 carries its
+`warnings`).
+
+**The Azure surface was driven end to end against live ARM**, with the discrimination check that
+matters — a reconciler that blocks everything is as broken as one that deletes everything:
+
+| Linked row | Azure reality | Result |
+|---|---|---|
+| `invisible-link` | 403, resource group not visible | **withheld**, warning names it; delete refused 409 |
+| `really-gone` | 404, genuinely absent | **offered**, deleted and archived |
+| `drifted-prefix` | 200, exists with a changed prefix | **offered** — this is E1's fix, dead before it |
+
+**Log:** 1467 lines, **zero `fail:`**, five `warn:`. Three are `Azure denied access to … (403), so it
+cannot be reported as deleted` — the deliberate permission probe working, logged by design, not a
+fault. The other two are environmental and pre-existing: DataProtection has no XML encryptor
+configured for a local run, and EF advises on `QuerySplittingBehavior` for a multi-`Include` query.
+
+**Coverage was not re-run.** This round deleted no code — E8 removed a call, not a declaration — so
+there is no dead-code delta to compare against a reference sweep.
+
+**Deliberately not done**, each argued in the struck entry that owns it: `[SafeText]` was **not**
+added to the subnet edit model (E2), because no Azure import path applies it and existing rows could
+become uneditable; the overloaded `VNetDeleted` "exists but has no IPv4 space" sub-case was left
+withholding (E1); the three copies of the usable-IP calculation were **not** consolidated (E13); and
+`subnetIds` in the reconcile 409 remains unrendered (E10).
+
 ## Verdict
 
 No critical or high-severity defects, and nothing that loses or wrongly deletes data.

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -495,27 +495,38 @@ _Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 
 ## E14. The reconcile confirmation screen overstates the blast radius `[×1]`
 
-**Confidence: confirmed.**
+_E14 is fixed and committed. A `targets` local — `chosen.filter(i => !covered[i.subnetId])` — now
+drives both `#rec-confirm-count` and `#rec-confirm-list`, so the screen counts and names what the
+server will actually report as deleted. The cascade sum iterates `targets` directly rather than
+`chosen` with a skip, which is the same set by construction and one fewer thing to keep in step.
+`confirmedIds` still carries every selected id: the server dedupes by subtree, and narrowing what is
+posted would change behaviour rather than reporting._
 
-**Where:** [_ReconcileScripts.cshtml:306](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L306)
-(`$("#rec-confirm-count").text(chosen.length);`) and the cascade block at :310-333.
+_Verified by lifting the `covered`/`targets`/sum block **verbatim** out of the shipped file — pulled
+by offset, not retyped — wrapping it in a function and running it in chromium against the finding's
+own scenario, a deleted VNet target plus its imported child, both ticked:_
 
-**Failure scenario.** Target "prod-vnet" (id 10, a VNet resource ID, one descendant) with imported child
-"prod-web" (id 11). When the VNet is deleted in Azure, `BuildPlan` emits **both** rows — id 10 as
-`VNetDeleted`, id 11 as `SubnetDeleted` — and `renderPlan` gives each an independent checkbox. Select
-all, and the confirmation reads "You are about to delete **2** subnet(s)…" followed by "This **also**
-archives **1** child subnet(s)…". The word "also" is false: that 1 child *is* one of the 2, so the
-screen announces 3 subnets where only 2 exist. The server then reports "deleted **1** stale subnet(s),
-archiving 2 subnet(s)" — so the operator is told 2 targets before confirming and 1 afterwards. On a
-real VNet import with a dozen children it is a dozen-way discrepancy, on a destructive confirmation.
+```
+{"targets":1,"descendants":1,"hostIps":2,"names":["prod-vnet"]}
+```
 
-The defect is one-sided: `covered` correctly suppresses the child as a cascade *contributor*, while
-`chosen.length` and `#rec-confirm-list` still count it as a delete *target*.
+_So the screen now reads "1 subnet(s)… this also archives 1 child subnet(s) and 2 host IP
+assignment(s)" — three numbers describing two subnets, and agreeing with the server's "deleted 1
+stale subnet(s), archiving 2 subnet(s)". Previously it read 2 targets **plus** 1 cascaded child,
+announcing three subnets where two exist, and then contradicted itself after the delete._
 
-**Fix.** Report what the server will actually do: compute top-level targets as
-`chosen.filter(i => !covered[i.subnetId])` and use that length for the count and the list, still posting
-the full `confirmedIds` (the server dedupes by subtree anyway). The existing cascade sum then genuinely
-is "also".
+_The first run of this check reported `hostIps: 0`, which was a **fault in my fixture, not the
+code**: the plan's counts are subtree-inclusive, so a parent's `hostIpCount` already contains its
+children's. Corrected to 2 and re-run, rather than recording a number that would have misled the next
+reader._
+
+_The finding's cheaper interim — leaving the count alone and rewording the cascade sentence to a
+total — was not taken. It fixes the arithmetic by changing the prose around it while
+`#rec-confirm-list` still enumerates rows that are not separate deletions._
+
+_Whole script re-parsed in chromium after the edit: `OK`._
+
+_Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -1,0 +1,635 @@
+# Bastet — Round-5 Audit Findings
+
+**Target:** branch `main`, HEAD `bf120d6` "Audit 4 Cleanup (#141)" (all 43 round-4 fixes squashed).
+**Test baseline:** 576 passing, 0 failed. `dotnet build --no-incremental` clean, 0 warnings.
+**Date:** 2026-07-26
+
+## Verdict
+
+No critical or high-severity defects, and nothing that loses or wrongly deletes data.
+
+The headline is **E1**, and it is a regression introduced *by* round 4's D3 fix: the per-resource
+confirmation D3 added is applied to every proposed row regardless of what the row asserts, so the two
+statuses that mean "the resource still exists but its prefix drifted" are confirmed `Live` and then
+dropped for still existing. Prefix drift is now permanently undetectable through the reconcile UI, and
+the operator is shown a warning stating the rows "were missing from the subscription listing" when they
+were not. I proved this end to end against a live Azure subscription, not by reading — see below.
+
+The same live rig proved the D3 fix itself is sound and load-bearing: with a credential that had lost
+access to a resource group, `BuildPlan` alone proposed **all 10** imported subnets for archival with
+`CanCommit=True`, and D3's direct-read guard correctly withheld every one of them. Round 4's most
+consequential fix does what its struck paragraph claims.
+
+After that it is a long tail. **E2** and **E3** are the two worth reading next — both persist a state
+the validated path would reject. The rest are messaging, diagnostics and client-side affordance defects.
+
+Read in this order: **E1** (a shipped capability is silently dead), **E2**, **E3**, then the lows.
+
+## How this audit ran
+
+Eight parallel finder beats — security/web, logic & data integrity, Azure, locking & lifecycle,
+UI/client-JS, regression-correctness, regression-tests, dead code — each finding then handed to an
+independent verifier instructed to **refute** it and to default to "not real" when uncertain.
+
+It ran **twice**, deliberately. 16 finders, 45 verifiers, 61 agents, 0 errors. Findings are tagged:
+
+- **[×2]** — found independently by both passes. Strongest signal.
+- **[×1]** — found by one pass only. *Not weaker in truth* — it means a full pass missed it, so it
+  deserves **more** scrutiny during reconciliation, not less. **Absence is weak evidence.**
+
+Pass 1: 13 survived, 8 refuted. Pass 2: 14 survived, 10 refuted. Merged and de-duplicated to 14 below.
+
+Two things distinguish this round from round 4:
+
+**The regression beats read atomic commits.** PR #141 squashed to one commit locally, but its 45
+original commits were recovered via `git fetch origin pull/141/head`. 43 map one-to-one onto D1–D43;
+the other two (`5770a3c`, `841e769`) are skill/docs only. Each fix was diffed against the struck
+paragraph describing it.
+
+**The Azure beat had a live rig.** Two service principals with *disjoint* scope — one seeing resource
+group `bastet`, one seeing `bastet-hidden`, neither seeing the other — driving Bastet's own
+`AzureService` and `AzureReconciler` against real ARM. Read-only throughout: enumeration and
+`ConfirmResourcesAsync` only, never an archival path, never a write to Azure. Findings it settled are
+marked **confirmed (live)**. Several verifiers built their own rigs too, including a real SQL Server
+container for E4 and an EF Core tracking harness for E6.
+
+I re-checked every citation in this file against the working tree by hand. Where a finder's line number
+was off, it is corrected here and noted.
+
+---
+
+# Medium
+
+## E1. Reconcile silently discards every prefix-drift row, and explains it with a false statement `[×2]`
+
+**Confidence: confirmed (live).** Reproduced end to end against a real Azure subscription.
+
+**Where:** [AzureReconciler.cs:126-148](../src/Bastet/Services/Azure/AzureReconciler.cs#L126-L148) —
+the `switch` at 134-145 and `plan.Items = keep` at 148.
+Also [AzureReconciler.cs:197](../src/Bastet/Services/Azure/AzureReconciler.cs#L197) (`VNetPrefixRemoved`),
+[:233](../src/Bastet/Services/Azure/AzureReconciler.cs#L233) (`SubnetPrefixChanged`),
+[:87-94](../src/Bastet/Services/Azure/AzureReconciler.cs#L87-L94) (only `FullyAllocatingSubnetDeleted`
+is diverted to `ReviewItems`; every other status lands in the deletable `Items`),
+[:162-164](../src/Bastet/Services/Azure/AzureReconciler.cs#L162-L164) (the false warning),
+[AzureController.cs:382](../src/Bastet/Controllers/AzureController.cs#L382) (submits every row, no
+status filter), [SubnetController.AzureReconcile.cs:70](../src/Bastet/Controllers/SubnetController.AzureReconcile.cs#L70)
+(the commit path applies the same filter).
+
+`ApplyConfirmations` partitions purely on the ARM verdict with no reference to `item.Status`. But
+`VNetPrefixRemoved` and `SubnetPrefixChanged` are produced *only* when the resource was found in the
+listing — their reason strings literally say "still exists". So `ConfirmOneAsync` returns `Live` for
+them by construction, every time, and they are routed to `stillLive` and stripped from `plan.Items`.
+
+**Failure scenario, run for real.** Against resource group `bastet`, `vnet-visible` genuinely exists at
+`10.10.0.0/16` and its subnet `snet-vnet-visible-a` at `10.10.1.0/24`. Feeding the reconciler linked
+rows recording `10.10.0.0/17` and `10.10.5.0/24` — i.e. prefix drift — produced:
+
+```
+--- BuildPlan (listing only) ---
+PROPOSED FOR DELETION: 2
+  #4 vnet-visible 10.10.0.0/17  [VNetPrefixRemoved]  VNet 'vnet-visible' still exists but no longer has the address prefix 10.10.0.0/17.
+  #5 snet-vnet-visible-a 10.10.5.0/24  [SubnetPrefixChanged]  ... its address prefix is now 10.10.1.0/24, not 10.10.5.0/24.
+
+--- ConfirmResourcesAsync (2 ids read directly from ARM) ---
+  Live  .../virtualNetworks/vnet-visible
+  Live  .../virtualNetworks/vnet-visible/subnets/snet-vnet-visible-a
+
+--- FINAL PLAN ---
+PROPOSED FOR DELETION: 0   CanCommit=False
+  WARN 2 Azure-linked subnet(s) were missing from the subscription listing but still exist in Azure,
+       so they have been withheld from deletion: 'vnet-visible', 'snet-vnet-visible-a'.
+```
+
+The operator sees zero actionable rows, the green "nothing to clean up" banner (E11), and a warning
+asserting the rows were *missing from the listing* — which is false; they were present and matched.
+Both statuses render "Prefix removed" / "Prefix changed" badges with checkboxes in
+[_ReconcileScripts.cshtml:186-188](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L186-L188),
+so they are actionable by design. Every re-scan repeats it: the drift can never be cleaned up here.
+
+No test catches it because `MockAzureService.DefaultConfirmation` is `Deleted`
+([MockAzureService.cs:226](../test/Bastet.Tests/TestHelpers/MockAzureService.cs#L226)), and
+`VNetLiveButPrefixRemoved_Flagged` / `SubnetPrefixChanged_Flagged` exercise `BuildPlan` only, never the
+controller's confirmation step.
+
+**Fix.** Confirmation is only meaningful for statuses that assert *absence*. In
+`ConfirmProposedDeletionsAsync`, submit only
+`plan.Items.Where(i => i.Status is AzureReconcileStatus.VNetDeleted or AzureReconcileStatus.SubnetDeleted)`,
+and have `ApplyConfirmations` leave any item it was given no verdict for untouched rather than treating
+absence as `Unknown`. A healthy drift scan then makes no extra ARM calls at all.
+
+**Cheaper interim:** at the top of the `foreach`, `if (item.Status is not (VNetDeleted or SubnetDeleted)) { keep.Add(item); continue; }`.
+That restores pre-D3 behaviour for exactly those rows and leaves D3's protection intact everywhere else.
+
+Any regression test **must** set `MockAzureService.Confirmations[id] = AzureResourceConfirmation.Live`
+explicitly; the mock's `Deleted` default hides this defect.
+
+*Not in scope of this finding:* the `VNetDeleted` status is overloaded — it also fires for "VNet exists
+but has no IPv4 address space left", where `GetVNetInventory` drops the VNet
+([AzureService.cs:337-341](../src/Bastet/Services/Azure/AzureService.cs#L337-L341)) and the direct read
+then answers `Live`. Withholding there is defensible rather than clearly wrong, so it is left alone.
+If it is ever addressed, the answer is to re-label the row, not to archive it.
+
+## E2. Subnet Edit silently destroys names, descriptions and tags that Create rejects `[×2]`
+
+**Confidence: confirmed.** A verifier reproduced all four cases through the real filter and action.
+
+**Where:** [EditSubnetViewModel.cs:37-51](../src/Bastet/Models/ViewModels/EditSubnetViewModel.cs#L37-L51)
+against [SubnetViewModels.cs:8-14](../src/Bastet/Models/ViewModels/SubnetViewModels.cs#L8-L14),
+[:27-31](../src/Bastet/Models/ViewModels/SubnetViewModels.cs#L27-L31),
+[:36-40](../src/Bastet/Models/ViewModels/SubnetViewModels.cs#L36-L40).
+Also [InputSanitizationService.cs:207-210](../src/Bastet/Services/Security/InputSanitizationService.cs#L207-L210),
+[GlobalSanitizationFilter.cs:19-32](../src/Bastet/Filters/GlobalSanitizationFilter.cs#L19-L32),
+[SubnetController.Edit.cs:141-143](../src/Bastet/Controllers/SubnetController.Edit.cs#L141-L143).
+
+`CreateSubnetViewModel` carries `[NoHtml]`, `[SafeText]` and `[Tags(MaxTags = 10, MaxTagLength = 50)]`.
+`EditSubnetViewModel` carries none of them — only the `[Sanitize*]` markers. `GlobalSanitizationFilter`
+runs **after** model binding and validation, so on Edit the sanitizer silently rewrites values that
+validation already accepted, instead of the form refusing them.
+
+**Failure scenarios**, all reproduced against the real `GlobalSanitizationFilter` + real Edit action:
+
+| Posted to /Subnet/Edit | Stored | Create's response to the same input |
+|---|---|---|
+| `Name = "<b></b>"` | `Name = ""` — an **empty required field** | "HTML tags are not allowed in subnet names" |
+| a single 60-char tag | `Tags = ""` — dropped entirely | "Each tag must be 50 characters or less" |
+| 11 tags | first 10 only | "Maximum 10 tags allowed" |
+| `Description = "temp < 5 and load > 3"` | `"temp  3"` | "HTML tags are not allowed in descriptions" |
+
+Each redirects with "Subnet '…' was updated successfully." The empty-name case is the load-bearing one:
+`[Required]` passes on the submitted value, then `StripHtml` empties it, and EF does not re-run
+DataAnnotations on `SaveChanges`, so `''` is persisted into a `NOT NULL` column and the tree renders a
+nameless row.
+
+**Fix.** Add `[NoHtml]` to `Name` and `Description`, and
+`[Bastet.Services.Security.Tags(MaxTags = 10, MaxTagLength = 50)]` to `Tags`. The user then gets a field
+error instead of silent loss, and `[Required]` on `Name` becomes load-bearing again.
+
+**Do not add `[SafeText]` to `Name` without checking existing data first.** Bulk Azure import passes
+names through `SanitizeName` only, never `IsSafeText`
+([AzureBulkImportPlanner.cs:663-671](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L663-L671)),
+so rows containing characters `SafeText` forbids can already exist and would become uneditable until
+renamed. The three attributes above close all four reported cases with no migration hazard.
+
+This is the mirror image of D7: the round-4 watch list flags sanitizers that *lengthen* a value; this is
+the same ordering hazard for sanitizers that *remove* content.
+
+## E3. A CIDR decrease from /31 or /32 strands a host IP on the new network address `[×1]`
+
+**Confidence: confirmed.** Reproduced by a verifier driving the real controller and services.
+
+**Where:** [SubnetController.Edit.cs:121](../src/Bastet/Controllers/SubnetController.Edit.cs#L121)
+(`if (viewModel.Cidr > subnet.Cidr)`, with the justifying comment at
+[:136-137](../src/Bastet/Controllers/SubnetController.Edit.cs#L136-L137)),
+[HostIpValidationService.cs:316](../src/Bastet/Services/Validation/HostIpValidationService.cs#L316)
+(`if (newCidr > originalCidr)` — the second gate),
+[HostIpValidationService.cs:70](../src/Bastet/Services/Validation/HostIpValidationService.cs#L70)
+(`if (subnet.Cidr < 31)` — what permits the assignment in the first place).
+
+The comment says a CIDR decrease needs no host-IP validation "since making a subnet larger cannot cause
+host IPs to fall outside its range". That is true about the *range* and false about *reservation*.
+
+**Failure scenario.** Parent `10.0.0.0/24`, child `10.0.0.0/31`. Assign host IP `10.0.0.0` — accepted,
+correctly, because RFC 3021 exempts /31 from the network/broadcast reservation. Now edit the child to
+`/30`. Host-IP validation is skipped entirely on both gates. Result:
+
+```
+PERSISTED: 10.0.0.0/30 with host IPs: 10.0.0.0
+ValidateNewHostIp('10.0.0.0', subnet) valid=False :: NETWORK_ADDRESS_RESERVED
+unallocated row: 10.0.0.1 - 10.0.0.2 count=2
+```
+
+The row now in the database is one the validated create path refuses — delete it and it cannot be
+re-created. The Details page simultaneously lists `10.0.0.0` as assigned and shows 2 free addresses, so
+it accounts for 3 addresses in a subnet whose `UsableIpAddresses` is 2. Same from `/32` → `/24`.
+
+**Fix.** Change the controller gate to `if (viewModel.Cidr != subnet.Cidr)` **and** add a decrease arm
+to `ValidateSubnetCidrChangeWithHostIps`: when `newCidr < originalCidr && newCidr < 31`, reject any
+assignment whose IP equals the network address. Both halves are required — the service's own
+`newCidr > originalCidr` gate at :316 means relaxing the controller alone changes nothing.
+
+Only the network address needs checking on a decrease: widening leaves it fixed and moves the broadcast
+strictly upward past every address the old range held, which is why only a /31 or /32 origin collides.
+
+This is the mirror image of D4, the broadcast-side defect at the same call site, which round 4 filed
+medium and fixed.
+
+---
+
+# Low
+
+## E4. Every transaction catch block rolls back before logging, destroying the original exception `[×2]`
+
+**Confidence: confirmed.** Proven against a real SQL Server 2022 with the pinned driver versions.
+
+**Where — five identical sites:**
+[SubnetController.Delete.cs:152-153](../src/Bastet/Controllers/SubnetController.Delete.cs#L152-L153),
+[SubnetController.Azure.cs:383-384](../src/Bastet/Controllers/SubnetController.Azure.cs#L383-L384),
+[SubnetController.BulkAzure.cs:292-293](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L292-L293),
+[SubnetController.AzureReconcile.cs:160-161](../src/Bastet/Controllers/SubnetController.AzureReconcile.cs#L160-L161),
+[HostIpController.cs:425-426](../src/Bastet/Controllers/HostIpController.cs#L425-L426).
+
+Every one is `await transaction.RollbackAsync();` followed by `logger.LogError(ex, …)`.
+
+**Failure scenario.** A bulk Azure import of 40 subnets; the writes succeed and the connection drops
+during `CommitAsync()`. Measured against real SQL Server (session killed from a second connection):
+
+```
+commit after KILL          -> SqlException: transport-level error
+rollback after that commit -> InvalidOperationException: This SqlTransaction has completed; it is no longer usable.
+rollback after a SUCCESSFUL commit -> InvalidOperationException (same)
+DisposeAsync after the failed rollback -> no exception
+```
+
+The `InvalidOperationException` replaces the `SqlException` *before* the next line runs, so the
+controller's contextual message ("Bulk Azure import commit failed") is never written and the intended
+`500 {"success":false,…}` JSON never returned — the AJAX wizard receives the HTML `/Error` page instead.
+
+**Scope, corrected from the finder's claim:** the underlying fault is *not* invisible. EF Core still
+logs `Database.Transaction[20205]` at Error with the exception attached, and `ExceptionHandlerMiddleware`
+logs the escaping one. What is lost is the controller's context and correlation, plus the intended
+response shape. That is why this is low, not medium: no data-integrity consequence — SQL Server rolls
+back server-side regardless — and the trigger is an infrastructure fault in a narrow window.
+
+**Fix.** The rule D12 already applied to the migration-lock release, applied here:
+
+```csharp
+catch (Exception ex)
+{
+    logger.LogError(ex, "…");
+    try { await transaction.RollbackAsync(); }
+    catch (Exception rollbackEx) { logger.LogError(rollbackEx, "Rollback failed after the error above"); }
+    return …;
+}
+```
+
+The `using` declaration already disposes (and rolls back) any transaction still live, so swallowing the
+explicit rollback strands nothing — confirmed by the `DisposeAsync` probe above.
+
+**Cheaper interim:** move the existing `logger.LogError(ex, …)` above the rollback at all five sites.
+
+## E5. Subnet Edit POST returns 500 on an out-of-range CIDR instead of redisplaying the form `[×2]`
+
+**Confidence: confirmed.** Reproduced against the real action for 33, 99, −1 and `int.MaxValue`.
+
+**Where:** [SubnetController.Edit.cs:235-238](../src/Bastet/Controllers/SubnetController.Edit.cs#L235-L238),
+which sits **after** the try/catch that closes at :215.
+[IpUtilityService.cs:16-19](../src/Bastet/Services/IpUtilityService.cs#L16-L19) is the throw;
+[EditSubnetViewModel.cs:26](../src/Bastet/Models/ViewModels/EditSubnetViewModel.cs#L26) is the `[Range(0,32)]`.
+
+`[Range]` makes `ModelState` invalid, which skips the guarded block entirely — and then makes
+`!ModelState.IsValid` true at :235, calling `CalculateSubnetMask(99)` outside any try.
+`ArgumentOutOfRangeException` escapes to `UseExceptionHandler`, so the operator gets a 500 instead of
+the form carrying the "CIDR must be between 0 and 32" message the model already produced.
+
+Reachability is narrow and worth stating plainly: `asp-for` on an int emits `type="number"` with
+`min`/`max` ([_EditForm.cshtml:20](../src/Bastet/Views/Subnet/Edit/_EditForm.cshtml#L20)), so native
+HTML5 constraint validation blocks a normal browser even with JS off. The vector is curl or devtools
+with a valid antiforgery token, by an already-authenticated Edit-role user — the same bar D8 was
+accepted under. Values that fail binding outright leave `Cidr == 0`, which is handled fine.
+
+**Fix.** Mirror D8's guard, which was scoped to the Create GET and never applied here:
+`bool hasUsableCidr = viewModel.Cidr is >= 0 and <= 32;` and compute `SubnetMask` only when it holds.
+Do not clamp — the posted `Cidr` is redisplayed and clamping would rewrite what the operator typed.
+`SubnetMask` is display-only on the error re-render, so nothing else depends on it.
+
+## E6. Concurrency-conflict handler displays a Last Modified time that was never saved `[×2]`
+
+**Confidence: confirmed.** The EF behaviour was measured, not assumed.
+
+**Where:** [SubnetController.Edit.cs:179-181](../src/Bastet/Controllers/SubnetController.Edit.cs#L179-L181)
+(the re-query under the comment "reload current data"),
+[:190](../src/Bastet/Controllers/SubnetController.Edit.cs#L190),
+[:218](../src/Bastet/Controllers/SubnetController.Edit.cs#L218) and
+[:247](../src/Bastet/Controllers/SubnetController.Edit.cs#L247) (the fall-through repopulation, which
+runs last and is what reaches the view),
+[_NetworkInformation.cshtml:24-27](../src/Bastet/Views/Subnet/Edit/_NetworkInformation.cshtml#L24-L27).
+
+The re-query is a **tracking** query on a context where the entity is still tracked in `Modified` state,
+so EF returns that same instance and discards the row it read. Measured on EF Core 10.0.10: the tracking
+re-query returned `ReferenceEquals == True` with the in-memory values, while `AsNoTracking()` on the same
+context returned the real row.
+
+**Failure scenario.** Subnet 5 last modified 10:05 by user B. User A submits a stale edit at 10:10;
+`subnet.LastModifiedAt` is set to 10:10 before the save, which then throws
+`DbUpdateConcurrencyException`. The page renders "Last Modified 1/1/2026 10:10 AM" directly above the
+banner "This subnet was modified by another user… review the current values before saving." The one
+current value on the screen is user A's own rejected attempt.
+
+**Bounded, deliberately:** `RowVersion` is *not* corrupted — line 72 loads the fresh row inside the lock,
+so only `OriginalValues` was rewound. Concurrency control and the retry work correctly; this is
+display-only. The view renders no username, so only the timestamp is wrong.
+
+**Fix.** `await context.Entry(subnet).ReloadAsync()` in the handler, or read the display fields with
+`.AsNoTracking()`. **The fall-through query at :218 needs the same treatment** — it runs last, so fixing
+:179 alone changes nothing on screen. Cheapest correct option: read from
+`ex.Entries[0].GetDatabaseValues()`, which EF already fetched for the failed UPDATE.
+
+## E7. Every leaf subnet's toggle becomes an inert "+" expander after any tree interaction `[×2]`
+
+**Confidence: confirmed.**
+
+**Where:** [site.js:33-42](../src/Bastet/wwwroot/js/site.js#L33-L42) (`updateToggleIcons`, no leaf test)
+against [site.js:43-54](../src/Bastet/wwwroot/js/site.js#L43-L54) (the startup loop, which has one).
+[_SubnetTreeItem.cshtml:32](../src/Bastet/Views/Shared/_SubnetTreeItem.cshtml#L32) emits
+`.subnet-children` only when `ChildSubnets.Any()`.
+
+Two disagreeing definitions of "leaf". The startup loop gives a childless subnet a flat `bi-dash`,
+`cursor: default`, and unbinds its click handler. `updateToggleIcons` then iterates **all** toggles; for
+a leaf, `children('.subnet-children')` is an empty set and `.is(':visible')` is false on an empty
+collection, so the else branch repaints it as `bi-plus-square`.
+
+**Failure scenario.** Load /Subnet, click Expand All (or Collapse All, or any parent toggle). Every leaf
+now advertises collapsed children it does not have, and clicking does nothing — the handler was already
+removed. The startup loop never re-runs, so only a page reload restores the dash.
+
+Softening detail: the inline `cursor: default` survives the `.html()` rewrite, so the misleading
+affordance is the icon only, not the cursor.
+
+**Fix.** Give `updateToggleIcons` the same emptiness test: inside the `.each`, early-return when
+`$children.children().length === 0`. One rule for what a leaf looks like instead of two that disagree.
+
+## E8. The Create form calls `/api/subnets/calculate-mask`, a route that has never existed `[×1]`
+
+**Confidence: confirmed.** Found twice in pass 1 (UI and dead-code beats), by neither beat in pass 2 —
+so treat the absence as weak, per the tagging rule.
+
+**Where:** [_SubnetFormScripts.cshtml:46](../src/Bastet/Views/Subnet/Create/_SubnetFormScripts.cshtml#L46).
+
+A repo-wide grep for `calculate-mask` returns exactly one line: this one. There is no `Api` controller
+and the only `[Route]` attributes in the tree are `ErrorController.cs:16` and `:61`. So the request
+404s, is re-executed through `UseStatusCodePagesWithReExecute("/Error/{0}")` — registered in both the
+dev and non-dev branches — and renders a full server-side Razor error page that jQuery then discards,
+because a 404 sends it to `.fail()`, which computes the mask locally anyway.
+
+**Failure scenario.** Every keystroke in the CIDR field costs a wasted round-trip plus a discarded
+multi-KB error render. And because `CreateSubnetViewModel.Cidr` is a non-nullable int, `asp-for` renders
+`value="0"` and `initializeForm()` fires one on **every** page load before the user types anything.
+
+The success callback at line 47 is unreachable code that has never executed.
+
+**Fix.** Delete the `$.get`/`.fail` wrapper and call the local helper directly:
+`$('#subnetMaskDisplay').text(calculateSubnetMask(cidrValue));`. It is already the fallback, already
+covers /0 through /32, and being synchronous removes the ordering hazard between concurrent responses.
+
+## E9. `BatchCreateChildSubnets` discards every selected child when an encompassing entry is present `[×2]`
+
+**Confidence: confirmed.** An existing passing test asserts the buggy outcome.
+
+**Where:** [SubnetController.Azure.cs:322](../src/Bastet/Controllers/SubnetController.Azure.cs#L322)
+(`if (!hasFullyEncompassingSubnet)` — skips the creation loop wholesale),
+[:181](../src/Bastet/Controllers/SubnetController.Azure.cs#L181) (D9's guard, which does not check the
+count), [:366](../src/Bastet/Controllers/SubnetController.Azure.cs#L366) (the unconditional success
+message).
+
+**Failure scenario.** POST with `parentId=1`, `isAzureImport=true`, `vnetName="prod-vnet"` and three
+entries: one `FullyEncompassesVNetPrefix=true` covering `10.0.0.0/24`, plus `web 10.0.0.0/25` and
+`app 10.0.0.128/25`. D9's guard passes, both /25s validate, and then the creation loop is skipped
+entirely. Result: parent renamed and marked `IsFullyAllocated=true`, two submitted subnets never
+created, and "Successfully renamed parent subnet… and marked it as fully allocated." Because
+`ValidateSubnetCreation` refuses children under a fully-allocated parent, they can never be added later
+without an operator clearing the flag by hand.
+
+`SubnetControllerFullyEncompassingTests.cs:311` asserts exactly this, including
+`Assert.Equal(0, childSubnetCount)` — a test pinning the defect.
+
+**Severity, corrected down from the finder's medium** to match where its twin D22 was filed: the
+selection cannot arise from real Azure or the wizard. `GetCompatibleSubnets` sets the flag only when the
+prefix equals a VNet prefix *and* matches the chosen parent, and Azure forbids overlapping subnets
+within a VNet, so the two cannot coexist in one result list. The trigger is a crafted or corrupted POST
+from an authenticated admin behind antiforgery — D22's reachability exactly.
+
+**Fix.** Extend the D9 guard at :181 with a count clause and reject the combination outright, mirroring
+the planner's wording. **Do not** instead hoist the creation loop above the fully-allocated write — that
+would produce a parent that is both fully allocated and has children, a state
+`ValidateSubnetCanBeFullyAllocated` and `SetAllocationStatus` both forbid.
+
+## E10. The reconcile 409's `warnings` payload is never rendered `[×2]` — **verifier split**
+
+**Confidence: confirmed as to mechanism; contested as to harm.** This is the most interesting
+disagreement in the round and is recorded rather than resolved.
+
+**Where:** [_ReconcileScripts.cshtml:407-419](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L407-L419)
+(`showCommitError` reads only `payload.error` and `payload.globalErrors`),
+[SubnetController.AzureReconcile.cs:78-87](../src/Bastet/Controllers/SubnetController.AzureReconcile.cs#L78-L87)
+(the Conflict body, `warnings = plan.Warnings` at :86).
+
+The mechanism is not in dispute and was verified by every agent that looked: the 409 carries no
+`globalErrors` key, so the list renders empty and both `warnings` **and** `subnetIds` are parsed and
+thrown away. D3's struck paragraph claims "plan.Warnings now rides along in that Conflict response" —
+it does, and nothing reads it.
+
+**Five finders reported it; three verifiers confirmed it and three refuted it.** The refutation:
+`ReconcileScan` runs the same `ConfirmProposedDeletionsAsync`, so re-running the scan — which the 409's
+own message explicitly instructs — regenerates the identical text into `#rec-scan-warnings`. The
+explanation is deferred by one click along the route the error prescribes, not lost. The confirmation:
+that argument holds for a persistent RBAC loss but not for a transient throttle, where the explanation
+is lost outright, and the operator meanwhile sees a message pointing at a stale browser view.
+
+I have kept it because the mechanism is real and the fix is two lines; reconciliation may reasonably
+decide the deferred path is good enough and close it as won't-fix.
+
+**Fix.** In `showCommitError`, after the `globalErrors` loop:
+`(payload.warnings || []).forEach(function (w) { list.append($("<li></li>").text(w)); });`.
+They share `#rec-commit-error-list`, so no markup change is needed. Note `subnetIds` is likewise unread,
+so the operator is not told *which* rows were withheld either.
+
+## E11. The green "nothing to clean up" banner shows even when rows were withheld `[×1]`
+
+**Confidence: confirmed.**
+
+**Where:** [_ReconcileScripts.cshtml:247-248](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L247-L248)
+— both toggles key on `items.length` alone.
+[_StepReview.cshtml:30-33](../src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml#L30-L33) is the banner.
+
+**Failure scenario.** The credential loses access to a resource group. Every affected row is withheld,
+so `items` is empty and the success banner renders — directly beneath the yellow warning saying rows
+were withheld because Azure would not confirm their state. The page asserts as fact
+("Everything imported from this subscription still exists in Azure") the very thing Bastet just recorded
+it could not establish. It also renders beneath E1's factually wrong warning.
+
+**Fix.** Gate on there being nothing to report at all, not nothing deletable. `warnings` is already in
+scope at :219; `reviewItems` is declared at :250 and must be hoisted above the toggle if included:
+`items.length > 0 || warnings.length > 0 || reviewItems.length > 0`. Better: when `items` is empty but
+something was reported, render a neutral "Nothing can be offered for deletion from this scan" so the
+page never claims a clean bill it did not earn.
+
+## E12. Collapsing a subtree leaves the toggle showing the expanded icon `[×1]`
+
+**Confidence: confirmed.**
+
+**Where:** [site.js:12](../src/Bastet/wwwroot/js/site.js#L12) (`slideToggle(200)`) and
+[site.js:15](../src/Bastet/wwwroot/js/site.js#L15) (`updateToggleIcons()` on the next line);
+same shape at [site.js:28-29](../src/Bastet/wwwroot/js/site.js#L28-L29) for Collapse All.
+
+jQuery applies `display: none` for a *hide* in the animation's completion callback, but sets `display`
+up front for a *show*. So the icon update on the next synchronous line reads the pre-animation state:
+on collapse, `:visible` is still true and the glyph is rewritten to minus. 200 ms later the children are
+gone and the icon still reads "expanded". Nothing revisits it, so after the first collapse the plus
+glyph is unreachable for that node. Expanding hides the bug because `slideDown` sets display first.
+
+**Fix.** Prefer computing the target state *before* animating and setting the glyph from that boolean.
+Passing `updateToggleIcons` as the `slideToggle` completion callback works for the toggle handler, but
+for `#collapse-all` it is not sufficient on its own: line 27's synchronous `.show()` can change state,
+and when the tree has no second-level `.subnet-children` the animated selector matches nothing and the
+callback never fires — so keep the bare call there in addition.
+
+## E13. The Details page's Create-Subnet modal reports "0 IP addresses" for /31 and /32 `[×1]`
+
+**Confidence: confirmed.**
+
+**Where:** [_SubnetCalculationScripts.cshtml:150-154](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L150-L154)
+— `const usableSize = size > 2 ? size - 2 : 0;`.
+The correct sibling implementation is
+[Create/_SubnetFormScripts.cshtml:28-38](../src/Bastet/Views/Subnet/Create/_SubnetFormScripts.cshtml#L28-L38),
+and the server's is [IpUtilityService.cs:98-113](../src/Bastet/Services/IpUtilityService.cs#L98-L113);
+both special-case RFC 3021.
+
+**Failure scenario.** On a `/30` with no children, `findOptimalCidr` returns 31 and writes it into the
+modal, which then displays "Resulting subnet size: 0 IP addresses" with the Create button enabled.
+Typing 32 gives the same. The server says 2 and 1 respectively — round 4's D4 turns on exactly that —
+and the very next page shows "Usable IPs: 2" for the same /31 the modal just called 0.
+
+The wider trigger is not the /30 edge case but any parent with CIDR ≤ 30 where the operator types 31 or
+32, which is reachable from every Details page with an unallocated range.
+
+**Fix.** Add the same special case: `const usableSize = cidr >= 31 ? (cidr === 31 ? 2 : 1) : Math.max(0, size - 2);`.
+This is the third copy of this calculation; lifting one shared implementation into `site.js` would stop
+a fourth from drifting, but the load-bearing change is the special case alone.
+
+## E14. The reconcile confirmation screen overstates the blast radius `[×1]`
+
+**Confidence: confirmed.**
+
+**Where:** [_ReconcileScripts.cshtml:306](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L306)
+(`$("#rec-confirm-count").text(chosen.length);`) and the cascade block at :310-333.
+
+**Failure scenario.** Target "prod-vnet" (id 10, a VNet resource ID, one descendant) with imported child
+"prod-web" (id 11). When the VNet is deleted in Azure, `BuildPlan` emits **both** rows — id 10 as
+`VNetDeleted`, id 11 as `SubnetDeleted` — and `renderPlan` gives each an independent checkbox. Select
+all, and the confirmation reads "You are about to delete **2** subnet(s)…" followed by "This **also**
+archives **1** child subnet(s)…". The word "also" is false: that 1 child *is* one of the 2, so the
+screen announces 3 subnets where only 2 exist. The server then reports "deleted **1** stale subnet(s),
+archiving 2 subnet(s)" — so the operator is told 2 targets before confirming and 1 afterwards. On a
+real VNet import with a dozen children it is a dozen-way discrepancy, on a destructive confirmation.
+
+The defect is one-sided: `covered` correctly suppresses the child as a cascade *contributor*, while
+`chosen.length` and `#rec-confirm-list` still count it as a delete *target*.
+
+**Fix.** Report what the server will actually do: compute top-level targets as
+`chosen.filter(i => !covered[i.subnetId])` and use that length for the count and the list, still posting
+the full `confirmedIds` (the server dedupes by subtree anyway). The existing cascade sum then genuinely
+is "also".
+
+---
+
+# Refuted — reported by a finder, killed by the verifier
+
+18 of 45 verified findings were killed (40%). Recorded so round 6 does not rediscover them.
+
+| Finding | Why it was killed |
+|---|---|
+| D10's three tests mock away the only file the fix changed (×2, both passes) | Facts accurate, no runtime defect. HEAD behaves correctly; the scenario is hypothetical future regression — the "could drift while currently agreeing" category. All three callers already catch and return `success=false`, so the new `throw;` cannot escape as a 500. |
+| D3's scan-path confirmation call is unpinned by any test (×2, both passes) | Citation and coverage gap both real, but no wrong output from real code. Traced end to end: the RBAC-filtered scan produces the *correct* result at HEAD. The scenario only becomes wrong after the auditor edits the source. Test-coverage gap, not a defect. |
+| `AzureResourceIdentity.ToPortalPath` ships with no test | Names inputs and the **correct** output. The finder's own input makes `IsAzureSubnet` return false, so the ID is returned unchanged and the link is right. The broken URL existed only in the scratch tree the finder edited. |
+| `AzureServiceTests` asserts on `MockAzureService`, whose compatibility rule contradicts the real service | Divergence is real but lives entirely inside test code. No test asserts an application outcome that depends on it, and nothing in `src/` references the mock. |
+| `AzureBulkImportPlanner.TruncateForName` is orphaned by D19 (×2, both passes) | Every fact verified — genuinely dead, orphaned by `bf120d6`. Dies on reachability: with zero call sites no input can reach it and no wrong output can leave it. Unused-but-harmless member. |
+| `IsFeatureEnabled` on two view models is write-only (×2, both passes) | Exhaustively verified as never read. Write-only, always-true, no runtime effect; the finder's own scenario concedes "the rendered pages are byte-identical". |
+| `IInputSanitizationService.SanitizeString` and its private support chain have no caller | Genuinely dead — which is what kills it. No input a user of the shipped app can supply reaches it. |
+| `SubnetTreeViewModel.ParentSubnetId` is set on every node and never read | Verified write-only. Unused-but-harmless member with no wrong output. |
+| `BulkImportPlanItem.Warnings` has no writer, making a JS block unreachable | The guard simply evaluates false, skipping nothing that should have shown. Hard errors render correctly via the block above it. |
+| `AzureReconcileItem.IsVNetLevel` is written and never read | Worst case its own scenario names is one extra `true` in a JSON row the browser discards. |
+| The stale `/subnets/` doc comment on `AzureLinkedSubnetSnapshot` contradicts D2 | Comment really is stale, but no production code performs the substring test — the only two occurrences are doc comments. The claimed outcome is unreachable and describes pre-fix code. |
+| Reconcile 409 drops `warnings` (×3 — see **E10**) | Killed by three verifiers on harm, not mechanism: re-running the scan, which the error message instructs, renders the identical text. Kept as E10 because three other verifiers confirmed it; the split is recorded there. |
+
+The pattern is consistent with round 4: what dies is **test-coverage observations and unused-but-harmless
+members**. Nine of the eighteen are one or the other. The dead-code beat produced almost nothing that
+survived — a strong signal that round 4's deletion pass was thorough.
+
+# Watch list — not findings, but worth knowing
+
+Carried forward from round 4, all re-checked and still accepted:
+
+- **ForwardedHeaders trust-all with `AllowedHosts: "*"`**; the Development-only `DevAuthHandler` bypass;
+  `GlobalSanitizationFilter` skipping nested `System.*` collections; `CollectDescendants` lacking a
+  cycle guard; the unreachable IP-change branch in `ValidateHostIpUpdate`; the blind `catch {}` around
+  the DataProtectionKeys probe; **C20** (the Azure reconcile check/act window).
+- **`GlobalSanitizationFilter` runs after model binding and validation.** Round 4 flagged this for
+  sanitizers that *lengthen* a value (D7). **E2 is the same hazard in the removing direction** — this is
+  now a demonstrated defect class, not a theoretical one, and any new `[Sanitize*]` attribute needs a
+  matching validator.
+- **`MockAzureService.DefaultConfirmation` is `Deleted`.** This single default is why no test caught E1.
+  Any test touching the confirmation path must set the verdict explicitly.
+- **Still no `WebApplicationFactory` or integration host, and still no JS test harness.** E7, E8, E11,
+  E12, E13 and E14 are all client-side and none can be pinned by an automated test today.
+- **The usable-IP calculation now exists in three places** (server, Create script, Details modal). E13 is
+  the copy that drifted.
+- **Migration `.Designer.cs` snapshots still contain old column widths.** Correct and frozen — do not
+  "fix" them.
+
+New this round:
+
+- **A real Azure tenant ID is committed in the repository.**
+  [launchSettings.json:41](../src/Bastet/Properties/launchSettings.json#L41) carries
+  `BASTET_OIDC_AUTHORITY` pointing at a specific tenant GUID, landed in `aedd0bd` (#133). Not a
+  credential — tenant IDs are discoverable from any domain's OIDC metadata — and it produces no wrong
+  output, which is why it is here and not in the findings. But it ties a public repository to a
+  specific tenant, and launch profiles are developer convenience rather than shipped configuration.
+  Replacing it with a placeholder (or `common`) costs nothing.
+
+# Clean bill
+
+Swept across both passes and produced nothing:
+
+- **Authorization coverage.** Every public action across all controllers enumerated against the fallback
+  policy (`SetFallbackPolicy(RequireAuthenticatedUser)`), so a forgotten attribute fails closed. The four
+  `[AllowAnonymous]` actions each have a reason that holds. No missing or wrong policy.
+- **Antiforgery.** Every `[HttpPost]` carries `[ValidateAntiForgeryToken]`, verified by grepping the
+  attribute against the verb attribute rather than assuming. All three AJAX wizards post the token via
+  the configured header and render `@Html.AntiForgeryToken()`. No state-changing GET.
+- **XSS — swept deeper than round 4.** Every `.html()` call site in the three wizard scripts and
+  `site.js` was read: all server- or Azure-derived text goes through the local `escapeHtml`, and the
+  unescaped interpolations are server ints or fixed literals from a `switch`. Specifically checked the
+  two encoding-insufficient sinks — inline `on*=` handlers containing Razor (none anywhere) and Razor
+  inside `<script>` (two sites, both safe).
+- **SQL injection / command injection.** The only raw SQL remains the parameterised
+  `sp_getapplock`/`sp_releaseapplock` calls. No `FromSqlRaw`, no `Process.Start`, no `HttpClient`.
+- **SSRF.** The only outbound calls are ARM SDK calls; no host or scheme is caller-controlled.
+- **Open redirect.** The one input-derived redirect target is guarded by `Url.IsLocalUrl`; the AJAX
+  `redirectUrl` values are `Url.Action`-generated.
+- **Security response headers.** D11's fix is intact, correctly placed below both error handlers and
+  above `UseStaticFiles`. `BASTET_FRAME_ANCESTORS` is validated at startup through `HttpHeaderValue`,
+  which correctly mirrors Kestrel's rule.
+- **The Azure deletion path under real RBAC partial visibility — proven live, both directions.** With
+  disjoint credentials, `BuildPlan` proposed all 10 (and symmetrically 3) imported rows for archival;
+  D3's direct-read guard withheld every one. ARM returns **403** for cross-RG resources at both VNet and
+  subnet level, while genuinely absent resources return **404** (`ResourceNotFound` for VNets,
+  `NotFound` for subnets) — exactly as `ConfirmOneAsync`'s comment claims. Nothing live was ever offered
+  for deletion.
+- **`GetVNetInventory` fails closed — proven live.** An authentication failure returns `Success=false`
+  with an error, not an empty list, so the reconciler cannot mistake "could not ask" for "nothing there".
+- **IPv6 handling of the inventory — proven live.** A VNet whose only address space is
+  `fd00:1234:5678::/48` is filtered out of the inventory entirely, honouring the documented IPv4-only
+  contract.
+- **The 43 round-4 fixes, reviewed as atomic commits.** Each diffed against its struck paragraph. The
+  five that deviated from their finding's recommendation (D7, D22, D24, D29, D41) each do what their
+  paragraph says they do. E1 is the only regression found; every other fix holds.
+- **Test quality of the ~45 tests added by PR #141.** No assertion weakened to let a fix land, none
+  asserting behaviour a fix was meant to change. The 305 lines removed from `SubnetOperationTests.cs`
+  were traced: the coverage moved rather than vanished. (E9's test is a pre-existing test pinning a
+  pre-existing defect, not a weakened one.)
+- **Locking and lifecycle.** `sp_getapplock` session ownership under EF connection pooling,
+  release-on-every-path, command-timeout arithmetic, transaction boundaries and DI lifetimes all hold.
+  No captive dependencies. E4 is about diagnostics, not lock or transaction correctness.
+- **Dead code.** Round 4's deletion pass was thorough: everything this round's beats surfaced was
+  either already gone or an unused-but-harmless member that the verifiers correctly killed.
+
+---
+
+## Suggested order of attack
+
+1. **E1** — a documented, badge-rendered reconcile capability is silently and permanently dead, and the
+   operator is given a false explanation. Fix the status partition and add the `Live`-verdict test.
+2. **E2, E3** — both persist a state the validated path rejects. E2 defeats a `[Required]`.
+3. **E4, E5, E6** — diagnostics and error-path defects; E4 is five sites and one mechanical change.
+4. **E7–E14** — client-side and messaging. E11 pairs naturally with E1, and E10 may reasonably be closed
+   as won't-fix given the verifier split.

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -432,23 +432,36 @@ _Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 
 ## E12. Collapsing a subtree leaves the toggle showing the expanded icon `[×1]`
 
-**Confidence: confirmed.**
+_E12 is fixed and committed. The toggle handler now passes `updateToggleIcons` as `slideToggle`'s
+completion callback, so the icon is chosen from the settled state instead of the one being animated
+away._
 
-**Where:** [site.js:12](../src/Bastet/wwwroot/js/site.js#L12) (`slideToggle(200)`) and
-[site.js:15](../src/Bastet/wwwroot/js/site.js#L15) (`updateToggleIcons()` on the next line);
-same shape at [site.js:28-29](../src/Bastet/wwwroot/js/site.js#L28-L29) for Collapse All.
+_The verifier's correction was applied rather than the finder's original: for `#collapse-all` the
+bare `updateToggleIcons()` call is **kept in addition to** the callback. Replacing it would break a
+one-level tree, where the deeper-levels selector matches nothing, the callback never fires, and the
+first level would never be refreshed. `#expand-all` was left alone — `slideDown` sets `display` up
+front, so its existing bare call already reads the correct state._
 
-jQuery applies `display: none` for a *hide* in the animation's completion callback, but sets `display`
-up front for a *show*. So the icon update on the next synchronous line reads the pre-animation state:
-on collapse, `:visible` is still true and the glyph is rewritten to minus. 200 ms later the children are
-gone and the icon still reads "expanded". Nothing revisits it, so after the first collapse the plus
-glyph is unreachable for that node. Expanding hides the bug because `slideDown` sets display first.
+_Reproduced and then re-verified in a real browser with the pinned jQuery 4.0.0, using the same rig as
+E7:_
 
-**Fix.** Prefer computing the target state *before* animating and setting the glyph from that boolean.
-Passing `updateToggleIcons` as the `slideToggle` completion callback works for the toggle handler, but
-for `#collapse-all` it is not sufficient on its own: line 27's synchronous `.show()` can change state,
-and when the tree has no second-level `.subnet-children` the animated selector matches nothing and the
-callback never fires — so keep the bare call there in addition.
+```
+before:  children actually visible? False   parent icon: bi-dash-square   <- claims expanded
+after:   children actually visible? False   parent icon: bi-plus-square
+```
+
+_The round trip was checked too, since changing **when** the icon updates could easily break the
+other direction: re-expanding restores visible children and the minus icon, and Collapse All followed
+by Expand All leaves every parent on minus and every leaf on its flat dash. That last check also
+confirms E7's fix still holds through the animated paths._
+
+_As a `[×1]` the mechanism was confirmed directly rather than accepted: jQuery defers `display:none`
+for a hide into the animation's completion, which is why only the collapse direction was ever wrong
+and why the bug survived unnoticed — expanding happened to produce the right icon by accident._
+
+_Tests 603 → 603 (unchanged). Build clean, 0 warnings._
+
+---
 
 ## E13. The Details page's Create-Subnet modal reports "0 IP addresses" for /31 and /32 `[×1]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -109,47 +109,41 @@ _Tests 576 → 584 (+8). Build clean, 0 warnings._
 
 ## E2. Subnet Edit silently destroys names, descriptions and tags that Create rejects `[×2]`
 
-**Confidence: confirmed.** A verifier reproduced all four cases through the real filter and action.
+_E2 is fixed and committed. `EditSubnetViewModel` now carries `[NoHtml]` on `Name` and `Description`
+and `[Bastet.Services.Security.Tags(MaxTags = 10, MaxTagLength = 50)]` on `Tags`, matching the
+`CreateSubnetViewModel` rules for the same three columns. The form now refuses the input instead of
+accepting it and letting the sanitizer rewrite it afterwards, which restores `[Required]` on `Name`
+as a real constraint._
 
-**Where:** [EditSubnetViewModel.cs:37-51](../src/Bastet/Models/ViewModels/EditSubnetViewModel.cs#L37-L51)
-against [SubnetViewModels.cs:8-14](../src/Bastet/Models/ViewModels/SubnetViewModels.cs#L8-L14),
-[:27-31](../src/Bastet/Models/ViewModels/SubnetViewModels.cs#L27-L31),
-[:36-40](../src/Bastet/Models/ViewModels/SubnetViewModels.cs#L36-L40).
-Also [InputSanitizationService.cs:207-210](../src/Bastet/Services/Security/InputSanitizationService.cs#L207-L210),
-[GlobalSanitizationFilter.cs:19-32](../src/Bastet/Filters/GlobalSanitizationFilter.cs#L19-L32),
-[SubnetController.Edit.cs:141-143](../src/Bastet/Controllers/SubnetController.Edit.cs#L141-L143).
+_**`[SafeText]` was deliberately not added**, which is where this departs from simple parity with
+Create. The reason was checked rather than assumed: `[SafeText]` appears on exactly three properties
+in the tree — `CreateSubnetViewModel.Name` and the two HostIp models — and **no Azure import path
+applies it**. Imported names go through `SanitizeName` only, which strips markup and trims but does
+not enforce the `^[a-zA-Z0-9\s\-_.,!?@#$%&()+=]*$` character class. So a stored name outside that
+class is reachable, and adding `[SafeText]` to the edit model would make those rows uneditable until
+renamed — a migration hazard well beyond the four defects reported. The three attributes above close
+all four._
 
-`CreateSubnetViewModel` carries `[NoHtml]`, `[SafeText]` and `[Tags(MaxTags = 10, MaxTagLength = 50)]`.
-`EditSubnetViewModel` carries none of them — only the `[Sanitize*]` markers. `GlobalSanitizationFilter`
-runs **after** model binding and validation, so on Edit the sanitizer silently rewrites values that
-validation already accepted, instead of the form refusing them.
+_Six parity tests were written first, as a new `SubnetViewModelValidationParityTests`, asserting that
+Create and Edit refuse the same input. **The first version of them was wrong and passed for the wrong
+reason**, which is worth recording: `NoHtmlAttribute` and `TagsAttribute` both return a
+`ValidationResult` carrying **no member names**, so the helper's `MemberNames.Contains(...)` match
+never hit and the failures it produced were on the Create side, not the Edit side. Rewritten to
+validate one property at a time with `Validator.TryValidateProperty` and an explicit `MemberName`,
+which attributes the failure exactly. Both attributes also resolve `IInputSanitizationService` from
+the validation context, so the tests supply one — without it every rule fails with "Input
+sanitization service not available" and the whole suite would pass vacuously._
 
-**Failure scenarios**, all reproduced against the real `GlobalSanitizationFilter` + real Edit action:
+_Proven by reverting only `EditSubnetViewModel.cs` in a scratch copy and re-running: five failures,
+each reading `EditSubnetViewModel.<property> was accepted but should have been rejected`. Against the
+fix all six pass. The sixth is a guard against over-correcting — ordinary values, including a tag
+sitting exactly on the 50-character limit and exactly ten of them, must still be accepted by both
+models. It caught a bug in its own fixture first: ten 50-character tags exceed the 255-character
+`[StringLength]` that governs the field as a whole, which both models correctly reject._
 
-| Posted to /Subnet/Edit | Stored | Create's response to the same input |
-|---|---|---|
-| `Name = "<b></b>"` | `Name = ""` — an **empty required field** | "HTML tags are not allowed in subnet names" |
-| a single 60-char tag | `Tags = ""` — dropped entirely | "Each tag must be 50 characters or less" |
-| 11 tags | first 10 only | "Maximum 10 tags allowed" |
-| `Description = "temp < 5 and load > 3"` | `"temp  3"` | "HTML tags are not allowed in descriptions" |
+_Tests 584 → 590 (+6). Build clean, 0 warnings._
 
-Each redirects with "Subnet '…' was updated successfully." The empty-name case is the load-bearing one:
-`[Required]` passes on the submitted value, then `StripHtml` empties it, and EF does not re-run
-DataAnnotations on `SaveChanges`, so `''` is persisted into a `NOT NULL` column and the tree renders a
-nameless row.
-
-**Fix.** Add `[NoHtml]` to `Name` and `Description`, and
-`[Bastet.Services.Security.Tags(MaxTags = 10, MaxTagLength = 50)]` to `Tags`. The user then gets a field
-error instead of silent loss, and `[Required]` on `Name` becomes load-bearing again.
-
-**Do not add `[SafeText]` to `Name` without checking existing data first.** Bulk Azure import passes
-names through `SanitizeName` only, never `IsSafeText`
-([AzureBulkImportPlanner.cs:663-671](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L663-L671)),
-so rows containing characters `SafeText` forbids can already exist and would become uneditable until
-renamed. The three attributes above close all four reported cases with no migration hazard.
-
-This is the mirror image of D7: the round-4 watch list flags sanitizers that *lengthen* a value; this is
-the same ordering hazard for sanitizers that *remove* content.
+---
 
 ## E3. A CIDR decrease from /31 or /32 strands a host IP on the new network address `[×1]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -305,51 +305,33 @@ _Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 
 ## E7. Every leaf subnet's toggle becomes an inert "+" expander after any tree interaction `[×2]`
 
-**Confidence: confirmed.**
+_E7 is fixed and committed. `updateToggleIcons` now early-returns for a subnet with no children,
+using `$children.children().length === 0` — the same test the startup loop already applies, so there
+is one definition of "leaf" instead of two that disagree._
 
-**Where:** [site.js:33-42](../src/Bastet/wwwroot/js/site.js#L33-L42) (`updateToggleIcons`, no leaf test)
-against [site.js:43-54](../src/Bastet/wwwroot/js/site.js#L43-L54) (the startup loop, which has one).
-[_SubnetTreeItem.cshtml:32](../src/Bastet/Views/Shared/_SubnetTreeItem.cshtml#L32) emits
-`.subnet-children` only when `ChildSubnets.Any()`.
+_Reproduced in a real browser before fixing, not reasoned about. The rig loads the **actual
+`site.js`** read from the repo at run time, against **jQuery 4.0.0 from the same CDN URL
+`_Layout.cshtml` pins**, into a tree built from `_SubnetTreeItem.cshtml`'s shipped markup with only
+the Razor stripped. The version matters: the defect turns on `:visible` returning false for an empty
+jQuery set, which is a library behaviour, not something to take on trust from a different build._
 
-Two disagreeing definitions of "leaf". The startup loop gives a childless subnet a flat `bi-dash`,
-`cursor: default`, and unbinds its click handler. `updateToggleIcons` then iterates **all** toggles; for
-a leaf, `children('.subnet-children')` is an empty set and `.is(':visible')` is false on an empty
-collection, so the else branch repaints it as `bi-plus-square`.
+```
+--- after ready ---                --- after clicking Expand All ---
+  parent 'corp' : bi-dash-square     leaf 'web'  : bi-plus-square
+  leaf   'web'  : bi-dash            leaf 'solo' : bi-plus-square
+  leaf   'solo' : bi-dash
+```
 
-**Failure scenario.** Load /Subnet, click Expand All (or Collapse All, or any parent toggle). Every leaf
-now advertises collapsed children it does not have, and clicking does nothing — the handler was already
-removed. The startup loop never re-runs, so only a page reload restores the dash.
+_Both a nested leaf and a top-level childless subnet flip, confirming it is not specific to depth.
+Against the fix both stay `bi-dash` through Expand All, Collapse All and a parent toggle click._
 
-Softening detail: the inline `cursor: default` survives the `.html()` rewrite, so the misleading
-affordance is the icon only, not the cursor.
+_The finding's "cheaper interim" — marking leaves at startup with a class and excluding them by
+selector — was not taken. It keeps the two definitions of "leaf" and just adds a third mechanism to
+hold them together; the early return removes the disagreement outright._
 
-**Fix.** Give `updateToggleIcons` the same emptiness test: inside the `.each`, early-return when
-`$children.children().length === 0`. One rule for what a leaf looks like instead of two that disagree.
-
-## E8. The Create form calls `/api/subnets/calculate-mask`, a route that has never existed `[×1]`
-
-_E8 is fixed and committed. The `$.get(...).fail(...)` wrapper is deleted and `updateSubnetInfo` now
-calls the local `calculateSubnetMask(cidrValue)` directly — which is what the `.fail` handler already
-did on every single keystroke, since the request could never succeed._
-
-_**Taken out of numeric order, ahead of E7**, which is recorded here rather than left implicit: E7 is
-a client-side jQuery defect needing a browser rig, and this one needed nothing but a grep. E7 follows
-immediately._
-
-_Verified the route genuinely does not exist rather than trusting the finding: a repo-wide grep for
-`api/subnets` and `calculate-mask` across `.cs`, `.cshtml` and `.js` returned exactly one line — the
-call itself — and the only `[Route]` attributes in the entire application are `ErrorController`'s two.
-After the fix the only remaining mention anywhere is the comment explaining what used to be there._
-
-_No fallback behaviour is lost. The guard immediately above the call already constrains the value to
-0–32, so `calculateSubnetMask` is never handed anything it reports as invalid, and the server renders
-the initial value into the span independently. Being a `[×1]` this was re-derived rather than assumed;
-it was found twice within pass 1 (by both the UI and dead-code beats) and missed entirely by pass 2._
-
-_No test ships: there is no JS harness in the repo, and the change removes a network call rather than
-altering a computed value. The definitive check is the absence of a 404 for that URL when the Create
-page is exercised, which is folded into the closing sweep._
+_No test ships. There is no JS harness in the repo, and adding Playwright to the suite for one
+cosmetic defect is far beyond this finding's weight — the rig stayed in the scratchpad. Recorded here
+instead, which is what the watch list already anticipated for client-side findings._
 
 _Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -236,28 +236,31 @@ _Tests 596 → 599 (+3). Build clean, 0 warnings._
 
 ## E5. Subnet Edit POST returns 500 on an out-of-range CIDR instead of redisplaying the form `[×2]`
 
-**Confidence: confirmed.** Reproduced against the real action for 33, 99, −1 and `int.MaxValue`.
+_E5 is fixed and committed, mirroring D8's guard on the Create action — the one entry point D8's
+struck paragraph explicitly scoped itself to. A `hasUsableCidr` local now gates the mask calculation
+at the tail of the Edit POST, leaving `SubnetMask` empty when the posted CIDR is outside 0–32._
 
-**Where:** [SubnetController.Edit.cs:235-238](../src/Bastet/Controllers/SubnetController.Edit.cs#L235-L238),
-which sits **after** the try/catch that closes at :215.
-[IpUtilityService.cs:16-19](../src/Bastet/Services/IpUtilityService.cs#L16-L19) is the throw;
-[EditSubnetViewModel.cs:26](../src/Bastet/Models/ViewModels/EditSubnetViewModel.cs#L26) is the `[Range(0,32)]`.
+_The posted `Cidr` is **not** clamped, following the finding's own warning. It is redisplayed in the
+form, so rewriting it would silently change what the operator typed and hide the mistake the range
+message is about to explain. `SubnetMask` is display-only on an error re-render — nothing in the Edit
+views or the POST path reads it back — so leaving it empty costs nothing._
 
-`[Range]` makes `ModelState` invalid, which skips the guarded block entirely — and then makes
-`!ModelState.IsValid` true at :235, calling `CalculateSubnetMask(99)` outside any try.
-`ArgumentOutOfRangeException` escapes to `UseExceptionHandler`, so the operator gets a 500 instead of
-the form carrying the "CIDR must be between 0 and 32" message the model already produced.
+_Four tests written first, one per boundary (33, 99, −1 and `int.MaxValue`), all four failing against
+the unfixed action with `System.ArgumentOutOfRangeException : CIDR must be between 0 and 32
+(Parameter 'cidr')` — the defect itself. They assert the action returns a view with the `Cidr` error
+intact **and** that the posted value survives unclamped, so a future "fix" that clamps would fail
+them. Values that fail model binding outright leave `Cidr` at 0, which was always handled._
 
-Reachability is narrow and worth stating plainly: `asp-for` on an int emits `type="number"` with
-`min`/`max` ([_EditForm.cshtml:20](../src/Bastet/Views/Subnet/Edit/_EditForm.cshtml#L20)), so native
-HTML5 constraint validation blocks a normal browser even with JS off. The vector is curl or devtools
-with a valid antiforgery token, by an already-authenticated Edit-role user — the same bar D8 was
-accepted under. Values that fail binding outright leave `Cidr == 0`, which is handled fine.
+_Reachability is narrower than a casual reading suggests and is worth recording so it is not
+re-raised as more serious than it is: `asp-for` on an int emits `type="number"` with `min`/`max`, so
+a normal browser blocks the submit even with JavaScript disabled. The vector is a crafted POST by an
+already-authenticated Edit-role user holding a valid antiforgery token — the same bar D8 was accepted
+under — and the blast radius is a 500 on that caller's own request. The guarded block is skipped
+entirely, so no CIDR-change validation is bypassed and nothing is written._
 
-**Fix.** Mirror D8's guard, which was scoped to the Create GET and never applied here:
-`bool hasUsableCidr = viewModel.Cidr is >= 0 and <= 32;` and compute `SubnetMask` only when it holds.
-Do not clamp — the posted `Cidr` is redisplayed and clamping would rewrite what the operator typed.
-`SubnetMask` is display-only on the error re-render, so nothing else depends on it.
+_Tests 599 → 603 (+4). Build clean, 0 warnings._
+
+---
 
 ## E6. Concurrency-conflict handler displays a Last Modified time that was never saved `[×2]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -372,33 +372,31 @@ _Tests 603 → 603 (unchanged; one test rewritten, none added or removed). Build
 
 ## E10. The reconcile 409's `warnings` payload is never rendered `[×2]` — **verifier split**
 
-**Confidence: confirmed as to mechanism; contested as to harm.** This is the most interesting
-disagreement in the round and is recorded rather than resolved.
+_E10 is fixed and committed. `showCommitError` now renders `payload.warnings` into the same
+`#rec-commit-error-list` the `globalErrors` loop already fills, mirroring the line directly above it._
 
-**Where:** [_ReconcileScripts.cshtml:407-419](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L407-L419)
-(`showCommitError` reads only `payload.error` and `payload.globalErrors`),
-[SubnetController.AzureReconcile.cs:78-87](../src/Bastet/Controllers/SubnetController.AzureReconcile.cs#L78-L87)
-(the Conflict body, `warnings = plan.Warnings` at :86).
+_**The split was resolved in favour of fixing**, and the reasoning is recorded because the file left
+it open. Neither side disputed the mechanism: a grep of the 424-line script confirms `warnings` is
+read at lines 219–222 only, inside `renderPlan`, which runs for the scan response and never for a
+commit — so the 409's explanation was parsed and dropped. The refuters argued the harm is nil because
+re-running the scan, which the error message itself instructs, regenerates the identical text. That
+holds for a **persistent** cause such as a lost RBAC assignment. It does not hold for a **transient**
+one: an ARM throttle that has cleared by the time the operator re-scans produces a clean scan and no
+explanation at all, leaving them with a message that reads like a stale browser view. Against a
+two-line fix mirroring adjacent code, that residual case is worth closing._
 
-The mechanism is not in dispute and was verified by every agent that looked: the 409 carries no
-`globalErrors` key, so the list renders empty and both `warnings` **and** `subnetIds` are parsed and
-thrown away. D3's struck paragraph claims "plan.Warnings now rides along in that Conflict response" —
-it does, and nothing reads it.
+_No rig was used and none was warranted: the defect is the absence of a reader, which grep settles
+outright, and the fix is a copy of the loop above it against an element that already exists in
+`_StepConfirm.cshtml`. Recording that plainly rather than implying a browser run that did not happen._
 
-**Five finders reported it; three verifiers confirmed it and three refuted it.** The refutation:
-`ReconcileScan` runs the same `ConfirmProposedDeletionsAsync`, so re-running the scan — which the 409's
-own message explicitly instructs — regenerates the identical text into `#rec-scan-warnings`. The
-explanation is deferred by one click along the route the error prescribes, not lost. The confirmation:
-that argument holds for a persistent RBAC loss but not for a transient throttle, where the explanation
-is lost outright, and the operator meanwhile sees a message pointing at a stale browser view.
+_Left undone deliberately: `subnetIds` in the same 409 body is likewise never read, so the operator
+still is not told *which* rows were withheld by name in the error panel — though the warning text the
+fix now renders does name them. Adding a second unrendered field to the panel is a UI decision beyond
+this finding, and the warning covers the practical need._
 
-I have kept it because the mechanism is real and the fix is two lines; reconciliation may reasonably
-decide the deferred path is good enough and close it as won't-fix.
+_Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 
-**Fix.** In `showCommitError`, after the `globalErrors` loop:
-`(payload.warnings || []).forEach(function (w) { list.append($("<li></li>").text(w)); });`.
-They share `#rec-commit-error-list`, so no markup change is needed. Note `subnetIds` is likewise unread,
-so the operator is not told *which* rows were withheld either.
+---
 
 ## E11. The green "nothing to clean up" banner shows even when rows were withheld `[×1]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -191,53 +191,48 @@ _Tests 590 → 596 (+6). Build clean, 0 warnings._
 
 ## E4. Every transaction catch block rolls back before logging, destroying the original exception `[×2]`
 
-**Confidence: confirmed.** Proven against a real SQL Server 2022 with the pinned driver versions.
+_E4 is fixed and committed at all five sites. Each catch block now logs first and then calls a shared
+`TransactionCleanup.RollbackQuietlyAsync`, which rolls back and logs rather than throws if the
+rollback itself fails._
 
-**Where — five identical sites:**
-[SubnetController.Delete.cs:152-153](../src/Bastet/Controllers/SubnetController.Delete.cs#L152-L153),
-[SubnetController.Azure.cs:383-384](../src/Bastet/Controllers/SubnetController.Azure.cs#L383-L384),
-[SubnetController.BulkAzure.cs:292-293](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L292-L293),
-[SubnetController.AzureReconcile.cs:160-161](../src/Bastet/Controllers/SubnetController.AzureReconcile.cs#L160-L161),
-[HostIpController.cs:425-426](../src/Bastet/Controllers/HostIpController.cs#L425-L426).
-
-Every one is `await transaction.RollbackAsync();` followed by `logger.LogError(ex, …)`.
-
-**Failure scenario.** A bulk Azure import of 40 subnets; the writes succeed and the connection drops
-during `CommitAsync()`. Measured against real SQL Server (session killed from a second connection):
+_Reproduced independently against a real SQL Server 2022 container with the pinned
+Microsoft.Data.SqlClient 6.1.1, rather than trusting the audit's recorded measurement. Killing the
+session mid-transaction and then replaying the shipped catch-block order gives:_
 
 ```
-commit after KILL          -> SqlException: transport-level error
-rollback after that commit -> InvalidOperationException: This SqlTransaction has completed; it is no longer usable.
-rollback after a SUCCESSFUL commit -> InvalidOperationException (same)
-DisposeAsync after the failed rollback -> no exception
+A1 commit threw   -> SqlException: A transport-level error has occurred when receiving results from the server.
+A2 rollback threw -> InvalidOperationException: This SqlTransaction has completed; it is no longer usable.
+   => the logger.LogError(ex, ...) on the NEXT line never runs.
+B  rollback after successful commit threw -> InvalidOperationException: This SqlTransaction has completed.
+C1 write threw    -> SqlException: Conversion failed when converting the varchar value ...
+C2 rollback: succeeded - so the common case is NOT affected by the fix
 ```
 
-The `InvalidOperationException` replaces the `SqlException` *before* the next line runs, so the
-controller's contextual message ("Bulk Azure import commit failed") is never written and the intended
-`500 {"success":false,…}` JSON never returned — the AJAX wizard receives the HTML `/Error` page instead.
+_Case C is the one that mattered to get right. An ordinary failure — a constraint violation, a bad
+conversion — leaves the transaction usable and still rolls back exactly as before, so the fix changes
+nothing on the path that actually runs most often. Case B shows the provider has no guard at all:
+rollback after a **successful** commit throws identically._
 
-**Scope, corrected from the finder's claim:** the underlying fault is *not* invisible. EF Core still
-logs `Database.Transaction[20205]` at Error with the exception attached, and `ExceptionHandlerMiddleware`
-logs the escaping one. What is lost is the controller's context and correlation, plus the intended
-response shape. That is why this is low, not medium: no data-integrity consequence — SQL Server rolls
-back server-side regardless — and the trigger is an infrastructure fault in a narrow window.
+_A shared helper was chosen over five copies of the same try/catch, following the precedent the
+migration-lock release already set. It is a new file, `Controllers/TransactionCleanup.cs`, which is
+more structure than a five-line finding usually earns — the alternative was the same six lines
+written out five times, which is exactly the kind of residue these rounds keep finding. The class is
+`public` rather than `internal` so the test project can reach it: the repo has no `InternalsVisibleTo`
+and no convention of testing internals, and Bastet ships as an application rather than a library, so
+widening it costs nothing real._
 
-**Fix.** The rule D12 already applied to the migration-lock release, applied here:
+_Three tests pin the helper, and their value was checked by removing the swallow in a scratch copy —
+two of the three fail. The remaining one is the guard: a rollback that succeeds must log nothing._
 
-```csharp
-catch (Exception ex)
-{
-    logger.LogError(ex, "…");
-    try { await transaction.RollbackAsync(); }
-    catch (Exception rollbackEx) { logger.LogError(rollbackEx, "Rollback failed after the error above"); }
-    return …;
-}
-```
+_The audit's severity reasoning was carried over unchanged and is worth keeping: the underlying fault
+is **not** invisible without this fix. EF Core still logs `Database.Transaction[20205]` with the
+exception attached, and the exception-handler middleware logs the escaping one. What was lost is the
+controller's own contextual message and correlation, and the action's intended response shape — an
+AJAX caller receiving an HTML error page where it parses JSON._
 
-The `using` declaration already disposes (and rolls back) any transaction still live, so swallowing the
-explicit rollback strands nothing — confirmed by the `DisposeAsync` probe above.
+_Tests 596 → 599 (+3). Build clean, 0 warnings._
 
-**Cheaper interim:** move the existing `logger.LogError(ex, …)` above the rollback at all five sites.
+---
 
 ## E5. Subnet Edit POST returns 500 on an out-of-range CIDR instead of redisplaying the form `[×2]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -465,26 +465,33 @@ _Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 
 ## E13. The Details page's Create-Subnet modal reports "0 IP addresses" for /31 and /32 `[×1]`
 
-**Confidence: confirmed.**
+_E13 is fixed and committed. `updateSubnetSize` now carries the RFC 3021 special case the server and
+the Create page's copy both already had, and clamps the ordinary branch with `Math.max(0, size - 2)`._
 
-**Where:** [_SubnetCalculationScripts.cshtml:150-154](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L150-L154)
-— `const usableSize = size > 2 ? size - 2 : 0;`.
-The correct sibling implementation is
-[Create/_SubnetFormScripts.cshtml:28-38](../src/Bastet/Views/Subnet/Create/_SubnetFormScripts.cshtml#L28-L38),
-and the server's is [IpUtilityService.cs:98-113](../src/Bastet/Services/IpUtilityService.cs#L98-L113);
-both special-case RFC 3021.
+_Verified by extracting the shipped function **verbatim** — no retyping, only the jQuery line swapped
+for a `return` — running it in chromium, and comparing every value against
+`IpUtilityService.CalculateUsableIpAddresses` executed directly from the real assembly:_
 
-**Failure scenario.** On a `/30` with no children, `findOptimalCidr` returns 31 and writes it into the
-modal, which then displays "Resulting subnet size: 0 IP addresses" with the Create button enabled.
-Typing 32 gives the same. The server says 2 and 1 respectively — round 4's D4 turns on exactly that —
-and the very next page shows "Usable IPs: 2" for the same /31 the modal just called 0.
+```
+cidr | modal JS | server | match          cidr | modal JS | server | match
+/0   | 4294967294 | 4294967294 | yes      /30  |        2 |      2 | yes
+/8   |   16777214 |   16777214 | yes      /31  |        2 |      2 | yes
+/24  |        254 |        254 | yes      /32  |        1 |      1 | yes
+/29  |          6 |          6 | yes
+```
 
-The wider trigger is not the /30 edge case but any parent with CIDR ≤ 30 where the operator types 31 or
-32, which is reachable from every Details page with an unallocated range.
+_Checking the whole range rather than only the two reported CIDRs was the point: `/0` confirms the
+clamp did not introduce a precision or sign problem at the other extreme, where the count exceeds
+what a 32-bit int holds. Before the fix, `size > 2 ? size - 2 : 0` returned 0 for `/31` (size 2) and
+`/32` (size 1) — the two cases where the subtraction should not happen at all._
 
-**Fix.** Add the same special case: `const usableSize = cidr >= 31 ? (cidr === 31 ? 2 : 1) : Math.max(0, size - 2);`.
-This is the third copy of this calculation; lifting one shared implementation into `site.js` would stop
-a fourth from drifting, but the load-bearing change is the special case alone.
+_The finding's optional suggestion — hoisting this into `site.js` so all three copies share one
+implementation — was **not** taken. It is the right instinct and is recorded on the watch list, but
+it touches two pages plus the shared script to fix a defect that lives in one function, and an
+unrequested refactor riding along in a fix commit is exactly the residue these rounds keep finding._
+_Tests 603 → 603 (unchanged). Build clean, 0 warnings._
+
+---
 
 ## E14. The reconcile confirmation screen overstates the blast radius `[×1]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -400,23 +400,35 @@ _Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 
 ## E11. The green "nothing to clean up" banner shows even when rows were withheld `[×1]`
 
-**Confidence: confirmed.**
+_E11 is fixed and committed. The success banner is now gated on a `nothingToReport` local —
+`items.length === 0 && warnings.length === 0 && reviewItems.length === 0` — so it only appears when
+the scan genuinely established that there is nothing to say._
 
-**Where:** [_ReconcileScripts.cshtml:247-248](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L247-L248)
-— both toggles key on `items.length` alone.
-[_StepReview.cshtml:30-33](../src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml#L30-L33) is the banner.
+_The finding's own correction was applied: `reviewItems` was declared **after** the toggle it now
+participates in, so the declaration is hoisted to sit beside `items`. Dropping the suggested
+one-liner in as written would not have compiled meaningfully — it would have referenced a `const` in
+its temporal dead zone. The finding caught this itself; it is recorded because it is the kind of
+detail that turns a two-line fix into a broken page._
 
-**Failure scenario.** The credential loses access to a resource group. Every affected row is withheld,
-so `items` is empty and the success banner renders — directly beneath the yellow warning saying rows
-were withheld because Azure would not confirm their state. The page asserts as fact
-("Everything imported from this subscription still exists in Azure") the very thing Bastet just recorded
-it could not establish. It also renders beneath E1's factually wrong warning.
+_The alternative of adding a neutral "nothing can be offered for deletion from this scan" message was
+not taken. It needs new markup, and the warnings block sitting directly above already says precisely
+why nothing is offered — a second message would restate it less specifically. Hiding the false claim
+is the whole of the defect._
 
-**Fix.** Gate on there being nothing to report at all, not nothing deletable. `warnings` is already in
-scope at :219; `reviewItems` is declared at :250 and must be hoisted above the toggle if included:
-`items.length > 0 || warnings.length > 0 || reviewItems.length > 0`. Better: when `items` is empty but
-something was reported, render a neutral "Nothing can be offered for deletion from this scan" so the
-page never claims a clean bill it did not earn.
+_Verified the edited script still parses, by extracting the `<script>` body with the four
+`@Url.Action` expressions substituted (not retyped) and running it through `new Function(src)` in
+chromium: `OK`. Worth doing because a syntax error in a `.cshtml` is invisible to the C# compiler and
+to the test suite — it would surface only when the page is requested. This also covers E10's edit to
+the same file. The banner's rendered behaviour is exercised in the closing sweep._
+
+_Being a `[×1]` the premise was re-checked rather than assumed: both toggles at that point keyed on
+`items` alone, so a scan with zero deletable rows and a non-empty warnings array did assert
+"Everything imported from this subscription still exists in Azure" directly beneath a warning saying
+otherwise._
+
+_Tests 603 → 603 (unchanged). Build clean, 0 warnings._
+
+---
 
 ## E12. Collapsing a subtree leaves the toggle showing the expanded icon `[×1]`
 

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -339,35 +339,36 @@ _Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 
 ## E9. `BatchCreateChildSubnets` discards every selected child when an encompassing entry is present `[×2]`
 
-**Confidence: confirmed.** An existing passing test asserts the buggy outcome.
+_E9 is fixed and committed. A second guard now sits beside D9's: an encompassing entry submitted with
+any other subnet is refused outright, naming how many others were sent. The message tells the caller
+how to proceed — submit the encompassing entry alone, or the others without it — rather than leaving
+them to work out why a "successful" import created nothing._
 
-**Where:** [SubnetController.Azure.cs:322](../src/Bastet/Controllers/SubnetController.Azure.cs#L322)
-(`if (!hasFullyEncompassingSubnet)` — skips the creation loop wholesale),
-[:181](../src/Bastet/Controllers/SubnetController.Azure.cs#L181) (D9's guard, which does not check the
-count), [:366](../src/Bastet/Controllers/SubnetController.Azure.cs#L366) (the unconditional success
-message).
+_Rejecting was chosen over the alternative of hoisting the creation loop above the fully-allocated
+write, and the finding is right that the alternative is worse: it would produce a parent that is both
+marked fully allocated **and** has children, a state `ValidateSubnetCanBeFullyAllocated` and
+`SetAllocationStatus` each forbid. Trading a silent drop for a corrupt one is no trade._
 
-**Failure scenario.** POST with `parentId=1`, `isAzureImport=true`, `vnetName="prod-vnet"` and three
-entries: one `FullyEncompassesVNetPrefix=true` covering `10.0.0.0/24`, plus `web 10.0.0.0/25` and
-`app 10.0.0.128/25`. D9's guard passes, both /25s validate, and then the creation loop is skipped
-entirely. Result: parent renamed and marked `IsFullyAllocated=true`, two submitted subnets never
-created, and "Successfully renamed parent subnet… and marked it as fully allocated." Because
-`ValidateSubnetCreation` refuses children under a fully-allocated parent, they can never be added later
-without an operator clearing the flag by hand.
+_**An existing test asserted the defect** and had to be rewritten, which is the part worth flagging
+for future rounds. `BatchCreate_MixedSubnets_HandlesFullyEncompassingCorrectly` asserted the parent
+was renamed, marked fully allocated, and that `childSubnetCount == 0` — i.e. it pinned "the two
+submitted /25s vanish and we call that success" as the contract. It is now
+`BatchCreate_EncompassingEntryWithSiblings_IsRefusedAndWritesNothing`, asserting the post is refused
+and that the parent is neither renamed nor flagged. Rewritten first, and it failed against the
+unfixed action at `AssertImportFailureRedirect` — no error was reported because the action had
+happily returned success._
 
-`SubnetControllerFullyEncompassingTests.cs:311` asserts exactly this, including
-`Assert.Equal(0, childSubnetCount)` — a test pinning the defect.
+_The guard is `subnets.Count > 1`, so the legitimate case D9 protects — a single encompassing entry
+inside a real Azure import — is untouched, and its test still passes._
 
-**Severity, corrected down from the finder's medium** to match where its twin D22 was filed: the
-selection cannot arise from real Azure or the wizard. `GetCompatibleSubnets` sets the flag only when the
-prefix equals a VNet prefix *and* matches the chosen parent, and Azure forbids overlapping subnets
-within a VNet, so the two cannot coexist in one result list. The trigger is a crafted or corrupted POST
-from an authenticated admin behind antiforgery — D22's reachability exactly.
+_Severity was recorded as low rather than the finder's medium, and that holds: the combination cannot
+come from Azure or the wizard, since subnets within a VNet may not overlap and the flag is only set
+when the prefix matches the chosen parent exactly. The vector is a crafted post from an authenticated
+admin behind antiforgery — the same reachability D22 was accepted under._
 
-**Fix.** Extend the D9 guard at :181 with a count clause and reject the combination outright, mirroring
-the planner's wording. **Do not** instead hoist the creation loop above the fully-allocated write — that
-would produce a parent that is both fully allocated and has children, a state
-`ValidateSubnetCanBeFullyAllocated` and `SetAllocationStatus` both forbid.
+_Tests 603 → 603 (unchanged; one test rewritten, none added or removed). Build clean, 0 warnings._
+
+---
 
 ## E10. The reconcile 409's `warnings` payload is never rendered `[×2]` — **verifier split**
 

--- a/src/Bastet/Controllers/AzureController.cs
+++ b/src/Bastet/Controllers/AzureController.cs
@@ -364,8 +364,9 @@ namespace Bastet.Controllers
         /// <see cref="IAzureReconciler.BuildPlan"/> can only work from a subscription listing, and
         /// ARM filters those by RBAC: a credential that has lost access to a resource group gets
         /// HTTP 200 with those resources simply absent, which is indistinguishable from deletion. A
-        /// direct read tells them apart (404 versus 403). Only the proposed rows are read, so a scan
-        /// with nothing to delete makes no extra calls at all.
+        /// direct read tells them apart (404 versus 403). Only the rows that claim the resource is
+        /// gone are read: a drift row was built from a listing that contained the resource, so
+        /// reading it back can only ever answer Live and would withhold the row for no reason.
         /// Shared by the scan and the delete paths so the two cannot diverge on what is deletable.
         /// </remarks>
         internal static async Task ConfirmProposedDeletionsAsync(
@@ -373,13 +374,17 @@ namespace Bastet.Controllers
             IAzureService azureService,
             IAzureReconciler reconciler)
         {
-            if (plan.Items.Count == 0)
+            string[] absenceClaims = [.. plan.Items
+                .Where(i => AzureReconciler.IsAbsenceStatus(i.Status))
+                .Select(i => i.AzureResourceId)];
+
+            if (absenceClaims.Length == 0)
             {
                 return;
             }
 
             IReadOnlyDictionary<string, AzureResourceConfirmation> confirmations =
-                await azureService.ConfirmResourcesAsync(plan.Items.Select(i => i.AzureResourceId));
+                await azureService.ConfirmResourcesAsync(absenceClaims);
 
             reconciler.ApplyConfirmations(plan, confirmations);
         }

--- a/src/Bastet/Controllers/HostIpController.cs
+++ b/src/Bastet/Controllers/HostIpController.cs
@@ -421,9 +421,9 @@ public class HostIpController(
                 }
                 catch (Exception ex)
                 {
-                    // Rollback transaction on error
-                    await transaction.RollbackAsync();
+                    // Log before rolling back - see TransactionCleanup.RollbackQuietlyAsync.
                     logger.LogError(ex, "Host IP delete failed");
+                    await TransactionCleanup.RollbackQuietlyAsync(transaction, logger);
                     TempData["ErrorMessage"] = "Error deleting host IP. Details have been logged.";
                     return RedirectToAction(nameof(Delete), new { ip });
                 }

--- a/src/Bastet/Controllers/SubnetController.Azure.cs
+++ b/src/Bastet/Controllers/SubnetController.Azure.cs
@@ -380,8 +380,8 @@ public partial class SubnetController : Controller
         }
         catch (Exception ex)
         {
-            await transaction.RollbackAsync();
             logger.LogError(ex, "Batch create of child subnets under parent {ParentId} failed", parentId);
+            await TransactionCleanup.RollbackQuietlyAsync(transaction, logger);
             const string unexpected = "An unexpected error occurred while creating subnets. Details have been logged.";
             return BatchCreateFailure(isAzureImport, parentId, unexpected, StatusCode(500, unexpected));
         }

--- a/src/Bastet/Controllers/SubnetController.Azure.cs
+++ b/src/Bastet/Controllers/SubnetController.Azure.cs
@@ -188,6 +188,23 @@ public partial class SubnetController : Controller
                 ModelStateMessage("The import could not be applied."), BadRequest(ModelState));
         }
 
+        // The same entry cannot coexist with ordinary children either. It marks the parent fully
+        // allocated, and the creation loop is skipped wholesale whenever one is present - so every
+        // other subnet in the post is discarded, silently, under a success message. They cannot be
+        // added afterwards either, because a fully-allocated parent refuses children. Azure cannot
+        // produce this selection (subnets within a VNet may not overlap), so reaching it means a
+        // crafted or corrupted post; refusing it matches what the bulk import planner already does
+        // with the same shape.
+        if (subnets.Count > 1 && subnets.Exists(s => s.FullyEncompassesVNetPrefix))
+        {
+            ModelState.AddModelError("subnets",
+                $"A subnet marked as fully encompassing the VNet prefix covers the whole of the parent, so nothing "
+                + $"can be created inside it, but {subnets.Count - 1} other subnet(s) were submitted with it. "
+                + "Submit the encompassing subnet on its own, or submit the others without it.");
+            return BatchCreateFailure(isAzureImport, parentId,
+                ModelStateMessage("The import could not be applied."), BadRequest(ModelState));
+        }
+
         try
         {
             // Validation reads and writes must happen under the global lock, or a concurrent

--- a/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
+++ b/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
@@ -157,8 +157,8 @@ public partial class SubnetController : Controller
                 }
                 catch (Exception ex)
                 {
-                    await transaction.RollbackAsync();
                     logger.LogError(ex, "Azure reconcile delete failed");
+                    await TransactionCleanup.RollbackQuietlyAsync(transaction, logger);
                     return StatusCode(500, new { success = false, error = "The delete failed and no changes were saved. Details have been logged." });
                 }
             });

--- a/src/Bastet/Controllers/SubnetController.BulkAzure.cs
+++ b/src/Bastet/Controllers/SubnetController.BulkAzure.cs
@@ -289,8 +289,8 @@ public partial class SubnetController : Controller
         }
         catch (Exception ex)
         {
-            await transaction.RollbackAsync();
             logger.LogError(ex, "Bulk Azure import commit failed");
+            await TransactionCleanup.RollbackQuietlyAsync(transaction, logger);
             return StatusCode(500, new { success = false, error = "The bulk import failed and no changes were saved. Details have been logged." });
         }
     }

--- a/src/Bastet/Controllers/SubnetController.Delete.cs
+++ b/src/Bastet/Controllers/SubnetController.Delete.cs
@@ -148,9 +148,11 @@ public partial class SubnetController : Controller
         }
         catch (Exception ex)
         {
-            // Rollback the transaction on error
-            await transaction.RollbackAsync();
+            // Log before rolling back. If the commit itself is what failed, the transaction is
+            // already complete and RollbackAsync throws, which would replace this exception before
+            // it was ever recorded - the message the user is about to be shown promises otherwise.
             logger.LogError(ex, "Subnet delete failed for subnet {SubnetId}", id);
+            await TransactionCleanup.RollbackQuietlyAsync(transaction, logger);
             TempData["ErrorMessage"] = "Error deleting subnet. Details have been logged.";
             return RedirectToAction(nameof(Delete), new { id });
         }

--- a/src/Bastet/Controllers/SubnetController.Edit.cs
+++ b/src/Bastet/Controllers/SubnetController.Edit.cs
@@ -176,8 +176,15 @@ public partial class SubnetController : Controller
                     return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 404 });
                 }
 
-                // Handle concurrency conflict - reload current data and show user-friendly message
+                // Handle concurrency conflict - reload current data and show user-friendly message.
+                //
+                // AsNoTracking is load-bearing, not a performance tweak. The failed save left this
+                // subnet tracked and Modified, and UpdateAuditFields already re-stamped its
+                // LastModifiedAt, so an ordinary tracking query resolves to that same dirty instance
+                // and returns the caller's own rejected values as "current database values" - the
+                // exact opposite of what the message below tells the user they are looking at.
                 Subnet? currentSubnet = await context.Subnets
+                    .AsNoTracking()
                     .Include(s => s.ParentSubnet)
                     .FirstOrDefaultAsync(s => s.Id == id);
 
@@ -215,8 +222,12 @@ public partial class SubnetController : Controller
             }
         }
 
-        // If we got this far, something failed - repopulate the view model and return to the form
+        // If we got this far, something failed - repopulate the view model and return to the form.
+        // AsNoTracking for the same reason as the concurrency handler above: this runs last and is
+        // what actually reaches the view, so fixing only that one would change nothing on screen.
+        // Nothing here is saved - every field below is display or the concurrency token.
         Subnet? origSubnet = await context.Subnets
+            .AsNoTracking()
             .Include(s => s.ParentSubnet)
             .FirstOrDefaultAsync(s => s.Id == id);
 

--- a/src/Bastet/Controllers/SubnetController.Edit.cs
+++ b/src/Bastet/Controllers/SubnetController.Edit.cs
@@ -117,8 +117,11 @@ public partial class SubnetController : Controller
                             throw new ValidationException($"CIDR validation failed: {errorMessage}");
                         }
 
-                        // Only validate host IPs when CIDR is increasing (making subnet smaller)
-                        if (viewModel.Cidr > subnet.Cidr)
+                        // Validate host IPs on any CIDR change. An increase can move the broadcast
+                        // address onto an assigned IP; a decrease from a /31 or /32 can reinstate
+                        // the network address reservation under one. Both leave a row the create
+                        // path refuses to produce, so neither direction can be skipped.
+                        if (viewModel.Cidr != subnet.Cidr)
                         {
                             // Validate that all host IPs are still within the subnet range after CIDR change
                             ValidationResult hostIpValidationResult = hostIpValidationService.ValidateSubnetCidrChangeWithHostIps(
@@ -133,8 +136,6 @@ public partial class SubnetController : Controller
                                 throw new ValidationException($"Host IP validation failed: {errorMessage}");
                             }
                         }
-                        // For CIDR decreases (subnet expansion), no host IP validation is needed
-                        // since making a subnet larger cannot cause host IPs to fall outside its range
                     }
 
                     // Update all editable properties including CIDR now

--- a/src/Bastet/Controllers/SubnetController.Edit.cs
+++ b/src/Bastet/Controllers/SubnetController.Edit.cs
@@ -232,10 +232,21 @@ public partial class SubnetController : Controller
         // Always set original CIDR to the actual DB value to prevent validation bypass
         viewModel.OriginalCidr = origSubnet.Cidr;
 
-        // Update the subnet mask based on user's input CIDR value
+        // Update the subnet mask based on user's input CIDR value.
+        //
+        // This runs after a failed ModelState, which is exactly when Cidr can be a value
+        // CalculateSubnetMask refuses - [Range(0,32)] is what made ModelState invalid, and this code
+        // sits outside the try/catch above, so throwing here loses the whole form to an error page
+        // instead of redisplaying it with the range message. The posted value is deliberately not
+        // clamped: it is redisplayed, and rewriting what the operator typed would hide the mistake.
+        // Same guard the Create action applies to a prefilled CIDR from the query string.
+        bool hasUsableCidr = viewModel.Cidr is >= 0 and <= 32;
+
         if (!ModelState.IsValid || viewModel.Cidr != origSubnet.Cidr)
         {
-            viewModel.SubnetMask = ipUtilityService.CalculateSubnetMask(viewModel.Cidr);
+            viewModel.SubnetMask = hasUsableCidr
+                ? ipUtilityService.CalculateSubnetMask(viewModel.Cidr)
+                : string.Empty;
         }
         else
         {

--- a/src/Bastet/Controllers/TransactionCleanup.cs
+++ b/src/Bastet/Controllers/TransactionCleanup.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Bastet.Controllers;
+
+/// <summary>
+/// Cleanup that must not itself become the failure being reported.
+/// </summary>
+public static class TransactionCleanup
+{
+    /// <summary>
+    /// Rolls back, and logs rather than throws if the rollback fails.
+    /// </summary>
+    /// <remarks>
+    /// When a commit fails - an Azure SQL failover, a gateway drop - the provider marks the
+    /// transaction complete, so the <c>RollbackAsync</c> in the catch block throws
+    /// <c>InvalidOperationException: This SqlTransaction has completed; it is no longer usable</c>.
+    /// Called before the logging line, that exception replaces the real one and leaves the incident
+    /// with no record of what actually went wrong, while the caller receives an unhandled error page
+    /// instead of the response the action meant to return. Measured against SQL Server 2022 with
+    /// Microsoft.Data.SqlClient 6.1.1 by killing the session mid-transaction.
+    ///
+    /// Nothing is stranded by swallowing it: the caller's <c>using</c> declaration disposes the
+    /// transaction, which rolls back anything still live, and a broken connection is rolled back
+    /// server-side regardless. An ordinary failure - a constraint violation, a bad conversion -
+    /// leaves the transaction usable and rolls back here exactly as before.
+    ///
+    /// Same rule the migration lock already follows: an exception raised while cleaning up must not
+    /// destroy the one already in flight.
+    /// </remarks>
+    public static async Task RollbackQuietlyAsync(IDbContextTransaction transaction, ILogger logger)
+    {
+        try
+        {
+            await transaction.RollbackAsync();
+        }
+        catch (Exception rollbackException)
+        {
+            logger.LogError(rollbackException,
+                "Rolling back after the error above also failed; the transaction had already completed");
+        }
+    }
+}

--- a/src/Bastet/Models/ViewModels/EditSubnetViewModel.cs
+++ b/src/Bastet/Models/ViewModels/EditSubnetViewModel.cs
@@ -34,19 +34,27 @@ public class EditSubnetViewModel
 
     // Editable properties
 
+    // The [NoHtml] and [Tags] rules below are not decoration: sanitization runs *after* validation,
+    // so without them the sanitizer silently rewrites a value this model has already accepted.
+    // StripHtml can empty a name outright, defeating [Required], and SanitizeTags drops over-long
+    // tags and everything past the tenth - all reported to the user as a successful update. These
+    // must stay in step with CreateSubnetViewModel, which writes the same three columns.
     [Required(ErrorMessage = "Name is required")]
     [StringLength(100, ErrorMessage = "Name cannot be longer than 100 characters")]
+    [NoHtml(ErrorMessage = "HTML tags are not allowed in subnet names")]
     [SanitizeName] // Auto-sanitization
     [Display(Name = "Subnet Name")]
     public string Name { get; set; } = string.Empty;
 
     [Display(Name = "Description")]
     [StringLength(1000, ErrorMessage = "Description cannot be longer than 1000 characters")]
+    [NoHtml(ErrorMessage = "HTML tags are not allowed in descriptions")]
     [SanitizeDescription] // Auto-sanitization
     public string? Description { get; set; }
 
     [Display(Name = "Tags")]
     [StringLength(255, ErrorMessage = "Tags cannot be longer than 255 characters")]
+    [Bastet.Services.Security.Tags(MaxTags = 10, MaxTagLength = 50, ErrorMessage = "Invalid tags format")]
     [SanitizeTags] // Auto-sanitization
     public string? Tags { get; set; }
 

--- a/src/Bastet/Services/Azure/AzureReconciler.cs
+++ b/src/Bastet/Services/Azure/AzureReconciler.cs
@@ -125,6 +125,18 @@ namespace Bastet.Services.Azure
 
             foreach (AzureReconcileItem item in plan.Items)
             {
+                // A confirmation answers one question: is the resource gone? Only the absence
+                // statuses ask it. A drift row was produced *because* the resource was found in the
+                // listing with a different prefix, so Live is the expected answer for it and says
+                // nothing about the drift - and a NotVisible or Unknown answer says nothing either,
+                // because the prefix comparison already came from a successful read of that VNet.
+                // Judging drift rows on this verdict withholds every one of them, permanently.
+                if (!IsAbsenceStatus(item.Status))
+                {
+                    keep.Add(item);
+                    continue;
+                }
+
                 // Absent from the map counts as unconfirmed. Only an explicit 404 survives.
                 AzureResourceConfirmation verdict =
                     confirmations.TryGetValue(item.AzureResourceId, out AzureResourceConfirmation c)
@@ -164,6 +176,15 @@ namespace Bastet.Services.Azure
                     $"in Azure, so they have been withheld from deletion: {NameList(stillLive)}.");
             }
         }
+
+        /// <summary>
+        /// True for the statuses that assert the Azure resource no longer exists, and so are the only
+        /// ones a direct read can confirm or contradict. Public so the caller that decides which IDs
+        /// to read applies exactly the same rule <see cref="ApplyConfirmations"/> does, rather than
+        /// restating it and letting the two drift apart.
+        /// </summary>
+        public static bool IsAbsenceStatus(AzureReconcileStatus status) =>
+            status is AzureReconcileStatus.VNetDeleted or AzureReconcileStatus.SubnetDeleted;
 
         /// <summary>Comma-separated subnet names, capped so a warning stays readable.</summary>
         private static string NameList(List<AzureReconcileItem> items)

--- a/src/Bastet/Services/Validation/HostIpValidationService.cs
+++ b/src/Bastet/Services/Validation/HostIpValidationService.cs
@@ -345,6 +345,30 @@ public class HostIpValidationService(IIpUtilityService ipUtilityService, BastetD
                 }
             }
         }
+        else if (newCidr < originalCidr
+            && newCidr < 31
+            && ipUtilityService.IsValidSubnet(networkAddress, newCidr))
+        {
+            // The mirror of the case above. Widening cannot push a host IP out of range, and it
+            // moves the broadcast address strictly upward - past every address the old range held -
+            // so neither check above can fire on a decrease. What it can do is reinstate the network
+            // address reservation: a /31 is a point-to-point pair and a /32 a single host, neither
+            // of which reserves anything (RFC 3021), so the network address is a legal assignment
+            // there. Dropping below /31 makes that same address reserved without the operator
+            // touching it, leaving a row ValidateNewHostIp refuses to create - so it could not be
+            // re-added after a delete. The network address itself never moves when the subnet is
+            // aligned to the new CIDR, which IsValidSubnet establishes; an unaligned decrease is
+            // rejected before it reaches here.
+            foreach (HostIpAssignment hostIp in subnet.HostIpAssignments)
+            {
+                if (hostIp.IP == networkAddress)
+                {
+                    result.AddError(CIDR_CHANGE_INVALID,
+                        $"Cannot decrease CIDR to /{newCidr} as host IP {hostIp.IP} would become the subnet's network address");
+                    break;
+                }
+            }
+        }
 
         return result;
     }

--- a/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
@@ -310,10 +310,8 @@
 
             const chosen = (lastPlan.items || []).filter(function (i) { return ids.indexOf(i.subnetId) !== -1; });
 
-            // Everything below describes exactly these subnets, and so does the deletion.
+            // The deletion is submitted for every selected id; the server dedupes by subtree.
             confirmedIds = chosen.map(function (i) { return i.subnetId; });
-
-            $("#rec-confirm-count").text(chosen.length);
 
             // The counts are subtree-inclusive, so an item selected together with one of its
             // ancestors is already inside the ancestor's numbers - same rule the server applies
@@ -323,12 +321,17 @@
                 (i.descendantSubnetIds || []).forEach(function (id) { covered[id] = true; });
             });
 
+            // What the server will actually report as deleted. A selected subnet that is also a
+            // descendant of another selected subnet is archived as part of that ancestor's subtree,
+            // not as a target of its own. Counting it here as well as in the cascade below
+            // announced more subnets than exist - and disagreed with the result message afterwards.
+            const targets = chosen.filter(function (i) { return !covered[i.subnetId]; });
+
+            $("#rec-confirm-count").text(targets.length);
+
             let descendants = 0;
             let hostIps = 0;
-            chosen.forEach(function (i) {
-                if (covered[i.subnetId]) {
-                    return;
-                }
+            targets.forEach(function (i) {
                 descendants += i.descendantCount;
                 hostIps += i.hostIpCount;
             });
@@ -343,7 +346,7 @@
             }
 
             const list = $("#rec-confirm-list").empty();
-            chosen.forEach(function (i) {
+            targets.forEach(function (i) {
                 list.append($('<li class="list-group-item"></li>')
                     .text(i.name + " (" + i.networkAddress + "/" + i.cidr + ") - " + statusLabel(i.statusName).text));
             });

--- a/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
@@ -412,6 +412,15 @@
                 list.append($("<li></li>").text(e));
             });
 
+            // The 409 carries no globalErrors - the reason a row was withheld travels in warnings,
+            // and without this the operator sees only "no longer reported as deleted", which reads
+            // like a stale browser view rather than "Azure would not confirm it" or "the credential
+            // lost access". Re-running the scan shows the same text, but only while the condition
+            // persists: a throttle that has cleared by then explains nothing.
+            (payload.warnings || []).forEach(function (w) {
+                list.append($("<li></li>").text(w));
+            });
+
             $("#rec-commit-error").removeClass("d-none");
             // Let the user retry: the commit is transactional, so nothing was partially applied.
             // Still snapshot-aware - a failure that invalidated the snapshot must not leave a live

--- a/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
@@ -222,6 +222,9 @@
             $("#rec-scan-warnings").toggleClass("d-none", warnings.length === 0);
 
             const items = plan.items || [];
+            // Declared here rather than below because the "nothing to clean up" banner is gated on
+            // it as well as on items.
+            const reviewItems = plan.reviewItems || [];
             const rows = $("#rec-stale-rows").empty();
 
             items.forEach(function (item) {
@@ -245,9 +248,16 @@
             });
 
             $("#rec-stale-section").toggleClass("d-none", items.length === 0);
-            $("#rec-nothing-stale").toggleClass("d-none", items.length > 0);
 
-            const reviewItems = plan.reviewItems || [];
+            // "Everything still exists in Azure. There is nothing to clean up." is a statement of
+            // fact, so it may only appear when the scan actually established that. Rows withheld
+            // because Azure could not be asked produce a warning and no items, and subnets needing
+            // review produce reviewItems and no items - in both cases there is something to report,
+            // and claiming a clean bill over the top of it is the same fail-open assertion in prose
+            // that the deletion path is careful never to make.
+            const nothingToReport = items.length === 0 && warnings.length === 0 && reviewItems.length === 0;
+            $("#rec-nothing-stale").toggleClass("d-none", !nothingToReport);
+
             const reviewRows = $("#rec-review-rows").empty();
             reviewItems.forEach(function (item) {
                 const tr = $("<tr></tr>");

--- a/src/Bastet/Views/Subnet/Create/_SubnetFormScripts.cshtml
+++ b/src/Bastet/Views/Subnet/Create/_SubnetFormScripts.cshtml
@@ -42,14 +42,10 @@
         const cidrValue = parseInt($('#cidrInput').val(), 10);
         
         if (!isNaN(cidrValue) && cidrValue >= 0 && cidrValue <= 32) {
-            // Do AJAX call to get the subnet mask
-            $.get(`/api/subnets/calculate-mask?cidr=${cidrValue}`, function(data) {
-                $('#subnetMaskDisplay').text(data.subnetMask);
-            }).fail(function() {
-                // Fallback calculation for all IPv4 CIDRs
-                const mask = calculateSubnetMask(cidrValue);
-                $('#subnetMaskDisplay').text(mask);
-            });
+            // Computed locally. This used to GET /api/subnets/calculate-mask, a route that has never
+            // existed in this application - so every keystroke 404'd, was re-executed into a full
+            // server-rendered error page, and then fell back to exactly this call anyway.
+            $('#subnetMaskDisplay').text(calculateSubnetMask(cidrValue));
             
             // Calculate and display IP counts
             const totalIPs = calculateTotalIPs(cidrValue);

--- a/src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml
+++ b/src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml
@@ -149,7 +149,13 @@
         // Function to calculate subnet size based on CIDR
         function updateSubnetSize(cidr) {
             const size = Math.pow(2, 32 - cidr);
-            const usableSize = size > 2 ? size - 2 : 0; // Adjust for network & broadcast addresses
+            // A /31 is a point-to-point pair and a /32 a single host: neither reserves a network or
+            // broadcast address (RFC 3021), so both are usable. Subtracting two there reported "0
+            // IP addresses" for a subnet the server, and the Create page's own copy of this
+            // calculation, both count as usable.
+            const usableSize = cidr >= 31
+                ? (cidr === 31 ? 2 : 1)
+                : Math.max(0, size - 2);
             $('#subnetSizeDisplay').text(usableSize.toLocaleString());
         }
         

--- a/src/Bastet/wwwroot/js/site.js
+++ b/src/Bastet/wwwroot/js/site.js
@@ -33,6 +33,16 @@ $(document).ready(function () {
     function updateToggleIcons() {
         $('.subnet-toggle').each(function () {
             var $children = $(this).closest('.subnet-item').children('.subnet-children');
+
+            // Leave childless subnets alone. The view omits .subnet-children entirely when there
+            // are no children, and jQuery's :visible is false on an empty set - so without this the
+            // else branch below repaints their flat dash as a collapsed expander that can never
+            // expand, the startup loop having already unbound their click handler. Same test the
+            // startup loop uses, so there is one definition of "leaf" rather than two that disagree.
+            if ($children.children().length === 0) {
+                return;
+            }
+
             if ($children.is(':visible')) {
                 $(this).html('<i class="bi bi-dash-square"></i>');
             } else {

--- a/src/Bastet/wwwroot/js/site.js
+++ b/src/Bastet/wwwroot/js/site.js
@@ -9,10 +9,12 @@ $(document).ready(function () {
     // Toggle subnet children visibility
     $('.subnet-toggle').on('click', function () {
         var $children = $(this).closest('.subnet-item').children('.subnet-children');
-        $children.slideToggle(200);
-        
-        // Update the toggle icon
-        updateToggleIcons();
+
+        // Update the icon when the animation finishes, not before it starts. jQuery applies
+        // display:none for a hide only in the completion callback (a show sets display up front),
+        // so reading :visible on the next statement reports the state we are animating away from
+        // and paints "expanded" on a subtree that is closing. Nothing revisits it afterwards.
+        $children.slideToggle(200, updateToggleIcons);
     });
     
     // Expand all subnets
@@ -25,7 +27,10 @@ $(document).ready(function () {
     $('#collapse-all').on('click', function () {
         // Keep the first level visible
         $('.subnet-tree > .subnet-item > .subnet-children').show();
-        $('.subnet-tree .subnet-item .subnet-item > .subnet-children').slideUp(200);
+        // Both calls are needed. The callback corrects the deeper levels once they are actually
+        // hidden; the bare call keeps the first level right even when the tree is only one level
+        // deep, in which case the selector above matches nothing and the callback never fires.
+        $('.subnet-tree .subnet-item .subnet-item > .subnet-children').slideUp(200, updateToggleIcons);
         updateToggleIcons();
     });
     

--- a/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
@@ -448,6 +448,112 @@ public class AzureReconcilerTests
     }
 
     // -------------------------------------------------------------------------
+    // ApplyConfirmations and the drift statuses. A confirmation answers "is it gone?", which is a
+    // question only the absence statuses ask. VNetPrefixRemoved and SubnetPrefixChanged are built
+    // from a listing that contained the resource, so Live is the expected answer for them and is
+    // not evidence against the drift.
+    // -------------------------------------------------------------------------
+
+    /// <summary>The VNet is live and listed; only the prefix Bastet recorded is gone.</summary>
+    private AzureReconcilePlanViewModel PlanWithOnePrefixRemovedItem(out string resourceId)
+    {
+        resourceId = VNetId("vnet-a");
+        return Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),
+            Linked(1, "second prefix", "10.1.0.0", 16, resourceId));
+    }
+
+    /// <summary>The Azure subnet is live and listed; it has simply been re-addressed.</summary>
+    private AzureReconcilePlanViewModel PlanWithOnePrefixChangedItem(out string resourceId)
+    {
+        resourceId = SubnetId("vnet-a", "snet-a");
+        return Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"], AzSubnet("vnet-a", "snet-a", "10.0.9.0/24"))),
+            Linked(1, "snet-a", "10.0.1.0", 24, resourceId));
+    }
+
+    [Theory]
+    [InlineData(AzureResourceConfirmation.Live)]
+    [InlineData(AzureResourceConfirmation.NotVisible)]
+    [InlineData(AzureResourceConfirmation.Unknown)]
+    public void ApplyConfirmations_VNetPrefixRemoved_SurvivesEveryVerdict(
+        AzureResourceConfirmation verdict)
+    {
+        AzureReconcilePlanViewModel plan = PlanWithOnePrefixRemovedItem(out string id);
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [id] = verdict
+        });
+
+        AzureReconcileItem item = Assert.Single(plan.Items);
+        Assert.Equal(AzureReconcileStatus.VNetPrefixRemoved, item.Status);
+        Assert.True(plan.CanCommit);
+        Assert.Empty(plan.Warnings);
+    }
+
+    [Theory]
+    [InlineData(AzureResourceConfirmation.Live)]
+    [InlineData(AzureResourceConfirmation.NotVisible)]
+    [InlineData(AzureResourceConfirmation.Unknown)]
+    public void ApplyConfirmations_SubnetPrefixChanged_SurvivesEveryVerdict(
+        AzureResourceConfirmation verdict)
+    {
+        AzureReconcilePlanViewModel plan = PlanWithOnePrefixChangedItem(out string id);
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [id] = verdict
+        });
+
+        AzureReconcileItem item = Assert.Single(plan.Items);
+        Assert.Equal(AzureReconcileStatus.SubnetPrefixChanged, item.Status);
+        Assert.True(plan.CanCommit);
+        Assert.Empty(plan.Warnings);
+    }
+
+    /// <summary>
+    /// The drift rows are not submitted for confirmation at all, so they arrive with no verdict.
+    /// Absence from the map must not be read as "unanswered, therefore withhold" for them.
+    /// </summary>
+    [Fact]
+    public void ApplyConfirmations_DriftRowsAbsentFromTheMap_AreKept()
+    {
+        AzureReconcilePlanViewModel plan = PlanWithOnePrefixRemovedItem(out _);
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>());
+
+        _ = Assert.Single(plan.Items);
+        Assert.Empty(plan.Warnings);
+    }
+
+    /// <summary>
+    /// A mixed plan: the absence row is still governed by the 404-only rule while the drift row
+    /// passes through untouched. Both halves must hold at once.
+    /// </summary>
+    [Fact]
+    public void ApplyConfirmations_DriftAndAbsenceTogether_JudgedSeparately()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),
+            Linked(1, "drifted", "10.1.0.0", 16, VNetId("vnet-a")),
+            Linked(2, "gone", "10.5.0.0", 16, VNetId("vnet-gone")));
+
+        Assert.Equal(2, plan.Items.Count);
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [VNetId("vnet-gone")] = AzureResourceConfirmation.NotVisible
+        });
+
+        AzureReconcileItem item = Assert.Single(plan.Items);
+        Assert.Equal(AzureReconcileStatus.VNetPrefixRemoved, item.Status);
+        _ = Assert.Single(plan.Warnings);
+        Assert.Contains("'gone'", plan.Warnings[0]);
+        Assert.DoesNotContain("'drifted'", plan.Warnings[0]);
+    }
+
+    // -------------------------------------------------------------------------
     // VNet-vs-subnet routing. Every builder above hard-codes "resourceGroups/rg", so a resource
     // group whose own name collides with the "/subnets/" segment was never covered.
     // -------------------------------------------------------------------------

--- a/test/Bastet.Tests/HostIpManagement/SubnetHostIpInteractionTests.cs
+++ b/test/Bastet.Tests/HostIpManagement/SubnetHostIpInteractionTests.cs
@@ -593,4 +593,88 @@ public class SubnetHostIpInteractionTests : IDisposable
         Assert.False(result.IsValid);
         Assert.Contains(result.Errors, e => e.Message.Contains("outside the subnet range"));
     }
+
+    // -------------------------------------------------------------------------
+    // The mirror image: a CIDR *decrease* cannot move the network address, but dropping below /31
+    // makes it reserved for the first time. A /31 or /32 is allowed to hand out its network address
+    // (RFC 3021), so widening one is the only way an assigned host IP can become the network
+    // address without the operator touching it.
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// 10.4.0.0 is a legal assignment in a /31, where nothing is reserved. Widening to /30 keeps the
+    /// same network address but reinstates the reservation, so the row becomes one ValidateNewHostIp
+    /// refuses to create - delete it and it cannot be re-added.
+    /// </summary>
+    [Fact]
+    public void ValidateSubnetCidrChangeWithHostIps_WideningFromSlash31_HostIpBecomesNetworkAddress_IsRejected()
+    {
+        SeedSubnetWithHostIp(104, "10.4.0.0", 31, "10.4.0.0");
+
+        ValidationResult result = _hostIpValidationService
+            .ValidateSubnetCidrChangeWithHostIps(104, "10.4.0.0", 31, 30);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Message.Contains("10.4.0.0"));
+        Assert.Contains(result.Errors, e => e.Message.Contains("network address"));
+    }
+
+    /// <summary>The same from a /32, whose single address is also its network address.</summary>
+    [Fact]
+    public void ValidateSubnetCidrChangeWithHostIps_WideningFromSlash32_HostIpBecomesNetworkAddress_IsRejected()
+    {
+        SeedSubnetWithHostIp(105, "10.5.0.0", 32, "10.5.0.0");
+
+        ValidationResult result = _hostIpValidationService
+            .ValidateSubnetCidrChangeWithHostIps(105, "10.5.0.0", 32, 24);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Message.Contains("10.5.0.0"));
+    }
+
+    /// <summary>
+    /// The other half of a /31 is an ordinary host once widened - 10.6.0.1 sits between the /30's
+    /// network and broadcast addresses - so widening must still be allowed.
+    /// </summary>
+    [Fact]
+    public void ValidateSubnetCidrChangeWithHostIps_WideningFromSlash31_OtherAddress_IsAllowed()
+    {
+        SeedSubnetWithHostIp(106, "10.6.0.0", 31, "10.6.0.1");
+
+        ValidationResult result = _hostIpValidationService
+            .ValidateSubnetCidrChangeWithHostIps(106, "10.6.0.0", 31, 30);
+
+        Assert.True(result.IsValid);
+    }
+
+    /// <summary>
+    /// The boundary that matters: widening a /32 to a /31 lands on a CIDR that still reserves
+    /// nothing, so the host IP sitting on the network address stays legal. Checking the network
+    /// address without the newCidr &lt; 31 guard would wrongly reject this.
+    /// </summary>
+    [Fact]
+    public void ValidateSubnetCidrChangeWithHostIps_WideningToSlash31_ReservesNothing()
+    {
+        SeedSubnetWithHostIp(107, "10.7.0.0", 32, "10.7.0.0");
+
+        ValidationResult result = _hostIpValidationService
+            .ValidateSubnetCidrChangeWithHostIps(107, "10.7.0.0", 32, 31);
+
+        Assert.True(result.IsValid);
+    }
+
+    /// <summary>
+    /// An ordinary widening between two CIDRs that both reserve the network address cannot create a
+    /// new collision, because the address was already reserved before the change.
+    /// </summary>
+    [Fact]
+    public void ValidateSubnetCidrChangeWithHostIps_OrdinaryWidening_IsAllowed()
+    {
+        SeedSubnetWithHostIp(108, "10.8.0.0", 30, "10.8.0.1");
+
+        ValidationResult result = _hostIpValidationService
+            .ValidateSubnetCidrChangeWithHostIps(108, "10.8.0.0", 30, 29);
+
+        Assert.True(result.IsValid);
+    }
 }

--- a/test/Bastet.Tests/Security/SubnetViewModelValidationParityTests.cs
+++ b/test/Bastet.Tests/Security/SubnetViewModelValidationParityTests.cs
@@ -1,0 +1,176 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services.Security;
+using System.ComponentModel.DataAnnotations;
+
+namespace Bastet.Tests.Security;
+
+/// <summary>
+/// Create and Edit write the same three columns, so they must refuse the same input.
+///
+/// Where they disagree the damage is silent rather than loud: GlobalSanitizationFilter runs after
+/// model binding and validation, so a value Edit's model accepts is rewritten by the sanitizer
+/// afterwards and stored in its mangled form with a success message. StripHtml can empty a value
+/// outright, which defeats [Required]; SanitizeTags drops over-long tags and everything past the
+/// tenth. Create rejects all of it up front because it carries the validators.
+/// </summary>
+public class SubnetViewModelValidationParityTests
+{
+    /// <summary>
+    /// [NoHtml], [SafeText] and [Tags] all resolve IInputSanitizationService from the validation
+    /// context. Without one they fail with "Input sanitization service not available", which would
+    /// make every assertion below pass for entirely the wrong reason.
+    /// </summary>
+    private sealed class SanitizationServiceProvider : IServiceProvider
+    {
+        private readonly InputSanitizationService _service = new();
+
+        public object? GetService(Type serviceType) =>
+            serviceType == typeof(IInputSanitizationService) ? _service : null;
+    }
+
+    private static List<ValidationResult> Validate(object model)
+    {
+        List<ValidationResult> results = [];
+        _ = Validator.TryValidateObject(
+            model,
+            new ValidationContext(model, new SanitizationServiceProvider(), null),
+            results,
+            validateAllProperties: true);
+        return results;
+    }
+
+    /// <summary>
+    /// Validates one property in isolation. [NoHtml] and [Tags] both return a ValidationResult with
+    /// no member names, so a whole-object validation cannot say which property failed - matching on
+    /// MemberNames silently never hits. Setting MemberName on the context makes the attribution
+    /// exact, and the value passed is read from the property by reflection so the two cannot
+    /// disagree.
+    /// </summary>
+    private static void AssertRejects(object model, string member, string expectedMessageFragment)
+    {
+        object? value = model.GetType().GetProperty(member)!.GetValue(model);
+
+        List<ValidationResult> results = [];
+        bool ok = Validator.TryValidateProperty(
+            value,
+            new ValidationContext(model, new SanitizationServiceProvider(), null) { MemberName = member },
+            results);
+
+        Assert.False(ok, $"{model.GetType().Name}.{member} was accepted but should have been rejected.");
+        Assert.Contains(results, r => r.ErrorMessage is not null && r.ErrorMessage.Contains(expectedMessageFragment));
+    }
+
+    // Name -------------------------------------------------------------------
+
+    /// <summary>
+    /// The worst case: StripHtml reduces this to the empty string, so [Required] passes on the
+    /// submitted value and the row is stored with no name at all.
+    /// </summary>
+    [Theory]
+    [InlineData("<b></b>")]
+    [InlineData("Site <HQ>")]
+    public void MarkupInName_RejectedByBoth(string name)
+    {
+        AssertRejects(
+            new CreateSubnetViewModel { Name = name, NetworkAddress = "10.0.0.0", Cidr = 24 },
+            nameof(CreateSubnetViewModel.Name),
+            "HTML tags are not allowed");
+
+        AssertRejects(
+            new EditSubnetViewModel { Id = 1, Name = name, NetworkAddress = "10.0.0.0", Cidr = 24 },
+            nameof(EditSubnetViewModel.Name),
+            "HTML tags are not allowed");
+    }
+
+    // Description ------------------------------------------------------------
+
+    /// <summary>
+    /// StripHtml's `&lt;[^&gt;]*&gt;` eats everything between the two comparison operators, so this
+    /// stores as "temp  3".
+    /// </summary>
+    [Fact]
+    public void MarkupInDescription_RejectedByBoth()
+    {
+        const string description = "temp < 5 and load > 3";
+
+        AssertRejects(
+            new CreateSubnetViewModel { Name = "ok", NetworkAddress = "10.0.0.0", Cidr = 24, Description = description },
+            nameof(CreateSubnetViewModel.Description),
+            "HTML tags are not allowed");
+
+        AssertRejects(
+            new EditSubnetViewModel { Id = 1, Name = "ok", NetworkAddress = "10.0.0.0", Cidr = 24, Description = description },
+            nameof(EditSubnetViewModel.Description),
+            "HTML tags are not allowed");
+    }
+
+    // Tags -------------------------------------------------------------------
+
+    /// <summary>A single over-long tag is dropped outright by SanitizeTags' length filter.</summary>
+    [Fact]
+    public void OverlongTag_RejectedByBoth()
+    {
+        string tags = new('a', 60);
+
+        AssertRejects(
+            new CreateSubnetViewModel { Name = "ok", NetworkAddress = "10.0.0.0", Cidr = 24, Tags = tags },
+            nameof(CreateSubnetViewModel.Tags),
+            "50 characters or less");
+
+        AssertRejects(
+            new EditSubnetViewModel { Id = 1, Name = "ok", NetworkAddress = "10.0.0.0", Cidr = 24, Tags = tags },
+            nameof(EditSubnetViewModel.Tags),
+            "50 characters or less");
+    }
+
+    /// <summary>Everything past the tenth tag is discarded by SanitizeTags' Take(10).</summary>
+    [Fact]
+    public void TooManyTags_RejectedByBoth()
+    {
+        string tags = string.Join(",", Enumerable.Range(1, 11).Select(i => $"t{i}"));
+
+        AssertRejects(
+            new CreateSubnetViewModel { Name = "ok", NetworkAddress = "10.0.0.0", Cidr = 24, Tags = tags },
+            nameof(CreateSubnetViewModel.Tags),
+            "Maximum 10 tags allowed");
+
+        AssertRejects(
+            new EditSubnetViewModel { Id = 1, Name = "ok", NetworkAddress = "10.0.0.0", Cidr = 24, Tags = tags },
+            nameof(EditSubnetViewModel.Tags),
+            "Maximum 10 tags allowed");
+    }
+
+    // Parity in the other direction ------------------------------------------
+
+    /// <summary>
+    /// The guard against over-correcting: ordinary values both models are supposed to accept must
+    /// still pass. One tag sits exactly on the 50-character limit and there are exactly ten of them,
+    /// so both [Tags] boundaries are touched while staying inside the 255-character [StringLength]
+    /// that governs the field as a whole.
+    /// </summary>
+    [Fact]
+    public void OrdinaryValues_AcceptedByBoth()
+    {
+        string tags = string.Join(",", [new string('a', 50), .. Enumerable.Range(1, 9).Select(i => $"tag-{i}")]);
+        const string description = "Primary transit range (site A), reviewed 2026-01-01.";
+
+        Assert.Empty(Validate(new CreateSubnetViewModel
+        {
+            Name = "HQ core",
+            NetworkAddress = "10.0.0.0",
+            Cidr = 24,
+            Description = description,
+            Tags = tags
+        }));
+
+        Assert.Empty(Validate(new EditSubnetViewModel
+        {
+            Id = 1,
+            Name = "HQ core",
+            NetworkAddress = "10.0.0.0",
+            Cidr = 24,
+            Description = description,
+            Tags = tags
+        }));
+    }
+}

--- a/test/Bastet.Tests/Security/TransactionCleanupTests.cs
+++ b/test/Bastet.Tests/Security/TransactionCleanupTests.cs
@@ -1,0 +1,79 @@
+using Bastet.Controllers;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Bastet.Tests.Security;
+
+/// <summary>
+/// A rollback that fails must not become the failure being reported. When a commit fails the
+/// provider marks the transaction complete, so the rollback in the catch block throws
+/// InvalidOperationException - and called before the logging line it replaces the real exception,
+/// losing the incident and turning the action's intended response into an unhandled error page.
+/// </summary>
+public class TransactionCleanupTests
+{
+    [Fact]
+    public async Task RollbackQuietlyAsync_RollbackThrows_DoesNotPropagate()
+    {
+        Mock<IDbContextTransaction> transaction = new();
+        transaction
+            .Setup(t => t.RollbackAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException(
+                "This SqlTransaction has completed; it is no longer usable."));
+
+        Mock<ILogger> logger = new();
+
+        // The assertion is the absence of a throw: an exception escaping here is the defect.
+        await TransactionCleanup.RollbackQuietlyAsync(transaction.Object, logger.Object);
+
+        transaction.Verify(t => t.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RollbackQuietlyAsync_RollbackThrows_LogsTheSecondaryFailure()
+    {
+        Mock<IDbContextTransaction> transaction = new();
+        InvalidOperationException rollbackFailure = new("This SqlTransaction has completed.");
+        transaction
+            .Setup(t => t.RollbackAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(rollbackFailure);
+
+        Mock<ILogger> logger = new();
+
+        await TransactionCleanup.RollbackQuietlyAsync(transaction.Object, logger.Object);
+
+        // The rollback failure is not silently dropped - it is recorded as secondary to the real one.
+        logger.Verify(
+            l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                rollbackFailure,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// The ordinary case - a constraint violation, say - leaves the transaction usable, and must
+    /// still roll back and log nothing.
+    /// </summary>
+    [Fact]
+    public async Task RollbackQuietlyAsync_RollbackSucceeds_LogsNothing()
+    {
+        Mock<IDbContextTransaction> transaction = new();
+        Mock<ILogger> logger = new();
+
+        await TransactionCleanup.RollbackQuietlyAsync(transaction.Object, logger.Object);
+
+        transaction.Verify(t => t.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
+        logger.Verify(
+            l => l.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
+    }
+}

--- a/test/Bastet.Tests/SubnetManagement/SubnetControllerCidrEditTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetControllerCidrEditTests.cs
@@ -334,6 +334,55 @@ public class SubnetControllerCidrEditTests : IDisposable
         Assert.Equal(23, cidr);
     }
 
+    /// <summary>
+    /// Pins the controller half of the /31-widening fix. The host-IP validator is only reached when
+    /// the CIDR-change gate lets a decrease through, so a gate that skips decreases leaves the
+    /// service rule unreachable and every service-level test still green. 10.20.0.0 is a legal
+    /// assignment in a /31 and becomes the network address of the /30.
+    /// </summary>
+    [Fact]
+    public async Task Edit_POST_DecreaseCidrFromSlash31_HostIpOnNetworkAddress_ReturnsViewWithError()
+    {
+        Subnet pointToPoint = new()
+        {
+            Id = 20,
+            Name = "P2P link",
+            NetworkAddress = "10.20.0.0",
+            Cidr = 31,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "test-admin"
+        };
+        _context.Subnets.Add(pointToPoint);
+        _context.HostIpAssignments.Add(new HostIpAssignment
+        {
+            IP = "10.20.0.0",
+            Name = "link-a",
+            SubnetId = 20,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "test-admin"
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        EditSubnetViewModel viewModel = new()
+        {
+            Id = 20,
+            Name = "P2P link",
+            NetworkAddress = "10.20.0.0",
+            Cidr = 30,
+            OriginalCidr = 31
+        };
+
+        IActionResult result = await _controller.Edit(20, viewModel);
+
+        // The form comes back rather than redirecting, and nothing was written.
+        _ = Assert.IsType<ViewResult>(result);
+        Assert.False(_controller.ModelState.IsValid);
+
+        Subnet? unchanged = await _context.Subnets.FindAsync([20], TestContext.Current.CancellationToken);
+        Assert.NotNull(unchanged);
+        Assert.Equal(31, unchanged.Cidr);
+    }
+
     [Fact]
     public async Task Edit_POST_DecreaseCidr_WithGrandparentAndGrandchild_ReturnsRedirectToDetails()
     {

--- a/test/Bastet.Tests/SubnetManagement/SubnetControllerCidrEditTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetControllerCidrEditTests.cs
@@ -486,6 +486,40 @@ public class SubnetControllerCidrEditTests : IDisposable
         Assert.Contains("Cidr", _controller.ModelState.Keys);
     }
 
+    /// <summary>
+    /// The out-of-range value must survive to be redisplayed with its message. The [Range(0,32)]
+    /// failure skips the guarded block entirely, so execution falls through to the mask calculation
+    /// at the tail of the action - which sits outside any try and throws for a CIDR it cannot
+    /// compute, turning a form validation error into a 500.
+    /// </summary>
+    [Theory]
+    [InlineData(33)]
+    [InlineData(99)]
+    [InlineData(-1)]
+    [InlineData(int.MaxValue)]
+    public async Task Edit_POST_OutOfRangeCidr_ReturnsViewInsteadOfThrowing(int cidr)
+    {
+        _controller.ModelState.AddModelError("Cidr", "CIDR must be between 0 and 32");
+
+        EditSubnetViewModel viewModel = new()
+        {
+            Id = 4,
+            Name = "Target Subnet",
+            NetworkAddress = "10.0.2.0",
+            Cidr = cidr,
+            OriginalCidr = 24
+        };
+
+        IActionResult result = await _controller.Edit(4, viewModel);
+
+        _ = Assert.IsType<ViewResult>(result);
+        Assert.False(_controller.ModelState.IsValid);
+        Assert.Contains("Cidr", _controller.ModelState.Keys);
+
+        // The value the operator typed is redisplayed rather than silently clamped.
+        Assert.Equal(cidr, viewModel.Cidr);
+    }
+
     [Fact]
     public async Task Edit_POST_IncreaseCidr_OrphansChildren_ReturnsViewWithError()
     {

--- a/test/Bastet.Tests/SubnetManagement/SubnetControllerFullyEncompassingTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetControllerFullyEncompassingTests.cs
@@ -307,8 +307,20 @@ public class SubnetControllerFullyEncompassingTests : IDisposable
         Assert.Equal("Parent Subnet", parent.Name);
     }
 
+    /// <summary>
+    /// An encompassing entry and ordinary children cannot both be honoured: the encompassing entry
+    /// renames the parent and marks it fully allocated, and the creation loop is skipped wholesale
+    /// when one is present. This test previously asserted that outcome - parent flagged, zero
+    /// children created, success reported - which is the defect, not the contract. The two
+    /// submitted /25s were discarded silently and could never be added afterwards, because a
+    /// fully-allocated parent refuses children.
+    ///
+    /// The combination cannot arise from Azure or the wizard (subnets within a VNet may not
+    /// overlap), so reaching it means a crafted or corrupted post. Refusing it is the same answer
+    /// the bulk planner already gives for the same shape.
+    /// </summary>
     [Fact]
-    public async Task BatchCreate_MixedSubnets_HandlesFullyEncompassingCorrectly()
+    public async Task BatchCreate_EncompassingEntryWithSiblings_IsRefusedAndWritesNothing()
     {
         // Arrange
         int parentId = 2; // Parent Subnet (10.11.0.0/24)
@@ -352,19 +364,18 @@ public class SubnetControllerFullyEncompassingTests : IDisposable
         // Act
         IActionResult result = await _controller.BatchCreateChildSubnets(parentId, subnets, vnetName, isAzureImport: true);
 
-        // Assert
-        RedirectToActionResult redirectResult = Assert.IsType<RedirectToActionResult>(result);
+        // Assert - the whole post is refused, with a message rather than a silent partial success.
+        AssertImportFailureRedirect(result, parentId);
 
-        // Verify parent subnet is renamed and marked as fully allocated
+        _context.ChangeTracker.Clear();
+
+        // The parent is untouched: not renamed, not flagged.
         Subnet? parentSubnet = await _context.Subnets.FindAsync([parentId], TestContext.Current.CancellationToken);
         Assert.NotNull(parentSubnet);
-        Assert.Equal(vnetName, parentSubnet.Name);
-        Assert.True(parentSubnet.IsFullyAllocated);
+        Assert.NotEqual(vnetName, parentSubnet.Name);
+        Assert.False(parentSubnet.IsFullyAllocated);
 
-        // Verify description contains information about the encompassing subnet
-        Assert.Contains("Default", parentSubnet.Description);
-
-        // Verify no child subnets were created - since the first subnet fully encompasses the VNet prefix
+        // And nothing was created - the /25s are not silently dropped, they are refused with the post.
         int childSubnetCount = await _context.Subnets
             .Where(s => s.ParentSubnetId == parentId && s.Id != parentId)
             .CountAsync(TestContext.Current.CancellationToken);


### PR DESCRIPTION
### Improvements
- **Azure reconcile now reports address-prefix drift again** — a VNet or subnet that still exists but no longer carries the range Bastet recorded is offered for cleanup, instead of being silently withheld with a warning claiming it was missing from the subscription
- The reconcile confirmation screen **counts only what will actually be deleted**, so a subnet selected alongside its parent is no longer announced twice, and the figures agree with the result message
- Reconcile explains **why** a row was withheld when a deletion is refused, rather than only reporting that it was
- The reconcile scan no longer claims "everything still exists in Azure" when rows were withheld or flagged for review
- **Subnet Edit now rejects the same input Create does** — names or descriptions containing markup, over-long tags, and more than ten tags produce a field error instead of being silently rewritten or dropped after saving
- A failed database transaction now **logs the real cause first**, so a connection lost mid-commit is diagnosable instead of being replaced by the rollback's own error
- Batch subnet creation **refuses a selection that mixes a fully-encompassing subnet with siblings**, which previously discarded the siblings and reported success
- The Create form computes the subnet mask locally instead of calling an endpoint that never existed, removing a failed request and a discarded error-page render on every keystroke

### Bug Fixes
- Widening a `/31` or `/32` could **leave a host IP sitting on the subnet's network address** — a state the create path refuses, so the address could not be re-added once removed. Host IPs are now validated on any CIDR change, not only increases
- Submitting an out-of-range CIDR on the Subnet Edit form **returned a server error page** and lost the form; it now redisplays with the validation message
- After an edit conflict, the Edit form showed a **"Last Modified" time that was never saved** — the reload read back the rejected in-memory edit rather than the database
- Collapsing a subnet in the tree left its toggle showing the **expanded icon**, and childless subnets were repainted as expandable after Expand All, Collapse All, or any toggle click
- The Details page's Create-Subnet dialog reported **"0 IP addresses" for `/31` and `/32`**, contradicting the server and the Create page, which both count them as usable
