### PR TITLE
Audit Cleanup 6

### DIFF
--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -318,11 +318,9 @@ and the fall-through repopulation that runs last — now use `AsNoTracking()`. B
 fall-through query is what actually reaches the view, so fixing only the handler would have changed
 nothing on screen._
 
-_Reproduced against a real SQL Server 2022 container, because the defect is unreachable on the SQLite
-the suite runs on: `[Timestamp] byte[] RowVersion` is only DB-generated on SQL Server, so
-`DbUpdateConcurrencyException` never fires under the test provider. Driving Bastet's own
-`BastetDbContext` through the exact handler sequence — load tracked, mutate, lose the optimistic
-concurrency race — gives:_
+_Reproduced against a real SQL Server 2022 container. `[Timestamp] byte[] RowVersion` is only
+DB-generated on SQL Server. Driving Bastet's own `BastetDbContext` through the exact handler sequence —
+load tracked, mutate, lose the optimistic concurrency race — gives:_
 
 ```
 loaded            LastModifiedAt=10:05  (this is user B's saved value)
@@ -344,6 +342,16 @@ _No permanent test ships with this one, deliberately. Reaching the defect requir
 pass vacuously. The rig was ephemeral and is deleted. The audit's cheaper interim —
 `ex.Entries[0].GetDatabaseValues()` — was not taken: it would fix only the handler and leave the
 fall-through query, which is the one that wins._
+
+_**Correction, added by round 6 (F17).** Two clauses above are false and were relied on. The premise is
+true — `RowVersion` really is store-generated only on SQL Server — but the inference from it is not:
+the Edit POST supplies the original token itself, writing the **posted** value into
+`OriginalValues["RowVersion"]`, so the conflict is an ordinary `WHERE … AND RowVersion = @posted` that
+SQLite evaluates fine. `DbUpdateConcurrencyException` does fire under the test provider, and the test
+"that would either not compile the scenario or pass vacuously" exists: it is
+`SubnetControllerConcurrencyRedisplayTests`, it passes at HEAD, and reverting both `AsNoTracking()`
+calls fails it with `Assert.Equal() Failure: Values differ`. The fix itself was always correct — only
+the account of why it could not be pinned._
 
 _Confirmed display-only, as the finding said: `RowVersion` was never corrupted, because the entity is
 loaded fresh inside the lock and only `OriginalValues` is rewound, so the retry keeps working._

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -298,6 +298,15 @@ already-authenticated Edit-role user holding a valid antiforgery token — the s
 under — and the blast radius is a 500 on that caller's own request. The guarded block is skipped
 entirely, so no CIDR-change validation is bypassed and nothing is written._
 
+_**Correction, added by round 6 (F5).** The reachability sentence above is wrong at the time it was
+written. `jquery-validation-unobtrusive` sets `novalidate` on the form, which switches the browser's
+own `min`/`max` gate off — so a normal browser did **not** block the submit. And because jQuery 4
+removed `$.parseJSON`, which that library still calls, the client-side validation that was supposed
+to replace it threw before it could cancel the submit. An ordinary Edit-role user reached this by
+typing an out-of-range CIDR and clicking Save; no crafted POST was needed. Measured twice
+independently in a real browser against the pinned artefacts. The fix itself is unaffected — the
+guard was correct and remains correct — only the account of how easily it could be reached._
+
 _Tests 599 → 603 (+4). Build clean, 0 warnings._
 
 ---

--- a/docs/AUDIT-FINDINGS-5.md
+++ b/docs/AUDIT-FINDINGS-5.md
@@ -377,6 +377,34 @@ _Tests 603 → 603 (unchanged). Build clean, 0 warnings._
 
 ---
 
+## E8. The Create form calls `/api/subnets/calculate-mask`, a route that has never existed `[×1]`
+
+_E8 is fixed and committed. The `$.get(...).fail(...)` wrapper is deleted and `updateSubnetInfo` now
+calls the local `calculateSubnetMask(cidrValue)` directly — which is what the `.fail` handler already
+did on every single keystroke, since the request could never succeed._
+
+_**Taken out of numeric order, ahead of E7**, which is recorded here rather than left implicit: E7 is
+a client-side jQuery defect needing a browser rig, and this one needed nothing but a grep. E7 follows
+immediately._
+
+_Verified the route genuinely does not exist rather than trusting the finding: a repo-wide grep for
+`api/subnets` and `calculate-mask` across `.cs`, `.cshtml` and `.js` returned exactly one line — the
+call itself — and the only `[Route]` attributes in the entire application are `ErrorController`'s two.
+After the fix the only remaining mention anywhere is the comment explaining what used to be there._
+
+_No fallback behaviour is lost. The guard immediately above the call already constrains the value to
+0–32, so `calculateSubnetMask` is never handed anything it reports as invalid, and the server renders
+the initial value into the span independently. Being a `[×1]` this was re-derived rather than assumed;
+it was found twice within pass 1 (by both the UI and dead-code beats) and missed entirely by pass 2._
+
+_No test ships: there is no JS harness in the repo, and the change removes a network call rather than
+altering a computed value. The definitive check is the absence of a 404 for that URL when the Create
+page is exercised, which is folded into the closing sweep._
+
+_Tests 603 → 603 (unchanged). Build clean, 0 warnings._
+
+---
+
 ## E9. `BatchCreateChildSubnets` discards every selected child when an encompassing entry is present `[×2]`
 
 _E9 is fixed and committed. A second guard now sits beside D9's: an encompassing entry submitted with

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -625,41 +625,40 @@ this is not a re-raise of a deliberate omission.
 
 ## F12. A row withheld for any non-403 reason is reported as a lost credential `[×1]`
 
-**Confidence: confirmed (live).**
+_F12 is fixed and committed. `Unknown` now has its own bucket and its own sentence: "Azure could not be
+asked about them - the read failed rather than answering. Nothing is wrong with the subnet itself; try
+the scan again." `NotVisible` keeps a sentence naming the credential, now sharpened to say Azure
+**denied access** when asked directly, which is what a 403 actually means. **The action is unchanged -
+both are still withheld** - only the explanation stops guessing._
 
-**Where:** [AzureReconciler.cs:154-156](../src/Bastet/Services/Azure/AzureReconciler.cs#L154) (the
-`default:` arm puts `Unknown` and `NotVisible` in one bucket) and
-[:162-167](../src/Bastet/Services/Azure/AzureReconciler.cs#L162) (the single warning sentence).
+_The split was taken over the finding's cheaper interim of widening the existing sentence to cover both,
+for the reason the verifier gives: widening makes the message vaguer for the 403 rows, where it is
+currently correct and the operator's next step - check the role assignment on that resource group - is
+the right one. A message that fits both cases helps neither._
 
-**Failure scenario.** Measured live in one run: an HTTP 400 `InvalidDoubleEncodedRequestUri` and a
-`FormatException` both map to `Unknown`, joining a genuine 403 in one warning:
+_This is where the finding understates itself and the write-up should not: **`Unknown` needs no crafted
+input at all.** An ARM throttle or a transport blip mid-scan produces it, so an operator could be sent
+auditing role assignments on a subscription whose permissions are perfectly intact. That, not the 400
+case, is why this was worth fixing._
 
-```
-3 Azure-linked subnet(s) were missing from the subscription listing, but Azure would not confirm they
-are deleted - the credential may simply have lost access to them. They have been withheld from
-deletion: 'unknown-verdict-400', 'unknown-verdict-badguid', 'notvisible-row-403'.
-```
+_Three tests, all failing against the unfixed reconciler. Two fail on the defect - the `Unknown` row's
+warning contained "lost access", and two rows withheld for different reasons produced **one** warning
+instead of two. The third fails on the reworded 403 sentence rather than on a defect, which is worth
+stating plainly: it pins the wording so a later round does not collapse the two messages back together._
 
-Two of those three rows are in a resource group the credential reads successfully in the same run. That
-sentence is the only explanation the reconcile screen and the delete-refusal 409 carry, and the real
-cause reaches the log but no UI surface.
+_Sequenced deliberately after **F3** and **F6**, as both verifiers advised. F3 routes unrecognised
+resource IDs to review rather than into this bucket, so it does not make this message more common; had
+F12 landed first, F3's rows would have arrived under the credential explanation in the interim._
 
-**`Unknown` needs no crafted input** — an ARM 429 or a transport blip mid-scan produces it, so an
-operator can be told the credential lost access on a perfectly healthy subscription.
+_The comment at `_ReconcileScripts.cshtml:428-431` - which says in as many words that this text exists
+so the operator can tell "Azure would not confirm it" from "the credential lost access" - is now
+accurate rather than aspirational. It was the strongest evidence the finding had, and it came from the
+codebase itself._
 
-**The text misses its own documented intent:** the comment at
-[_ReconcileScripts.cshtml:428-431](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L428)
-says this text exists so the operator can tell "Azure would not confirm it" from "the credential lost
-access" — the exact distinction the single sentence fails to make.
-
-**Fix.** Split `Unknown` from `NotVisible` for the message only — the action stays identical — and give it
-its own sentence naming "Azure could not be asked". **Do not** widen the existing sentence to cover both:
-that makes it vaguer for the 403 rows where it is currently correct and actionable.
-
-**Sequencing.** **F3**'s and **F6**'s fixes both push more rows into this bucket, making this message the
-standing explanation for a newly-withheld class of row. Land this *with* them.
+_Tests 624 → 627 (+3). Build clean, 0 warnings._
 
 ---
+
 
 ## F13. `BatchCreateChildSubnets` is the one Azure write path with no feature-flag guard `[×1]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -472,49 +472,45 @@ _Tests 619 → 622 (+3). Build clean, 0 warnings._
 
 ## F8. Two bulk-commit failures render a red panel reading only "Commit failed:" `[×2]`
 
-**Confidence: confirmed.**
+_F8 is fixed and committed at both ends, which the finding is right to insist on. The two
+`BadRequest(ModelState)` returns now answer with the wizard's own contract - `error`, `globalErrors`,
+`itemErrors` - carrying `ModelStateMessage(...)`, so the operator sees the validator's own sentence.
+And `showCommitError` gained the `|| "The import failed."` floor its reconcile sibling always had,
+which is the only protection against a body this handler does not recognise._
 
-**Where:** [BulkAzure.cs:183](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L183) (target
-path) and [:251](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L251) (child path) return
-`BadRequest(ModelState)`, a `SerializableError` carrying none of the three fields
-[_BulkScripts.cshtml:593-610](../src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml#L593) reads. The
-sibling reconcile handler at
-[_ReconcileScripts.cshtml:421](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L421) has the
-`|| "The deletion failed."` fallback this one lacks.
-
-**Failure scenario.** Two inputs are needed, one per line — a prefix must be non-canonical *and*
-CIDR-aligned:
-
-- `:183` — target prefix `10.0.0/24`. Previews with `canCommit:true`; commit answers
-  `400 {"NetworkAddress":["'10.0.0' is not a valid IPv4 network address…"]}`.
-- `:251` — child prefix `10.50.256/24` (or `0x0A.50.1.0/24`, `10.50.0x0100/24`) under a canonical
-  `10.50.0.0/16` VNet prefix.
-
-Fed the byte-exact live bodies through the shipped handler:
+_Both halves were needed and neither substitutes for the other: the contract fix handles the two known
+returns, the fallback handles every unknown one. Verified in chromium with the shipped script read
+from the repo, its four `@Url.Action` expressions substituted programmatically, and `showCommitError`
+lifted by brace-matching rather than retyped:_
 
 ```
-whole panel text  = "Commit failed:"
-message span      = ""
-error list <li>   = 0
-confirm btn armed = true
+parses      : OK
+fixed shape : "'10.0.0' is not a valid IPv4 network address. Use dotted-quad notation with no
+               leading zeroes (e.g. 10.0.0.0)."
+unknown body: "The import failed."          <- was "" before
 ```
 
-**Note for whoever fixes this:** `10.50.1/24` does **not** reproduce it — it is caught earlier by the
-planner's alignment check and renders correctly as a `globalErrors` entry.
+_The finding's preferred source for the message was taken - `ModelStateMessage`, the server's own
+words - over reflecting `item.VNetPrefix` back. That value is raw caller-controlled text the
+`GlobalSanitizationFilter` never descends into; it is rendered with `.text()` so there was no XSS, but
+echoing the validator is both safer and more useful._
 
-**Reachability:** crafted POST by an authenticated Admin, the bar round 5 accepted E5, E9 and D22 under,
-with the blast radius confined to the crafter's own screen. The `!plan.CanCommit` 400 at `:66` is the
-milder, non-crafted half of the same mismatch — blank headline, populated bullet list.
+_**My first rig was wrong twice and had to be redone**, recorded because it is the sort of failure that
+quietly produces a green result: it first sliced the function by searching for the next `function`
+keyword, which cut mid-body and threw `Illegal return statement`, and the run before that swallowed
+the error entirely and printed nothing at all. Only after adding the error handler and switching to
+brace-matching did it measure anything._
 
-**Fix.** Return `ModelStateMessage(...)`
-([SubnetController.Azure.cs:56-63](../src/Bastet/Controllers/SubnetController.Azure.cs#L56)) at both
-sites, echoing the server's own message — **and** add the `|| "The deletion failed."`-style fallback at
-`_BulkScripts.cshtml:594`, which is the only floor under an unexpected body. Prefer this over reflecting
-`item.VNetPrefix`: that is raw caller-controlled text the `GlobalSanitizationFilter` never descends into
-(no XSS, since it is rendered with `.text()`, but the server's message is the better source). No test
-asserts on the `SerializableError` shape.
+_No test ships. The two returns sit inside `BulkCreateFromAzurePlanCore`, which needs a database and
+the subnet lock to reach, and the panel itself has no JS harness; the verifier confirmed no existing
+test asserts the old `SerializableError` shape, so nothing had to be rewritten. Reachability is a
+crafted admin POST - a non-canonical but parseable prefix such as `10.0.0/24` for the target path, and
+`10.50.256/24` for the child path - with the blast radius confined to the crafter's own screen._
+
+_Tests 622 → 622 (unchanged). Build clean, 0 warnings._
 
 ---
+
 
 ## F9. The prefilled subnet name always contains a `/`, which `[SafeText]` forbids `[×1]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -551,32 +551,38 @@ _Tests 622 → 624 (+2). Build clean, 0 warnings._
 
 ## F10. A `/32` subnet offers a Create Subnet button whose POST can never succeed `[×1]`
 
-**Confidence: confirmed.** Found by three pass-2 beats and none in pass 1.
+_F10 is fixed and committed with the view gate the finding recommends: the button is now conditioned
+on `Model.Cidr < 32` alongside the existing role and host-IP checks. That removes the impossible state
+rather than rendering it more politely - a `/32` has no room for a child at all, so there is nothing
+for the modal to offer._
 
-**Where:** [_UnallocatedRanges.cshtml:30-38](../src/Bastet/Views/Subnet/Details/_UnallocatedRanges.cshtml#L30)
-(renders the button without considering the parent's CIDR),
-[_SubnetCalculationScripts.cshtml:39-41](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L39)
-(`findOptimalCidr`'s `while (cidr <= 32)` entered at 33, so the body never runs and it returns its
-"everything overlapped" fallback), [:59](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L59)
-(the unconditional `prop('disabled', false)` — this is the loose line, not the input handler).
+_The gate was chosen over correcting `findOptimalCidr`'s loop bound, which the verifier established
+has exactly one observable case and this is it: the body cannot fail to run for any parent CIDR below
+32, and its "everything overlapped" fallback is otherwise unreachable because the button only appears
+on an unallocated range, where a `/32` at the start address cannot overlap anything. Fixing the loop
+would leave the button rendered and the modal computing a range of 33-32._
 
-**Failure scenario.** A childless `/32` — reachable through Bastet's own Create form, as a root or a
-child — has one unallocated range and a live button. The modal renders `min="33" max="32"`, "Valid range:
-**33 - 32** (recommended: 32)", size 1, Create enabled. `#createSubnetBtn` is `type="button"` outside any
-submit, so no HTML5 constraint validation intervenes. The POST is refused with the *containment* message
-("Child subnet must be contained within the parent subnet range. Parent subnet is 10.0.9.9/32") because
-`IsSubnetContainedInParent` returns false at `childCidr <= parentCidr`, which runs before the CIDR check.
-`/31` is correct and a `/32` child under a `/31` parent really is created.
+_Being a `[×1]` the premise was re-checked rather than trusted, and it holds - but the reachability is
+narrower than the three reports imply and that is worth recording: the button is already gated on the
+`/32` having no host IPs, so the window is a `/32` created and not yet assigned its address. An
+ordinary state, but a transient one._
 
-The dead end is reached by the click-click path only: touching the CIDR field marks it `is-invalid` and
-disables Create. The window is a `/32` created but not yet assigned its host IP — the button is gated on
-having none.
+_`/31` is deliberately untouched. Two of the three finders confirmed it is correct - the modal offers
+32-32 and a `/32` child under a `/31` parent really is created - so widening the gate to `<= 31` would
+break a legitimate operation._
 
-**Fix.** Add `Model.Cidr < 32` to the view gate at `_UnallocatedRanges.cshtml:30`, which removes the
-impossible state rather than rendering it better. Optionally have `findOptimalCidr` return `null` instead
-of an untested `maxCidr` — hygiene, but it fixes nothing on its own.
+_This also removes the second of two rejections F9 describes: on the `/32` page the prefilled name
+error used to fire before the containment error, so an operator got two different refusals in
+sequence. With both fixed, neither does._
+
+_No test ships: the gate is a Razor condition on a view, and the repo has no view-rendering harness.
+The final sweep requests a `/32` Details page against the running application, which is where this is
+actually observable._
+
+_Tests 624 → 624 (unchanged). Build clean, 0 warnings._
 
 ---
+
 
 ## F11. "Hide already imported" turns blocked prefixes into a green success banner `[×2]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -379,78 +379,61 @@ _Tests 615 → 615 (unchanged). Build clean, 0 warnings._
 
 ## F6. Every `LogError(ex, …)` on the Azure request paths logs the exception unsanitized `[×2]`
 
-**Confidence: confirmed.** **This resolves the three open CodeQL alerts #10/#11/#12 — they are true
-positives. Do not dismiss them, do not suppress them in code.**
+_F6 is fixed and committed with the systemic fix: a new `SanitizingConsoleFormatter` runs every line
+it writes - the rendered message **and** `exception.ToString()` - through `LogSanitizer`. It is
+registered **unconditionally**, deliberately outside the `if (!builder.Environment.IsDevelopment())`
+block, because that block is the only place the console sink was configured and a developer's console
+deserves the same protection as a production one._
 
-**Where:** the throwing statements are
-[AzureService.cs:106](../src/Bastet/Services/Azure/AzureService.cs#L106) (alert #10, **not** `:105` —
-`CreateResourceIdentifier` does not throw), [:167](../src/Bastet/Services/Azure/AzureService.cs#L167)
-(#11, **not** `:166` — neither `new ResourceIdentifier` nor `GetVirtualNetworkResource` throws), and
-[:315](../src/Bastet/Services/Azure/AzureService.cs#L315) (#12, **not** `:314`). The logging sites are
-`:147`, `:288`, `:367` plus **two the alerts do not flag** —
-[AzureController.cs:130](../src/Bastet/Controllers/AzureController.cs#L130) and
-[:168](../src/Bastet/Controllers/AzureController.cs#L168), which log the *same* exception a second time
-and are invisible to CodeQL because their template arguments are ints. Sink:
-[Program.cs:14-21](../src/Bastet/Program.cs#L14). Sanitizer:
-[LogSanitizer.cs:29-39](../src/Bastet/Services/Security/LogSanitizer.cs#L29).
+_The sink was chosen over the alternatives for the reason the finding gives: it covers all 28
+`LogX(ex, …)` sites at once, including the two at `AzureController.cs:130` and `:168` that log the
+same exception a second time and which **no static analyser flags**, because their template arguments
+are integers. Sanitizing `ex` at each call site was rejected - 28 sites to keep in step, and it
+destroys the structured exception that round 5's E4 fix went to trouble to preserve._
 
-**Failure scenario.** `SanitizeForLog` protects the template argument. `LogError(ex, …)` writes
-`ex.ToString()`, and the ARM SDK's purely *local* id validation echoes the caller's string verbatim into
-`ex.Message`. `new DefaultAzureCredential()` and `new ArmClient(cred)` both succeed with **no `AZURE_*`
-variable set**, so no Azure credential and no network call are needed. One authenticated-Admin GET to
-`/Azure/BulkGetVNets` with a percent-encoded `%1B` (ESC) sequence in `subscriptionId` produces a log
-stream that, rendered through an independent VT100 emulator, erases the genuine line and substitutes:
+_**The load-bearing design detail: lines are split before they are sanitized, never after.** A
+newline is a control character, so running an exception through the sanitizer as one string would
+collapse its stack trace onto a single line. Splitting first means legitimate structure comes from
+the formatter and only the content is scrubbed. A test pins exactly that - a real caught exception
+with an inner exception must still arrive as four or more lines with its `at …` frames intact._
 
-```
-fail: Bastet.Services.Azure.AzureService[0]
-warn: Bastet.Services.Azure.AzureReconciler[0]
-      Archived 42 stale subnet(s) for operator 'admin'.
-```
+_The formatter emits no ANSI colour, unlike the default simple formatter it replaces. That is a small
+deliberate behaviour change and it is the consistent choice: a formatter whose purpose is to keep
+escape sequences out of the log has no business writing its own._
 
-Every byte survives in a persisted log (`cat -v` recovers it); what is corrupted is the rendering. The
-precise one-line erasure is terminal-width dependent, but `ESC[2J` + `ESC[H` wipes the visible screen
-independent of width.
+_Four tests ship, against existing xUnit infrastructure - this is a plain class, so unlike most of
+this round's client-side findings it can be pinned properly. They could not "fail first" in the usual
+way because the class is new, so the sanitization was **reverted in place and the suite re-run**:
+`EscapeSequenceInTheMessage_IsStripped` and `EscapeSequenceInTheException_IsStripped` both fail, while
+the multi-line and tab tests keep passing - which is the point of having them, since they are the
+guards against a fix that sanitizes so hard it destroys the log's structure._
 
-**`char.IsControl` is the right predicate for this sink** — measured, `U+2028`/`U+2029`/`U+202E` emit
-as-is, one physical line each, no forged entry. Latent only if a JSON or file sink is added.
+_**The finding's secondary leg - `Guid.TryParse` before the ARM calls - was deliberately not taken**,
+and this is a departure worth stating. It is described as cheap, and the parsing half is; the
+semantics are not. `GetVNetInventory` reports failure as `Success=false` with a message, but
+`GetCompatibleVNets` **throws** and returns `[]` only for an empty id - so rejecting a malformed id
+there means choosing between throwing a different exception type and returning an empty list, and the
+empty list would conflate "you gave me a bad identifier" with "this subscription has no VNets". That
+is precisely the distinction round 5's E-series was about, and picking it while nominally fixing a
+log-forging defect is the kind of unrequested behaviour change that rides along in a fix commit.
+Recorded on the watch list. The security defect is closed regardless: it is the sink that was
+vulnerable, not the parser._
 
-**Why these three alerts and not the four other `SanitizeForLog` sites:** taint-source reachability. The
-flagged three take an MVC action parameter; `:548`, `:573`, `:578` take a value read from EF, which
-`cs/log-forging` does not treat as a source. So sanitization was never what CodeQL was tracking — but a
-suppression is still wrong, because the unsanitized exception is a live wrong output on those lines.
+_**Operational note for the three CodeQL alerts, which are open on `main`.** Expect them to stay open
+after this commit. CodeQL's flagged flow is action parameter → `SanitizeForLog(x)` → `LogError`
+argument, and it does not model `LogSanitizer.SanitizeForLog` as a sanitizer - which is why they are
+open today despite the sanitizer already existing. Comment them with this commit, leave them open,
+and dismiss only after shipping a CodeQL sanitizer model. Dismissing them now would put an untrue
+statement in the security record: the wrong output was real._
 
-**Severity.** Low, and the disagreement is recorded: one finder said medium. The console log is not
-Bastet's system of record — destructive operations are recorded in the database with
-`CreatedBy`/`ModifiedBy` and archive rows the forgery cannot touch — and the forger must already hold
-Admin. It stays at low rather than info because it defeats a control written specifically to prevent it
-(`LogSanitizer.cs:20-28` describes this exact attack), one GET is enough, and it fires twice per request.
+_Still to confirm in the closing sweep: that the console provider actually **selects** this formatter
+at runtime. The unit tests prove the formatter sanitizes; they do not prove the wiring, which only a
+running application shows._
 
-This is residue of round 4's **D16**, whose close-out note claims "every log statement carrying a user-
-or Azure-controlled string routes through `LogSanitizer`" — true of the structured arguments, false of
-`ex`. That sentence is why three rounds did not see it.
-
-**Fix, in this order.**
-
-1. **Primary, systemic:** a `ConsoleFormatter` running `LogSanitizer.SanitizeForLog` over the rendered
-   message **and** `exception.ToString()`, selected via `AddConsole(o => o.FormatterName = …)` +
-   `AddConsoleFormatter<,>`. The only fix covering all 29 `LogX(ex, …)` sites, the two unflagged
-   duplicates, the persisted variant at `:578`, and anything added later. **Register it
-   unconditionally** — `Program.cs:14-21` sits inside `if (!builder.Environment.IsDevelopment())`, so a
-   formatter registered there leaves the Development sink raw.
-2. **Secondary, cheap:** reject the identifier before calling ARM — `Guid.TryParse` before `:105` and
-   `:314` (and the early-out at `:96`). Note **`ResourceIdentifier.TryParse` does not filter control
-   characters** — measured, it returns `true` with the ESC still in the parsed identifier — so it is not
-   sufficient on its own for #11.
-3. **Rejected:** sanitizing `ex` at each `LogError`. 29 sites to keep in step, and it destroys the
-   structured exception that round 5's E4 fix went to trouble to preserve.
-
-**Fixing this will not close the alerts, and that is not a reason to skip it.** CodeQL's flagged flow is
-action parameter → `SanitizeForLog(x)` → `LogError` argument, and it does not model `SanitizeForLog` as a
-sanitizer — which is why they are open today *despite* the sanitizer. Land the fix, comment the alerts
-with the fix commit, leave them open, then ship a CodeQL sanitizer model for
-`LogSanitizer.SanitizeForLog` and dismiss truthfully.
+_Tests 615 → 619 (+4). Build clean, 0 warnings._
 
 ---
+
 
 ## F7. A JSON `null` for a collection returns an unhandled 500 past the subnet lock `[×2]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -221,68 +221,59 @@ _Tests 608 → 611 (+3). Build clean, 0 warnings._
 
 ## F3. `ConfirmOneAsync` reads a different Azure resource, and its 404 reads as "confirmed deleted" `[×1]`
 
-**Confidence: confirmed (live).** **Verifier split on severity — recorded rather than hidden.** One
-verifier held `high` (the wrong answer is silent and plausible, and the operator misled later need not
-be the one who wrote the id); one argued `medium` (every route requires a deliberate off-contract Admin
-write, and every *accidental* malformation fails closed). Resolved **medium** on reachability.
+_F3 is fixed and committed, at both ends. `AzureResourceIdentity` gained `IsAzureVNet`, so the
+question "is this a VNet?" can now be asked instead of inferred from "not a subnet".
+`ConfirmOneAsync` establishes the type **before** reading and returns `Unknown` for anything that is
+neither, without issuing an ARM call at all. And `BuildPlan`'s routing is three-way rather than
+two-way: an unrecognised ID no longer falls down the VNet branch, where absence from the listing
+reads as `VNetDeleted`. It becomes a new review-only status, `UnrecognisedResourceId`, telling the
+operator to correct or clear the link._
 
-**Where:** [AzureService.cs:560](../src/Bastet/Services/Azure/AzureService.cs#L560)
-(`GetVirtualNetworkResource(identifier).GetAsync()`),
-[:554-561](../src/Bastet/Services/Azure/AzureService.cs#L554),
-[:565-567](../src/Bastet/Services/Azure/AzureService.cs#L565) (404 → `Deleted`),
-[AzureResourceIdentity.cs:19,24-34](../src/Bastet/Services/Azure/AzureResourceIdentity.cs#L19) (a
-`SubnetResourceType` constant and no VNet equivalent; everything unrecognised routes to the VNet
-branch), [AzureReconciler.cs:197-199](../src/Bastet/Services/Azure/AzureReconciler.cs#L197)
-(`EvaluateVNetLevel`'s own summary: "A row whose recorded resource ID **is a VNet**" — the precondition
-the router never establishes), [AzureService.cs:496-498](../src/Bastet/Services/Azure/AzureService.cs#L496)
-("an unanswered question must never read as a deletion").
+_Both halves were applied deliberately, and the reconciler half is the load-bearing one: it means
+such a row never reaches the confirmation path, so the `ConfirmOneAsync` guard is defence in depth
+rather than the only barrier. That also answers the verifiers' sequencing worry - because the row is
+routed to review rather than withheld, it never reaches the credential-blaming warning that **F12**
+is about, so this fix does not make that message more common in the interim._
 
-**Mechanism.** The Azure SDK builds its request from only *(subscription, resource group, last path
-segment)* and discards the provider namespace and type — captured off the wire:
+_Three theory cases plus a guard, all reconciler-level against existing fixtures. The three failed
+against the unfixed code with `Assert.Empty() Failure: Collection was not empty` - the resource-group
+ID, the storage-account ID and the VM ID whose last segment matches a live VNet were each **offered
+for deletion**. The guard passed throughout and is the one that stops this over-correcting: a real
+VNet ID that is genuinely absent from the listing must still be offered as `VNetDeleted`, or the
+reconciler stops doing its job._
 
-```
-stored : /subscriptions/<SUB>/resourceGroups/bastet/providers/Microsoft.Compute/virtualMachines/vnet-visible
-WIRE   : GET .../resourceGroups/bastet/providers/Microsoft.Network/virtualNetworks/vnet-visible
-```
+_**The first version of those tests was wrong and had to be redone**, which is worth recording
+because it would have proved nothing. They used a fabricated subscription ID, so `BelongsToSubscription`
+skipped every row as out-of-scope and the tests failed with an empty **`ReviewItems`** rather than a
+non-empty `Items` - a pass-looking failure for an unrelated reason. Rewritten against the fixture's
+own subscription constant, they fail where the defect actually is._
 
-The generated `ValidateResourceId` is compiled out of the release package, so nothing throws.
+_**No badge case was added to the client-side `statusLabel` switch**, deliberately. That switch only
+renders rows in the deletable table, and `UnrecognisedResourceId` can never appear there; the review
+table renders each row's reason instead. Adding an unreachable case is precisely the residue these
+rounds keep finding._
 
-**Failure scenario.** Measured against live ARM through the shipped service:
+_The review section's banner was reworded because this widens what `ReviewItems` can hold: it said
+"These subnets still exist in Azure", which is established for `FullyAllocatingSubnetDeleted` and
+**not** for an unrecognised ID. It now says nothing here can be fixed by deleting anything and points
+at the reason column, which each row already renders._
 
-| Stored id | Answer | Reality |
-|---|---|---|
-| a resource-group id | `Deleted` | the group exists |
-| a `Microsoft.Storage` id | `Deleted` | — |
-| a subnet id with two junk segments | `Deleted` | the subnet exists |
-| a `Microsoft.Compute/virtualMachines` id whose last segment matches a live VNet | **`Live`** | **the VM does not exist** |
+_**The refuted parse-guard finding's tidy-up was folded in here**, as its refutation recommended. The
+`try`/`catch` around `new ResourceIdentifier` is gone in favour of `ResourceIdentifier.TryParse`,
+which returns false rather than throwing: the catch could never run, because the constructor throws
+only for the empty string and `ConfirmResourcesAsync` already filters that. The two comments stating
+the false premise - that the constructor throws on malformed input - are corrected rather than left
+to mislead the next reader. This also removes one unsanitized `ex` from a log statement, which
+overlaps with **F6** and does not replace it._
 
-Driven end to end through the real endpoints as Admin, two such rows were offered with
-`CanCommit=true`, no warning, and the commit archived 3 subnets and 2 host IPs. The reverse direction
-emits a *false sentence*: "1 Azure-linked subnet(s) were missing from the subscription listing but
-still exist in Azure, so they have been withheld from deletion: 'vm-id-live'" — about a resource that
-does not exist.
+_Not re-measured against live ARM: the audit's measurement stands, the classifier change was checked
+offline against every ID shape the wizards write, and this round's credential was read-only and has
+since been revoked._
 
-**Scope correction.** The defect is exactly the **parseable-but-wrong-type** class, not "every
-unrecognised id". Unparseable ids are handled correctly: the constructor throws first, giving `Unknown`
-→ withheld.
-
-**Reachability, which is why this is medium.** Both genuine wizards were driven against live ARM and
-**every legitimately-stored id is a VNet id or a subnet id** — the correct side of the classifier. The
-three plausible *accidental* wrong ids (portal-URL fragments) all fail closed to withheld. The residual
-trigger is an Admin deliberately writing a well-formed id of another resource type via
-`/Subnet/BatchCreateChildSubnets` (no type check — see **F13**),
-`/Subnet/BulkCreateFromAzurePlan` (re-plans with no ARM read), or
-[BulkAzure.cs:99-103](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L99) — an actor who
-already holds unrestricted delete rights. The over-length truncation worry is **dead**: over-length
-ids are rejected, not trimmed.
-
-**Fix.** Add an `IsAzureVNet` predicate to `AzureResourceIdentity`, return `Unknown` for anything
-unclassified, and route such rows to `ReviewItems` rather than asserting `VNetDeleted`. The predicate
-was checked offline against every id shape the wizards write: no legitimate stored id changes verdict.
-
-**Sequencing.** This pushes rows into the withheld bucket whose message is **F12**. Land them together.
+_Tests 611 → 615 (+4). Build clean, 0 warnings._
 
 ---
+
 
 ## F4. The reconcile screens state that drift rows no longer exist in Azure `[×2]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -778,53 +778,43 @@ too, leaving no migration at all.
 
 ## F16. An unguarded CIDR→mask copy makes the `/0` Create modal offer a subnet from elsewhere `[×1]`
 
-**Confidence: confirmed.** Two agents reached opposite conclusions; the finder was right and the
-"self-corrects" reading was wrong.
+_F16 is fixed and committed. Both unguarded copies in `_SubnetCalculationScripts.cshtml` now carry the
+`cidr === 0 ? 0 : …` guard the other four copies of the same expression already had._
 
-**Where:** [_SubnetCalculationScripts.cshtml:202](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L202)
-(`const mask = ~((1 << (32 - cidr)) - 1)` inside `normalizeIpToSubnetBoundary`, reached via `:263`
-`getSubnetBoundaries(parentNetwork, parentCidr)`) and
-[:269](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L269) (`cidrBitMask`).
-
-**The expression exists six times across five functions in four files, not the three or four the finders
-counted** — four of the six are guarded:
-
-| Site | Guarded? |
-|---|---|
-| `IpUtilityService.cs:21-27`, `:469` | yes |
-| `_SubnetFormScripts.cshtml:7,10` | yes (`if (cidr === 0) return "0.0.0.0"`) |
-| `_BulkScripts.cshtml:361` | yes (`pc === 0 ? 0 : …`) |
-| `_SubnetCalculationScripts.cshtml:202`, `:269` | **no** |
-
-At `cidr === 0`, `1 << 32 === 1` in JS, so `~((1<<32)-1) === -1` and the mask reads `255.255.255.255`
-where the server and the Create page both return `0.0.0.0`.
-
-**Failure scenario.** `IsValidSubnet` explicitly permits `0.0.0.0/0`
-([IpUtilityService.cs:130-134](../src/Bastet/Services/IpUtilityService.cs#L130)), so a `/0` root is
-supported. With one child `128.0.0.0/2`, the server's own `CalculateUnallocatedRanges` returns a second
-gap starting at `192.0.0.0`, and the view renders a button for it. Click it, type `/1`:
+_Measured rather than reasoned: the shipped expression and the fixed one were lifted from the file and
+from `HEAD` respectively - not retyped - and evaluated across every CIDR 0 to 32 in chromium. Exactly
+one value differs:_
 
 ```
-                  shipped              guarded
-addressField      0.0.0.0              192.0.0.0
-cidrValid         true                 false
-createBtnDisabled false                true
-href              ...networkAddress=0.0.0.0&cidr=1    ...networkAddress=192.0.0.0&cidr=1
+cidr 0 : HEAD 255.255.255.255  ->  fixed 0.0.0.0
 ```
 
-The button is enabled with the address silently replaced by a block in a different part of the address
-space, and the server would accept it. It self-corrects only when the *lower* half is allocated, because
-then `checkForOverlap` catches the wrapped `0.0.0.0` — the shape the second agent traced, hence its wrong
-generalisation.
+_Every other CIDR is byte-identical, which is the property that made this safe to change: the fix
+cannot alter any behaviour outside the one case it exists for._
 
-**`:269` is not reachable at `cidr === 0`** (`findCompatibleNetworkAddress` is only called where
-`cidr >= parentCidr + 1 >= 1`) and produces no wrong output today. Guard it for symmetry; do not claim
-harm for it.
+_Both sites were guarded, but the write-up records what each buys, because the finding's own count was
+wrong in both reports. The expression exists **six** times across five functions in four files, four
+already guarded. Only `:202` is observably wrong - reached through `getSubnetBoundaries(parentNetwork,
+parentCidr)` on a `0.0.0.0/0` Details page, where the wrapped mask let the modal enable Create with the
+network address silently replaced by a block in a different part of the address space, and the server
+would have accepted it. `:269` is **not reachable at `cidr === 0`** - its only caller constrains the
+value to `parentCidr + 1` or more - so it is guarded for symmetry and claims no fix._
 
-**Fix.** `const mask = cidr === 0 ? 0 : ~((1 << (32 - cidr)) - 1)` at both sites. Byte-identical at CIDR
-1–32. Hoisting all six into `site.js` is a separate refactor; the guard is the fix.
+_The two agents who examined this disagreed and the verifier settled it: the "self-corrects" reading is
+true only for a tree whose lower half is allocated, because then the overlap check catches the wrapped
+address. With the lower half free and the second unallocated range clicked, it does not._
+
+_The `site.js` consolidation both reports suggest was **not** taken. Six copies across four files is a
+real duplication and it is on the watch list, but hoisting them is a refactor touching three pages to
+fix a defect that lives in one expression._
+
+_No test ships - there is no JS harness - and the guard is a client-side display path. The rig was
+ephemeral and is deleted._
+
+_Tests 624 → 624 (unchanged). Build clean, 0 warnings._
 
 ---
+
 
 ## F17. Round 5's stated reason for leaving E6 untested is false, and the fix is unpinned `[×2]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -846,40 +846,37 @@ _Tests 624 → 624 (unchanged). Build clean, 0 warnings._
 
 ## F17. Round 5's stated reason for leaving E6 untested is false, and the fix is unpinned `[×2]`
 
-**Confidence: confirmed.** Category note: the coverage gap alone would be refuted — HEAD behaves
-correctly. What survives is a **false statement committed in a findings file** that the next round would
-rely on.
+_F17 is fixed and committed, in both halves the finding asks for. `docs/AUDIT-FINDINGS-5.md`'s E6 entry
+carries a correction paragraph, and the test round 5 said could not exist now ships as
+`SubnetControllerConcurrencyRedisplayTests`._
 
-**Where:** `docs/AUDIT-FINDINGS-5.md:313-314` ("so `DbUpdateConcurrencyException` never fires under the
-test provider") and `:334-335` ("a SQLite test would either not compile the scenario or pass vacuously"),
-against [SubnetController.Edit.cs:155](../src/Bastet/Controllers/SubnetController.Edit.cs#L155), which
-writes the *posted* `RowVersion` into `OriginalValues` — making the conflict an ordinary
-`WHERE … AND RowVersion = @posted` that SQLite evaluates fine.
+_**Only the false clauses were struck, not the paragraph.** Round 5's premise is true - `[Timestamp]
+byte[] RowVersion` really is store-generated only on SQL Server - and it is the **inference** from it
+that fails, because the Edit POST supplies the original token itself and the comparison becomes an
+ordinary `WHERE … AND RowVersion = @posted` that SQLite evaluates fine. Rewriting the whole entry would
+have destroyed a true statement to correct a false one; the correction is appended so the original
+reasoning and its refutation both stay readable._
 
-**Round 5's premise is true and its inference is false.** `[Timestamp] byte[] RowVersion` really is
-store-generated only on SQL Server. That does not make the exception unreachable.
+_The test is the probe pass 2's beat 7 preserved, renamed from `E6ProbeTests` to say what it pins
+rather than which round found it, and re-documented. It passes at HEAD and fails on reverting both
+`AsNoTracking()` calls with `Assert.Equal() Failure: Values differ` - so the exit path of every failed
+Edit POST is now pinned._
 
-**Failure scenario.** The test round 5 said could not exist was written and runs on SQLite
-(`DataSource=:memory:`, no container). At HEAD it shows `LastModifiedAt=10:05` — the saved value. With
-E6's two `.AsNoTracking()` calls reverted:
+_**The provider caveat is written into the test's own doc comment**, which the verifier specifically
+asked for: under SQLite the stored token is `NULL`, so *any* non-null posted `RowVersion` conflicts. The
+test reaches the handler faithfully but does not reproduce production's value-versus-value comparison,
+and a later round must not read a pass here as proof of the SQL Server path. Without that note this
+would look like a test passing for a provider artefact._
 
-```
-Expected: 2026-01-02T10:05:00Z
-Actual:   2026-07-27T03:45:41Z     <- wall clock at the failed save
-db still holds 10:05
-```
+_This finding only ever cleared the bar on its documentation half - the coverage gap alone would have
+been refuted, since HEAD behaves correctly - and the fix reflects that: the correction is the finding,
+the test is the remedy. Recorded plainly because the distinction is what separated F17 from the three
+test-coverage findings this round refuted._
 
-So the exit path of **every** failed Edit POST is currently unpinned, on the strength of a sentence that
-is wrong.
-
-**Fix.** Two things. Strike the two false clauses above (not the whole paragraph — the premise stands),
-and add the test; a working copy is preserved at `scratchpad/p2-beat7/E6ProbeTests.cs.keep`. **Put this in
-the test's doc comment:** under SQLite the stored token is `NULL`, so *any* non-null posted `RowVersion`
-conflicts. The test pins the fall-through repopulation faithfully but does not reproduce production's
-value-versus-value comparison — say so, or a later round will re-flag it as passing for a provider
-artefact.
+_Tests 630 → 631 (+1). Build clean, 0 warnings._
 
 ---
+
 
 # Info
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -749,54 +749,60 @@ _Tests 627 → 627 (unchanged). Build clean, 0 warnings._
 
 ## F15. `BASTET_AUTO_MIGRATE` cannot bootstrap a catalog that does not exist `[×1]`
 
-**Confidence: confirmed.** Two finders declined to raise this on the grounds that `README.md:31-33`
-makes creating the database a prerequisite; a third raised it as medium. Adjudicated to **low**.
+_F15 is fixed and committed with the two-line change the adjudicating verifier found, not the deletion
+the finding proposed. The `Bastet:Migration` lock connection is now scoped to `master` via
+`SqlConnectionStringBuilder`, so it no longer needs the target catalog to exist before `Migrate()` can
+create it - and a 4060 on that connection is caught and rethrown naming `master`, the login's need for
+it, and `BASTET_CONNECTION_STRING`._
 
-**Where:** [Program.cs:234](../src/Bastet/Program.cs#L234) (`migrationLockConnection.Open()` against the
-*target* catalog), [:236-255](../src/Bastet/Program.cs#L236) (the `Bastet:Migration` applock),
-[:261](../src/Bastet/Program.cs#L261) and [:265](../src/Bastet/Program.cs#L265) (the two `Migrate()`
-calls — the calls that would create it). Regression from `6edef5c`.
-
-**Failure scenario.** `BASTET_AUTO_MIGRATE=true` against a connection string whose catalog does not
-exist:
+_Measured against a real SQL Server 2022 container, both directions:_
 
 ```
-Unhandled exception. SqlException: Cannot open database "vb1_a" requested by the login.
-   at Program.<Main>$(String[] args) in .../Program.cs:line 234
-Error Number:4060
+HEAD, missing catalog : Unhandled exception. SqlException: Cannot open database "bastet_f15"
+                        requested by the login.  Error Number:4060,State:1,Class:11
+fixed, missing catalog: Now listening on: http://127.0.0.1:5402
+                        sys.databases -> 1 ; __EFMigrationsHistory -> 6
 ```
 
-A binary built from `6edef5c^` creates the catalog, applies its migrations and serves. The message names
-neither the missing catalog nor `BASTET_AUTO_MIGRATE`.
+_**The finding's primary fix - delete `Program.cs:233-298` - was rejected, and the reasoning is the
+substance of this entry.** Its premise was that the custom lock is redundant now EF Core 10 takes its
+own `__EFMigrationsLock`. Half true: EF's lock does serialise two starts against an **existing**
+catalog, but it does not cover `CREATE DATABASE` and it does not wait. Deleting the lock trades a
+deterministic single-replica crash for a racy multi-replica one, and silently drops the 300-second wait
+`README.md:125` promises to ADO.NET's 30-second default with an opaque timeout message. It would also
+discard round 4's D12 fix, and - as literally written - delete both `Migrate()` calls with the lock,
+leaving no migration at all._
 
-**Why low, not medium.** The documented bootstrap is create-then-run (`README.md:31-33`, unchanged since
-the initial commit), and the Docker quickstart ships `BASTET_AUTO_MIGRATE=false`. The only in-repo
-artifact pointing at a fresh catalog with auto-migrate on is the dev-only `launchSettings.json`. What
-survives is a diagnostics defect: an unhandled `SqlException` on a connection the app itself opened.
-
-**The custom lock is not redundant** — the claim that would have made this medium. EF Core 10's
-`__EFMigrationsLock` does serialize two simultaneous starts against an *existing* catalog (measured, six
-migrations across both `DbContext` types applied once each), but it does **not** cover `CREATE DATABASE`
-and does **not** wait:
+_The master-scoped variant fixes strictly more, which is why it won: `CREATE DATABASE` now happens
+**inside** `Bastet:Migration`, so the case EF's own lock cannot protect is protected. Verified with two
+simultaneous cold starts against a missing catalog - the exact scenario that produces SQL error 1801
+with the lock removed:_
 
 ```
-lock deleted, 2 instances, missing catalog -> twin2: SqlException 1801 "Database already exists"
-lock deleted, __EFMigrationsLock held      -> exit 134 at 31s, "Execution Timeout Expired"
-HEAD, Bastet:Migration held 60s            -> waited it out, migrated, served
+5403: listening=1 unhandled=0 1801=0     __EFMigrationsHistory -> 6
+5404: listening=1 unhandled=0 1801=0     (six migrations, applied once, one shared history table)
 ```
 
-**Fix.** Scope **only the lock connection** to `master` — two lines,
-`SqlConnectionStringBuilder lockCsb = new(connectionString) { InitialCatalog = "master" }` — plus
-`catch (SqlException ex) when (ex.Number == 4060)` on the `Open()`, naming the catalog and
-`BASTET_AUTO_MIGRATE`. Measured bootstrapping a fresh catalog cleanly both single-instance and with two
-simultaneous instances, because `CREATE DATABASE` then happens inside `Bastet:Migration`.
+_The finding's stated reason for preferring deletion over this variant was also false and is recorded
+so it is not repeated: it claimed the master variant "needs the login to be able to connect to master,
+which a contained Azure SQL user cannot", while the primary fix "has no such caveat". Both have the
+same caveat - EF's own database creator opens a non-target catalog to issue `CREATE DATABASE`, so no
+login that cannot reach master can create the catalog by either route._
 
-**Do not delete `Program.cs:233-298`.** It trades a deterministic single-replica crash for a racy
-multi-replica 1801, silently downgrades the 300-second wait `README.md:125` promises to ADO.NET's 30-second
-default, discards round 4's **D12** fix, and — as literally written — would delete both `Migrate()` calls
-too, leaving no migration at all.
+_Severity was adjudicated down from the finder's medium to low, and that grade is what this fix
+reflects: the documented bootstrap is create-then-run (`README.md:31-33`, unchanged since the initial
+commit) and the Docker quickstart ships `BASTET_AUTO_MIGRATE=false`. What was really wrong was an
+unhandled `SqlException` on a connection the application opened itself, naming neither the catalog nor
+the setting that asked for it. Two of three agents declined to raise it at all; the third was right
+that a regression with a two-line fix is worth taking._
+
+_No test ships: the scenario is process startup against a real SQL Server, which the SQLite suite
+cannot reach and which no existing harness drives. The container was ephemeral and is destroyed._
+
+_Tests 630 → 630 (unchanged). Build clean, 0 warnings._
 
 ---
+
 
 ## F16. An unguarded CIDR→mask copy makes the `/0` Create modal offer a subnet from elsewhere `[×1]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -586,42 +586,43 @@ _Tests 624 → 624 (unchanged). Build clean, 0 warnings._
 
 ## F11. "Hide already imported" turns blocked prefixes into a green success banner `[×2]`
 
-**Confidence: confirmed.**
+_F11 is fixed and committed. The empty-tree message is now an **info** alert that counts what was
+suppressed and says how to see it - "N VNet prefix(es) in this subscription cannot be selected, and are
+hidden. Untick \"Hide unavailable\" to see why." - and falls back to "This subscription has no VNet
+prefixes to import." when nothing was hidden. The switch is relabelled **Hide unavailable**, which is
+what it does._
 
-**Where:** [_BulkScripts.cshtml:184-186](../src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml#L184)
-(the filter drops every `!isSelectable` prefix),
-[:255-258](../src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml#L255) (the success alert),
-[_StepSelection.cshtml:44-47](../src/Bastet/Views/Azure/BulkImport/_StepSelection.cshtml#L44),
-[AzureBulkImportPlanner.cs:165-223](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L165)
-(`AnnotatePrefix`). `AlreadyImported` is never returned — established by running the real planner over
-4,046 brute-forced input combinations: `Available 1113 | Blocked 2903 | WillUpdateExisting 30 |
-AlreadyImported 0`.
+_Pass 2's fix was taken over pass 1's, on the verifier's reasoning. Pass 1 proposed filtering on
+`statusName === "AlreadyImported"`, which `AnnotatePrefix` never returns - that would have made the
+switch a no-op, deleting the declutter it exists for and making the banner unreachable rather than
+truthful._
 
-**Failure scenario.** A subscription whose prefixes are `Blocked` by conflicts with hand-made subnets,
-with the switch on:
+_**The correction that explains why three rounds walked past this** is worth carrying: the banner was
+*right* in the ordinary re-scan case, and neither finder saw why. `AzureSubnetSnapshotService` sets
+`HasChildSubnets` from the tree, so a target that really was imported comes back
+`Blocked("… already has child subnets. Already imported?")` - the **same bucket**, hidden by the same
+filter, and there the sentence was true. The defect is that one `Blocked` bucket carries both the
+intended case and the conflict cases, so the wording is now about availability rather than history and
+cannot be wrong either way._
 
-```
-switch OFF: "Cannot import — Would contain existing Bastet subnet 'legacy' (10.0.1.0/24) …"
-switch ON : "Everything in this subscription has already been imported. Nothing left to select."
-            alert-success = true, reason text on screen = false
-```
+_Pass 1's second half was **dropped, not fixed**: the per-prefix "All subnets in this prefix are already
+imported." at `:240` survives untouched, because the verifier could not construct a selectable prefix
+holding a `Blocked` subnet, and for the reachable case - an `AlreadyImported` subnet - the sentence is
+true. Changing a correct message on the strength of an unreachable scenario would be the wrong trade._
 
-Nothing was imported, and the only explanation is hidden rather than shown.
+_Verified in chromium with the shipped script and its four `@Url.Action` expressions substituted
+programmatically: `parses: OK`, the success-alert-asserting-a-prior-import is gone, the suppressed
+counter is wired, and the "untick to see why" instruction is present. The alert level changed from
+`alert-success` to `alert-info` deliberately - nothing succeeded, so nothing should be green._
 
-**The correction all three reports missed, and it is why nobody noticed:** the banner *is* right in the
-ordinary re-scan case. `AzureSubnetSnapshotService.cs:27` sets `HasChildSubnets` from the tree, so a
-genuinely imported target comes back `Blocked("Bastet subnet 'X' already has child subnets. Already
-imported?")` — **the same bucket**, hidden by the same filter, and there the sentence is true. The defect
-is that one `Blocked` bucket carries both the intended case and the conflict cases.
+_No test ships; no JS harness. `AnnotatePrefix`'s inability to return `AlreadyImported` was established
+by the verifier over 4,046 brute-forced planner outcomes and is recorded on the watch list rather than
+pinned here, since it is the planner's behaviour and not this fix's._
 
-**Fix.** Count the suppressed prefixes and say so, relabelling the switch "Hide unavailable" — reserving
-the "already imported" wording for when every suppressed prefix carries the `HasChildSubnets` reason, or
-simply always naming the count with "untick to see why". **Do not** filter on
-`statusName === "AlreadyImported"`: that makes the switch a no-op and deletes the declutter it exists
-for. Round 5's E11 fixed this class in the *reconcile* wizard and never touched `_BulkScripts.cshtml`, so
-this is not a re-raise of a deliberate omission.
+_Tests 627 → 627 (unchanged). Build clean, 0 warnings._
 
 ---
+
 
 ## F12. A row withheld for any non-403 reason is reported as a lost credential `[×1]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -693,37 +693,42 @@ their scenario. What helps them is validating the stored id's shape.
 
 ## F14. The Create-Subnet modal unlocks a field nothing listens to, under a stale explanation `[×1]`
 
-**Confidence: confirmed.**
+_F14 is fixed and committed with the finding's cheaper interim, which the verifier established is the
+better fix: the field is never unlocked. `prop('readonly', false)` is gone, so the value the script
+computed is the value that gets posted._
 
-**Where:** [_SubnetCalculationScripts.cshtml:63-68](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L63)
-(clears `readonly` and sets the help text), [:78](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L78),
-[:141-147](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L141). "Nothing listens" is
-airtight: instrumenting `$.fn.on` and `addEventListener` *before* the shipped script ran captured exactly
-three bindings — `.create-subnet-btn` click, `#cidrInput` input, `#createSubnetBtn` click — **zero** on the
-address field and **zero delegated bindings anywhere**.
+_Nothing is lost by leaving it locked, and this was checked rather than assumed:
+`findCompatibleNetworkAddress` searches only within the parent's boundaries and skips every child, so
+the address it writes is always inside the parent, aligned, and clear of siblings. The verifier's
+warning against the finding's *preferred* fix was heeded - adding a listener means sharing a validator
+with the `#cidrInput` handler, which rewrites this field from `#originalNetworkAddress` on every
+`input` event and would overwrite what the operator is typing._
 
-**Failure scenario.** Open the modal on an unallocated range, then type `192.168.99.0` — outside the
-parent entirely — into the now-editable network-address field:
+_**A stale symbol was cleaned up rather than left behind.** With the unlock removed,
+`makeNetworkAddressEditable()` no longer made anything editable - a function whose name states the
+opposite of what it does is exactly the residue these rounds keep finding. It is now
+`markNetworkAddressAdjusted()`, and its single caller was updated. `makeNetworkAddressReadOnly()` keeps
+its name because it still does what it says._
 
-```
-#networkAddressHelp : "This network address has been adjusted to avoid overlaps."
-#createSubnetBtn disabled : false
-Create -> /Subnet/Create?networkAddress=192.168.99.0&cidr=25&parentId=703
-```
+_The finding's anchor was corrected, as the verifier required: the false thing on screen is
+`#networkAddressHelp` still reading "This network address has been adjusted to avoid overlaps" under a
+value the script never adjusted - not the `is-valid` class, which sits on `#cidrInput` and was
+accurate. With the field locked, that sentence is true whenever it appears._
 
-`checkForOverlap` is silently skipped. The **actually-false thing on screen is the help text**, under a
-value the script neither adjusted nor overlap-checked. (The finder's "`is-valid`" is a misattribution:
-that class is on `#cidrInput`, and the CIDR genuinely is valid.) The server holds cleanly — the POST is
-refused with the containment rule named and nothing is persisted — so this is a client-side affordance
-defect.
+_Verified in chromium: the script parses, no `readonly, false` remains, and the stale name is gone.
+**My first rig reported a syntax error that was its own fault** - a regex meant to strip the Razor
+`@foreach` swallowed part of the script and produced `Unexpected token 'var'`. Recorded because a rig
+that blames the file for its own damage is the fastest way to "fix" something that was never broken;
+re-done by replacing the Razor data literal precisely, from `@foreach` to the closing `];`, and
+asserting no `@` survived._
 
-**Fix.** Drop the `prop('readonly', false)` at `:64`. Nothing is lost:
-`findCompatibleNetworkAddress` searches only within the parent's boundaries and skips every child, so the
-address it writes is always inside the parent, aligned and non-overlapping. Prefer this over adding a
-listener — `#cidrInput`'s handler rewrites the field from `#originalNetworkAddress` on every `input`, so a
-shared validator must not reuse that branch or it will overwrite what the operator is typing.
+_No test ships; no JS harness. The server was already correct here and remains untouched - it refused
+an out-of-parent address with the containment rule named, which is why this stayed low._
+
+_Tests 627 → 627 (unchanged). Build clean, 0 warnings._
 
 ---
+
 
 ## F15. `BASTET_AUTO_MIGRATE` cannot bootstrap a catalog that does not exist `[×1]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -321,54 +321,59 @@ _Tests 615 → 615 (unchanged). Build clean, 0 warnings._
 
 ## F5. jQuery 4 breaks client-side validation on every validated form `[×2]`
 
-**Confidence: confirmed.** Measured on real rendered pages in real chromium with real trusted clicks.
+_F5 is fixed and committed with the one-line shim: `_ValidationScriptsPartial.cshtml` restores
+`jQuery.parseJSON = JSON.parse` before the two validation scripts load, guarded so it is a no-op on
+any jQuery that still ships the function - including a later rollback to 3.7.1._
 
-**Where:** [_Layout.cshtml:103](../src/Bastet/Views/Shared/_Layout.cshtml#L103) (pins `jquery@4.0.0`,
-which removed `$.parseJSON`),
-[_ValidationScriptsPartial.cshtml:3](../src/Bastet/Views/Shared/_ValidationScriptsPartial.cshtml#L3)
-(`jquery-validation-unobtrusive@4.0.0`, which calls it at its lines 58 and 91). Affects **four** views:
-`Subnet/Create.cshtml:21`, `Subnet/Edit.cshtml:21`, `HostIp/Create.cshtml:22`, `HostIp/Edit.cshtml:20`.
-Regression from `dcd50c2` (#82), the jQuery 3.7.1 → 4.0.0 bump.
-
-**Failure scenario.** On the shipped `/Subnet/Create`, a real click on the submit button with Name blank
-and `Cidr=99`:
+_The shim was chosen over pinning jQuery back to 3.7.1, and the reason is that it is **sufficient**
+rather than merely smaller: the verifier established that `$.parseJSON` is the only jQuery 4 removal
+this library chain actually touches, that `jQuery.validator.unobtrusive.options` is null so the
+second removed function is short-circuited before it is reached, and that the app's own scripts use
+no removed API at all. Pinning back would revert a deliberate upgrade (`dcd50c2`, #82) to work around
+one missing alias. The rollback remains available and the SRI hash it needs is recorded below, since
+it **cannot be recovered from git** - that commit predates the integrity attributes._
 
 ```
-POST body : Name=&NetworkAddress=10.99.0.0&Cidr=99&...
-Runtime.exceptionThrown: TypeError: s.parseJSON is not a function
+sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs
 ```
 
-The throw happens inside `showLabel` → `errorPlacement` → unobtrusive `onError`, *before*
-jquery-validation can `preventDefault()`. The library has already set `novalidate` on the form, so the
-browser's own `rangeOverflow` gate — confirmed live and would otherwise block it — is switched off.
-Three controls on the same real page (validation scripts blocked; a one-line shim; jQuery 3.7.1 with a
-valid SRI hash) all block the submit. **Every submit of those four forms throws, valid or not** — via
-`defaultShowErrors` iterating `successList`.
+_Measured in chromium against the artefacts `_Layout.cshtml` and this partial actually pin - jQuery
+4.0.0, jquery-validation 1.21.0, jquery-validation-unobtrusive 4.0.0, all fetched from the same CDN
+URLs - with the shim lifted verbatim out of the shipped partial rather than retyped:_
 
-**Blast radius, verified.** Nothing invalid is persisted and nothing 500s: `Cidr` of `-1, 33, 99,
-2147483647, 4294967296, abc` on both Create and Edit all return 200 re-renders with the range error, and
-the row is unchanged. The destructive paths check `confirmation != "approved"` server-side.
+```
+                          unfixed                                    fixed
+submit reached browser    true                                       false
+threw                     TypeError: s.parseJSON is not a function   null
+message                   ""                                         "Please enter a value less than
+                                                                      or equal to 32."
+novalidate                novalidate                                 novalidate
+```
 
-**The real cost is one extra HTTP round trip per validation error, plus a console `TypeError`** — not a
-missing message, because the fail-open POST lands on the same action and writes the same messages into
-the same validation spans. Both finders' framing overstated this; medium is the honest grade.
+_**The first version of that measurement was wrong and was redone.** It reported the form posting in
+*both* columns, because the recording listener was attached before jQuery's own submit handler and
+cancelled the event itself - so it measured "a submit event fired", not "the submit reached the
+browser". Re-instrumented to attach last and read `event.defaultPrevented`, which is the question that
+matters. `novalidate` is present in both columns, which is the point: the browser's own gate is off
+either way, so the shim is load-bearing rather than belt-and-braces._
 
-**This falsifies a claim in round 5's record.** E5's struck paragraph argues its reachability was narrow
-because "`asp-for` on an int emits `type="number"` with `min`/`max`, so a normal browser blocks the
-submit even with JavaScript disabled… the vector is a crafted POST". With JavaScript **enabled** — the
-shipped case — an ordinary `Edit`-role user posts `Cidr=99` by typing it. Amend that paragraph when this
-is fixed.
+_**Round 5's record was corrected**, which the finding explicitly asks for. E5's struck entry in
+`docs/AUDIT-FINDINGS-5.md` argued its reachability was narrow because "a normal browser blocks the
+submit even with JavaScript disabled" and "the vector is a crafted POST". Both are false: the library
+sets `novalidate`, and an ordinary Edit-role user reached it by typing a value and clicking Save. A
+correction paragraph is appended there rather than rewriting the entry, so the original reasoning and
+its refutation both stay visible._
 
-**Fix.** No jQuery-4-clean release of `jquery-validation-unobtrusive` exists — 4.0.0 is the latest
-published. Two options, both verified to produce zero new errors across six pages:
+_Scope: four views, not the five both finders listed. `HostIp/Delete.cshtml` has no `data-val`
+attributes, so `.validate()` is never called on it and its confirmation box is still gated by the
+browser's own `required`._
 
-- **Interim, one line, reversible:** `jQuery.parseJSON = JSON.parse` before the validation scripts.
-  Sufficient — `unobtrusive.options` is `null` and the app never calls the other removed function.
-- **Pin jQuery back to 3.7.1.** The SRI hash cannot be recovered from git (`dcd50c2` predates the
-  integrity attributes), so it is recorded here, computed from the CDN bytes and verified in-browser:
-  `sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs`
+_No test ships; there is still no JS harness in the repo. The rig was ephemeral and is deleted._
+
+_Tests 615 → 615 (unchanged). Build clean, 0 warnings._
 
 ---
+
 
 # Low
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -437,38 +437,38 @@ _Tests 615 → 619 (+4). Build clean, 0 warnings._
 
 ## F7. A JSON `null` for a collection returns an unhandled 500 past the subnet lock `[×2]`
 
-**Confidence: confirmed.**
+_F7 is fixed and committed at all four sites the two finders listed between them. The reconcile
+commit now tests `request.SubnetIds is null or { Count: 0 }`, the same pattern
+`SubnetController.Azure.cs:130` already used, and the planner guards its list, its entries and each
+entry's `Subnets` collection. Entries are guarded as well as collections because a null **element**
+arrives from the body exactly as easily as a null list._
 
-**Where:** [AzureBulkImportPlanner.cs:37](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L37)
-(`"vNetPrefixes":null`), [:49](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L49)
-(`"vNetPrefixes":[null]`), [:69](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L69)
-(`"subnets":null`), reached via
-[BulkAzure.cs:62](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L62) inside
-`ExecuteWithSubnetLockAsync` and outside the try at
-[:81](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L81), whose only `catch` is
-`TimeoutException`; and
-[SubnetController.AzureReconcile.cs:45](../src/Bastet/Controllers/SubnetController.AzureReconcile.cs#L45)
-(`"subnetIds":null`) — which fires **before** any lock is taken.
+_A null `Subnets` collection is treated as "no subnets", not as an error: a VNet prefix selected with
+no Azure subnets under it is a legitimate selection and the target is still created. A null list or a
+null entry is reported through `GlobalErrors`, which is the channel the wizard already renders._
 
-**Failure scenario.** `System.Text.Json` overwrites the DTO's `= []` initializer with `null`. Both bulk
-endpoints answer 500 with a non-JSON body (a `text/plain` stack trace in Development, the `text/html`
-error page in Production), where the field *omitted* correctly yields
-`400 {"success":false,"globalErrors":["No VNet address prefixes were selected."]}`. The sibling
-`/Azure/BulkImportPreview` handles the same body correctly. Reachable as a scripted mistake, not only a
-crafted one: an empty shell variable in the documented `jpost '{"subnetIds":[...]}'` idiom produces
-exactly `"subnetIds":null`.
+_Three tests, and they fail against the unfixed planner with `System.NullReferenceException : Object
+reference not set to an instance of an object.` - the defect verbatim. Proven by reverting the guards
+in place and re-running rather than by reasoning about them._
 
-**The lock is correctly released** — zero `APPLICATION` rows in `sys.dm_tran_locks` afterwards, 19
-acquires and 19 releases, next request served in 16 ms.
+_**One consequence to state rather than let a reader discover.** Fixing this in the planner also
+changes `/Azure/BulkImportPreview`'s answer to the same body: it used to return HTTP 200 with
+`{"success":false,"error":"Failed to build the import preview…"}` because the exception was caught
+there, and now returns `success:true` with a plan carrying `globalErrors`. That is the better shape -
+the operator is told which selection was empty rather than that the preview failed - but it is a
+behaviour change on a second endpoint and it should not be a surprise._
 
-**Fix.** Guard the three planner sites and add `is null or { Count: 0 }` at `AzureReconcile.cs:45`,
-matching `SubnetController.Azure.cs:130`. **State the side effect in the commit:** fixing it in the
-planner changes `/Azure/BulkImportPreview`'s answer to the same body from
-`{"success":false,"error":"Failed to build the import preview…"}` to `success:true` with a `globalErrors`
-plan. That is the better shape, but it is a behaviour change on a second endpoint. Do **not** merely
-widen the `catch` to `Exception` — that leaves the request classified as a server fault.
+_The finding's cheaper interim - widening the action's `catch (TimeoutException)` to `Exception` - was
+not taken, as both finders recommended: it would leave the request classified as a server fault when
+it is a malformed request._
+
+_The lock was already correct and is untouched. Both finders measured zero lingering `APPLICATION`
+locks after the failing request, with 19 acquires and 19 releases in the log._
+
+_Tests 619 → 622 (+3). Build clean, 0 warnings._
 
 ---
+
 
 ## F8. Two bulk-commit failures render a red panel reading only "Commit failed:" `[×2]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -882,41 +882,39 @@ _Tests 630 → 631 (+1). Build clean, 0 warnings._
 
 ## F18. Bulk import persists a subnet with an empty name `[×1]`
 
-**Confidence: confirmed.** Downgraded from low: a harm probe found nothing that breaks.
+_F18 is fixed and committed. A `TargetName(prefix)` helper gives the auto-created target the same
+empty-name fallback the child names four lines away always had, falling back to
+`{network}_{cidr}` - so `192.168.0.0/16` becomes `192.168.0.0_16` rather than nothing at all._
 
-**Where:** [AzureBulkImportPlanner.cs:386](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L386)
-and [:403](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L403) (the target's name, with no
-empty-name fallback) against [:470-474](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L470) (the
-*child* fallback, four lines away), written at
-[BulkAzure.cs:198](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L198).
-`ValidateSubnetCreation` never inspects `Name`.
+_The planner-side fix was taken over the stricter alternative of rejecting a null or whitespace `Name`
+in `ValidateSubnetCreation`, for the reason the finding gives: the preview then shows what the commit
+will write. The verifier checked the stricter option is also safe - every in-code caller already
+supplies a non-empty name - so it remains available if a later round wants belt and braces._
 
-**Failure scenario.** A crafted Admin POST with `vNetName` that sanitizes to empty (e.g. markup only):
+_All three target-name sites route through the helper, not just the two the finding cites. The third is
+the `renameMatched` path, which proposed the same sanitized value as a rename: left alone it would have
+renamed an existing subnet to nothing, which is the same defect wearing a different hat._
 
-```
-{"success":true,"createdTargets":1,"createdChildSubnets":1}
-8|[]|0|192.168.0.0|16|NULL      <- nameless target persisted
-9|[web]|3|192.168.1.0|24|8      <- the child kept its name
-```
+_Five tests: three theory rows for names that sanitize to empty - markup-only, whitespace-only and
+empty - which fail against the unfixed planner, plus a guard that an ordinary name is still used
+verbatim. Without that guard a fix that always used the prefix would pass._
 
-The same three values through the interactive Create POST are all refused ("HTML tags are not allowed in
-subnet names" / "Name is required"). No genuine wizard path can reach it: `vNetName` comes only from an
-ARM VNet name, and Azure names permit only alphanumerics, `_`, `.` and `-`.
+_Graded **info** rather than low by the verifier, and the fix reflects that this is an invariant repair
+rather than a harm repair: it went looking for something that breaks and found nothing - the tree row
+stayed clickable with the address as its visible text, Details returned 200 with an empty heading, the
+dropdown option was selectable, and the row archived cleanly. What justifies fixing it anyway is that
+`EditSubnetViewModel` carries an explicit comment about this exact hazard - "StripHtml can empty a name
+outright, defeating `[Required]`" - closed for both interactive models by round 5's E2 and left open on
+the one write path with the same sanitizer output and no equivalent guard._
 
-**Why info rather than low.** Everything downstream survives: the tree row is clickable with the address
-as its visible text, Details returns 200 with an empty `<h1>`, the parent dropdown option is selectable,
-Edit/Delete/DeletedSubnets all 200, and the row archives cleanly. Nothing fails.
+_Reachability is a crafted admin POST only, and that was re-verified rather than inherited: `vNetName`
+is only ever set from an ARM VNet name, and Azure names permit only alphanumerics, `_`, `.` and `-`, so
+no legal Azure name can sanitize to empty._
 
-**Why keep it at all.** [EditSubnetViewModel.cs:37-41](../src/Bastet/Models/ViewModels/EditSubnetViewModel.cs#L37)
-carries an explicit comment — "StripHtml can empty a name outright, defeating `[Required]`" — which is
-precisely this hazard, closed for both interactive models by E2 and left open on the one write that has
-the same sanitizer output and no equivalent guard.
-
-**Fix.** Mirror the child fallback at `:386`/`:403`, so the preview shows what the commit will write.
-Rejecting a null/whitespace `Name` in `ValidateSubnetCreation` is also safe — every in-code caller already
-supplies a non-empty name.
+_Tests 631 → 635 (+4). Build clean, 0 warnings._
 
 ---
+
 
 # Refuted — reported by a finder, killed by the verifier
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -4,6 +4,79 @@
 **Test baseline:** 603 passing, 0 failed. `dotnet build --no-incremental` clean, 0 warnings.
 **Date:** 2026-07-26
 
+## Reconciliation — complete
+
+**All 18 findings fixed, none refuted on re-verification**, plus the E8 restoration as step 0. One
+commit each, on `task/audit-6`.
+
+**Final state:** 635 passing (603 → 635, +32), 0 failed. Clean rebuild from deleted `bin`/`obj`,
+0 warnings. Working tree clean, no scaffolding committed, no credential in any commit.
+
+**Closing sweep.** Every major area was requested from the real application running against a real SQL
+Server 2022 container, asserting titles and content rather than status codes: home, subnet hierarchy,
+create, details, edit, deleted subnets, all-deleted-host-IPs, both Azure wizards, the reconcile wizard,
+and the 404 page. Security headers ride on both a normal 200 and the 404 (`X-Content-Type-Options`,
+`Referrer-Policy`, `Content-Security-Policy: frame-ancestors 'none'`, `X-Frame-Options`). One classified
+rather than glossed: `/HostIp` 404s because there is no index action — host IPs are reached through a
+subnet.
+
+**Six fixes were confirmed live through HTTP, not just by test:**
+
+| | |
+|---|---|
+| F1 | a crafted CIDR change on an Azure-linked row is refused with the new message; the stored CIDR stays 16 |
+| F1 | the Edit form renders `Cidr` as a hidden input plus the "Imported from Azure" note |
+| F5 | the `parseJSON` shim is served between jQuery 4.0.0 and the two validation scripts |
+| F6 | **the sanitizing formatter is actually selected at runtime** — the thing the unit tests could not prove |
+| F9 | the prefilled name `prod-10.0.5.0-24` posts verbatim and succeeds (302) |
+| F10 | a `/32` Details page renders **0** Create Subnet buttons; the `/16` renders 2 |
+
+**F2's plumbing confirmed against real ARM:** every subnet in the inventory carries a populated
+`ipv4AddressPrefixes`, deduplicated, and the IPv6-only VNet is still filtered out.
+
+**The Azure surface was driven end to end against live ARM**, with the discrimination check that
+matters — a reconciler that blocks everything is as broken as one that deletes everything. Two service
+principals with disjoint scope, probed rather than assumed: SP_A sees `bastet`, SP_B sees
+`bastet-hidden`.
+
+| Linked row | Azure reality | Result |
+|---|---|---|
+| `invisible-link` | 403, resource group not visible | **withheld**, warning names it; force-through refused 409, nothing deleted |
+| `really-gone` | 404, genuinely absent | **offered** `VNetDeleted`, committed and archived (1 archived) |
+
+Afterwards `invisible-link` is still live and only `really-gone` is in `DeletedSubnets`. The 409's
+warning carries **F12's new wording** — "Azure denied access when asked about them directly" — so that
+fix is confirmed live too.
+
+**Log:** 2,255 lines, **zero `crit:`, zero ESC bytes**, one `fail:` and six `warn:`, every one
+classified. The `fail:` is my own deliberate log-forging probe, and its rendering *is* F6's evidence:
+the crafted escape sequence appears as literal text in both the message and the exception line. Three
+`warn:` are `Azure denied access to …vnet-hidden (403), so it cannot be reported as deleted` — the
+deliberate permission probe working, logged by design. The other three are environmental and
+pre-existing, both recorded by round 5: DataProtection has no XML encryptor for a local run, and EF
+advises on `QuerySplittingBehavior` for a multi-`Include` query.
+
+**Coverage was not re-run.** This round deleted no code — F14 renamed a function and F18 added a
+helper — so there is no dead-code delta to compare against a reference sweep.
+
+**Deliberately not done**, each argued in the struck entry that owns it:
+
+- the ARM-based prefix-equality check at `SubnetController.Azure.cs:320` (F1) — it needs a network
+  round-trip inside a transactional write, far more invasive than a crafted-post-only defect warrants;
+- `Guid.TryParse` before the ARM calls (F6) — the parsing is cheap but the failure semantics differ per
+  method, and conflating "bad identifier" with "no VNets" is the distinction round 5's E-series was
+  about;
+- the bulk import still reads only a multi-prefix subnet's **first** prefix (F2) — closing that means
+  creating several Bastet subnets from one Azure subnet, a feature change;
+- `findOptimalCidr`'s loop bound (F10), the `site.js` consolidation of six mask copies (F16), and the
+  per-prefix "already imported" sentence (F11), which is correct for its one reachable case;
+- the reconcile badge colour for `VNetPrefixRemoved` (F4) — a UI preference once the reason is rendered.
+
+**Two round-5 entries were corrected** where this round disproved them: E5's reachability claim (a
+normal browser does *not* block the submit — the library sets `novalidate`) and E6's claim that a SQLite
+test was impossible. Both are appended as corrections rather than rewrites, so the original reasoning
+stays readable.
+
 ## Verdict
 
 **No critical findings. Two high, three medium, twelve low, one info.** 18 survived verification, 7

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -1,0 +1,1129 @@
+# Bastet — Round-6 Audit Findings
+
+**Target:** branch `main`, HEAD `8cefc64` "Audit 5 Cleanup (#142)" (all 14 round-5 fixes squashed).
+**Test baseline:** 603 passing, 0 failed. `dotnet build --no-incremental` clean, 0 warnings.
+**Date:** 2026-07-26
+
+## Verdict
+
+**No critical findings. Two high, three medium, twelve low, one info.** 18 survived verification, 7
+were refuted (28%).
+
+The headline is **F1**, and it is the most serious thing five rounds have found: an ordinary,
+validated CIDR edit on an Azure-linked subnet turns that subnet into a reconcile deletion candidate,
+and committing archives it, its descendants and their host IP assignments while Azure is entirely
+healthy — with **zero ARM reads**. Three things make it worse than its predecessors:
+
+- **It is a privilege escalation.** An `Edit`-role account is refused `/Subnet/Delete/{id}`,
+  `/Azure/ReconcileScan` and `/Subnet/BulkDeleteStaleAzureSubnets` with 403 — and can still set the
+  trap that makes an Admin archive a subtree. Measured, with a role matrix.
+- **The collateral is not Azure data.** A measured run archived 5 subnets and 3 host IPs, of which
+  **2 subnets and 2 host IPs had no `AzureResourceId` at all** — hand-created, never imported.
+- **The archive is lossy in exactly the wrong column.** `DeletedSubnets` has no `AzureResourceId`
+  and no `IsFullyAllocated`. The column whose disagreement with Azure caused the deletion is the one
+  the archive discards, and there is no restore path anywhere in the application.
+
+**F1 is not a regression from round 5.** Two finders framed it that way and both were wrong. A build
+from `6d0e8c4~1` — before round 4's D3, where `ApplyConfirmations` does not exist — reproduces the
+archival. The defect is original to the reconcile feature (`aedd0bd`, #133). D3 masked it as a side
+effect for one release-range and **E1 correctly un-masked it. E1 must stay.**
+
+**F2** is the same class from the Azure side and independent of F1: the subnet-level prefix check
+tests equality where the VNet-level check ten lines above tests membership. Multiple IPv4 prefixes
+per subnet went **GA on 2025-09-04**, so this is reachable on any current subscription without a
+preview flag.
+
+**F3** is the other way a healthy resource gets archived: a stored `AzureResourceId` that names
+something other than an Azure subnet is answered by a read of a *different* resource, and a 404 there
+reads as "Azure confirms it is gone".
+
+After that it is a long tail of messaging, diagnostics and affordance defects, plus **F5** — client-side
+validation is dead across the whole application, which also falsifies a reachability claim in round 5's
+own record.
+
+Read in this order: **F1**, **F2**, **F3**, then **F5**.
+
+## Reconcile step 0 — restore the E8 entry to `docs/AUDIT-FINDINGS-5.md`
+
+**Do this first, in its own commit, before `F1`.** The shipped round-5 findings file has no `E8`
+section. It was present through `8a2223a` and deleted by `3c805c1` (the E7 fix), whose replacement
+hunk swallowed the whole neighbouring entry — `-62/+32` on a file that should only ever have grown.
+E8 is still referenced twice in the surviving text, so the file cites an entry it does not contain.
+
+Recover it with `git show 8a2223a:docs/AUDIT-FINDINGS-5.md` (the section is around lines 351–372) and
+reinsert it **immediately ahead of `## E7`**, its original position, not in numeric order: the entry's
+own second paragraph explains why it sits there ("Taken out of numeric order, ahead of E7… E7 is a
+client-side jQuery defect needing a browser rig, and this one needed nothing but a grep"), and moving
+it would make a committed struck entry false. Nothing else in the file changes.
+
+Verify the restored range is byte-identical to `8a2223a`'s copy and that
+`grep -c '^## E' docs/AUDIT-FINDINGS-5.md` returns 14.
+
+It carries no `F` number: the `F` series is for code defects. The process lesson is worth keeping —
+**a fix commit that also edits the findings file must diff its own hunk before committing.**
+
+## How this audit ran
+
+Eight finder beats — security/web, logic & data integrity, Azure, locking & lifecycle, UI/client-JS,
+regression-correctness, regression-tests, dead code — **run twice** with fresh agents and no knowledge
+of each other, then every surviving finding handed to an independent verifier instructed to **refute**
+it and to default to "not real" when uncertain.
+
+**32 agents, 0 errors:** 1 rig builder, 16 finders, 15 verifiers producing 28 verdicts over 25
+findings. Findings are tagged:
+
+- **[×2]** — found independently by both passes. Strongest signal.
+- **[×1]** — found by one pass only. *Not weaker in truth* — it means a full pass missed it, so it
+  deserves **more** scrutiny during reconciliation, not less. **Absence is weak evidence.**
+
+Pass 1: 16 reports. Pass 2: 18 reports. Merged and de-duplicated to 25, of which 18 survived.
+
+Two calibration notes the tags alone would hide:
+
+- **F10 was found by three pass-2 beats and by none in pass 1.** It is tagged `[×1]` by the rule.
+  Three independent agents in one pass outweigh the other pass's silence.
+- **F5 was found by two beats and missed by a third working the same area.** Pass 2's UI beat swept
+  jQuery 4 for removed APIs and scoped itself to the app's own scripts, none of which render
+  `_ValidationScriptsPartial.cshtml`. Both were right within their scope. That is the honest measure
+  of what one beat's silence is worth.
+
+**Three things distinguish this round.**
+
+**The live rig entered the commit path.** Round 5 drove Azure read-only and deliberately never
+archived anything. This round used two service principals with disjoint RBAC scope over two resource
+groups, ARM strictly read-only, plus a throwaway SQL Server 2022 container and the real application —
+and drove reconcile scan *and commit* to completion against a local database. F1, F3 and F12 are
+`confirmed (live)` because of it, and so are the strongest clean-bill entries: **a withheld row cannot
+be forced through the commit — 9 of 9 attempts refused, database byte-identical before and after each
+one**, including the case that matters most, a deletable row mixed with a withheld one (409, and the
+deletable row was not archived either).
+
+**Verification changed the answer, not just the confidence.** It killed **four proposed fixes** by
+measurement — the containment fix for F1 (misses the widening half, and re-creates E1 where it does
+bite), clearing `AzureResourceId` on edit (irreversible; reconcile goes permanently blind),
+`ResourceIdentifier.TryParse` for F6 (does not filter control characters), and deleting the migration
+lock for F15 (trades a deterministic crash for a racy one and silently drops a 300s wait to 30s). It
+also corrected the provenance of F1 and F4, downgraded four severities, upgraded one, and found the
+privilege escalation in F1 that no finder saw.
+
+**Every finding was measured, not read.** Rigs included a recording `HttpMessageHandler` capturing the
+Azure SDK's real wire requests, `pyte` as an independent VT100 emulator for F6, a role matrix built
+with the dev-auth stub as the only changed file (verified by per-file `cmp`), instrumentation of
+`$.fn.on` and `addEventListener` before the shipped script ran for F14, 4,046 brute-forced planner
+outcomes for F11, ~6,100 allocation layouts and 6,950 random write operations against nine tree
+invariants for the arithmetic clean bill, and real trusted `Input.dispatchMouseEvent` clicks on real
+rendered pages for F5.
+
+I re-checked every citation in this file against the working tree by hand. Where a finder's line
+number was wrong it is corrected here and noted.
+
+---
+
+# High
+
+## F1. A legitimate CIDR edit on an Azure-linked subnet makes reconcile archive it and its subtree `[×2]`
+
+**Confidence: confirmed (live).** Three verifiers, three lenses, all confirmed.
+
+**Where:** [AzureReconciler.cs:216](../src/Bastet/Services/Azure/AzureReconciler.cs#L216) and
+[:252](../src/Bastet/Services/Azure/AzureReconciler.cs#L252) (the two prefix comparisons that produce
+`VNetPrefixRemoved` / `SubnetPrefixChanged` without establishing *which side* moved),
+[:134-136](../src/Bastet/Services/Azure/AzureReconciler.cs#L134) (non-absence rows are never judged),
+[AzureController.cs:377-381](../src/Bastet/Controllers/AzureController.cs#L377) (returns before
+`ConfirmResourcesAsync` when no absence rows exist — hence zero ARM reads),
+[SubnetController.Edit.cs:104](../src/Bastet/Controllers/SubnetController.Edit.cs#L104) and
+[:150](../src/Bastet/Controllers/SubnetController.Edit.cs#L150) (the CIDR write, which never reads
+`AzureResourceId`), [SubnetController.Azure.cs:320](../src/Bastet/Controllers/SubnetController.Azure.cs#L320)
+(a **third** writer of the same mismatch, with no prefix-equality check).
+
+**Failure scenario.** Import VNet `vnet-visible` (`10.10.0.0/16`) through the real bulk wizard. An
+`Edit`-role user POSTs `/Subnet/Edit/1` with `Cidr=17`; it validates, persists, and keeps
+`AzureResourceId`. Azure is untouched. An Admin then runs an ordinary reconcile:
+
+```
+scan: canCommit=true items=1 reviewItems=0 warnings=[]
+  OFFERED id=1 vnet-visible 10.10.0.0/17 VNetPrefixRemoved descendants=2 hostIps=1
+  reason: VNet 'vnet-visible' still exists but no longer has the address prefix 10.10.0.0/17.
+commit: {"success":true,"targetsDeleted":1,"subnetsArchived":5,"hostIpsArchived":3}
+```
+
+Both directions work — narrowing and widening. Host IPs on the subnet do not prevent the edit.
+
+**Why the operator does not catch it.** `SubnetPrefixChanged` states both prefixes, so it is
+detectable. `VNetPrefixRemoved` ([:218](../src/Bastet/Services/Azure/AzureReconciler.cs#L218)) states
+only Bastet's own prefix, so nothing on screen distinguishes a local edit from genuine Azure
+re-addressing, where archiving is correct. Neither reason reaches `_StepConfirm.cshtml`, which offers
+a "Select all" checkbox above the table (see **F4**).
+
+**Privilege escalation, measured.** `RequireEditRole` = `Edit, Delete, Admin`; `RequireAdminRole` =
+`Admin` ([Program.cs:206-211](../src/Bastet/Program.cs#L206)):
+
+```
+[Edit] POST /Subnet/Edit/1 Cidr=17              -> 302, persisted, AzureResourceId intact
+[Edit] POST /Azure/ReconcileScan                -> 403
+[Edit] POST /Subnet/BulkDeleteStaleAzureSubnets -> 403
+[Edit] POST /Subnet/Delete/2 (approved)         -> 403
+```
+
+**Recoverability.** No restore action exists — all 28 public actions across the subnet and host-IP
+controllers were enumerated, and the only control on `/Subnet/DeletedSubnets` is "Purge All".
+`DeletedSubnets` (14 columns) has no `AzureResourceId` and no `IsFullyAllocated`. The rendered table
+omits `Tags` and `OriginalParentId`, so hand recovery requires direct database access. The archived
+CIDR is the *edited* one, so a faithful restore re-triggers the deletion. Purge is purge-all and
+orphans the host-IP archive, whose rows then render `Unknown (Original Subnet ID: n)`.
+
+**Root cause.** Not E1, and not the status computation. The broken invariant is **"a row carrying an
+`AzureResourceId` records the prefix that resource had at link time"**. No downstream rule can repair
+it: the state left by a Bastet narrowing and the state left by an Azure widening are the *same state*,
+and the two scan rows are byte-identical (`diff rowX.json rowY.json -> IDENTICAL`).
+
+**Fix.** Refuse the CIDR change when `AzureResourceId` is set — beside the `ValidateSubnetCidrChange`
+call at `Edit.cs:104`, with `Cidr` rendered display-only for those rows the way `NetworkAddress`
+already is — **plus** the missing prefix-equality check at `SubnetController.Azure.cs:320`. It touches
+no reconcile code, so E1 stays intact and genuine Azure drift stays reportable and deletable.
+
+**What it costs, stated because it is a real loss:** `Subnet/Edit` is today the only non-destructive
+remedy for a genuine Azure prefix *resize* — editing the row back to Azure's prefix makes the drift row
+disappear. After this fix that operator must archive and re-import.
+
+**The correct long-term fix** is to persist the prefix the row was linked at (a nullable column written
+by the three import sites, compared in the two evaluators). It costs an EF migration, which is why the
+refusal is recommended now and this is the follow-up if the resize workflow is worth keeping.
+
+**Fixes that were tried and rejected by measurement — do not take them:**
+
+| Rejected fix | Why |
+|---|---|
+| Containment test in the two evaluators | Local widening `/16`→`/15` is **not** contained in the live `/16`, so the row stays deletable; and where it does bite it re-creates E1 by demoting genuine Azure drift to `ReviewItems` |
+| Clear `AzureResourceId` on edit | Reconcile goes blind to the row (`items=0`) and the link cannot be restored — re-import is refused with four global errors. Trades a loud wrong answer for a silent permanent blind spot |
+| Fix only the screen text | Healthy infrastructure is still archived on a 200. That is **F4**, a companion, not a fix |
+
+---
+
+## F2. The subnet-level prefix check tests equality where the VNet-level check tests membership `[×1]`
+
+**Confidence: plausible.** The unestablished step: which index ARM assigns a newly-added prefix in a
+subnet's `addressPrefixes` array. Settling it needs an ARM write, which this audit forbade. Everything
+either side of it is measured, and the defect is reachable under **both** plausible ordering policies.
+
+**Where:** [AzureReconciler.cs:216](../src/Bastet/Services/Azure/AzureReconciler.cs#L216)
+(`!vnet.Ipv4AddressPrefixes.Contains(prefix, StringComparer.OrdinalIgnoreCase)` — membership, correct)
+against [:252](../src/Bastet/Services/Azure/AzureReconciler.cs#L252)
+(`!string.Equals(livePrefix, prefix, …)` — equality against one collapsed value),
+[AzureService.cs:380-401](../src/Bastet/Services/Azure/AzureService.cs#L380) (`ExtractIpv4Prefix`
+collapses `IList<string> AddressPrefixes` to its first IPv4 entry; doc comment at `:376-379`),
+[:239-277](../src/Bastet/Services/Azure/AzureService.cs#L239) (`GetCompatibleSubnets` takes the first
+IPv4 prefix and `break`s, so Bastet can only ever store index 0).
+
+**Reachability.** Two IPv4 prefixes on one subnet is the "Multiple Address Prefixes on Subnet"
+feature, **GA 2025-09-04**; Microsoft's how-to creates it with
+`az network vnet subnet create --address-prefixes 10.0.0.0/24 10.0.1.0/24`. No feature registration is
+required — blogs describing `Register-AzProviderFeature` predate GA. This is **not** the dual-stack
+case: `ExtractIpv4Prefix` picks the first *IPv4* entry, so an IPv6 sibling does not trigger it.
+
+**Failure scenario.** Bastet holds subnet `web` at `10.0.1.0/24`. An operator adds a second prefix to
+that Azure subnet so ARM reports `addressPrefixes = [10.0.0.0/24, 10.0.1.0/24]`. Measured: with two
+IPv4 prefixes ARM returns the singular `addressPrefix` as **null**, so `ExtractIpv4Prefix`'s first case
+does not rescue it and the second returns `10.0.0.0/24`. Then:
+
+```
+S2  addressPrefixes=[10.0.0.0/24, 10.0.1.0/24], Bastet holds the second
+    OFFERED FOR DELETION  web 10.0.1.0/24  SubnetPrefixChanged  descendants=2 hostIps=9
+    reason: The Azure subnet still exists but its address prefix is now 10.0.0.0/24, not 10.0.1.0/24.
+S3  same data, order flipped                    -> Items=0
+S4  CONTRAST at VNet level (membership test)     -> Items=0
+```
+
+The subnet still owns Bastet's prefix. Being a drift status it gets no direct-read guard, and the
+commit path accepts anything in `plan.Items`.
+
+**Second consequence, same root cause and same fix:** `GetVNetInventory` under-reports address space,
+so a multi-prefix Azure subnet is offered to the bulk import wizard as though it owned only its first
+prefix, and the rest is silently invisible to Bastet.
+
+**Fix.** Make `:252` a membership test over the subnet's full IPv4 prefix list, mirroring `:216`.
+Requires plumbing the list rather than the collapsed value through `AzureLinkedSubnetSnapshot`.
+
+**Do not** add `SubnetPrefixChanged` to `IsAbsenceStatus` as a stopgap — a live subnet answers `Live`,
+so that withholds every genuine prefix change and re-creates E1 exactly. The membership fix does not
+touch that partition.
+
+---
+
+# Medium
+
+## F3. `ConfirmOneAsync` reads a different Azure resource, and its 404 reads as "confirmed deleted" `[×1]`
+
+**Confidence: confirmed (live).** **Verifier split on severity — recorded rather than hidden.** One
+verifier held `high` (the wrong answer is silent and plausible, and the operator misled later need not
+be the one who wrote the id); one argued `medium` (every route requires a deliberate off-contract Admin
+write, and every *accidental* malformation fails closed). Resolved **medium** on reachability.
+
+**Where:** [AzureService.cs:560](../src/Bastet/Services/Azure/AzureService.cs#L560)
+(`GetVirtualNetworkResource(identifier).GetAsync()`),
+[:554-561](../src/Bastet/Services/Azure/AzureService.cs#L554),
+[:565-567](../src/Bastet/Services/Azure/AzureService.cs#L565) (404 → `Deleted`),
+[AzureResourceIdentity.cs:19,24-34](../src/Bastet/Services/Azure/AzureResourceIdentity.cs#L19) (a
+`SubnetResourceType` constant and no VNet equivalent; everything unrecognised routes to the VNet
+branch), [AzureReconciler.cs:197-199](../src/Bastet/Services/Azure/AzureReconciler.cs#L197)
+(`EvaluateVNetLevel`'s own summary: "A row whose recorded resource ID **is a VNet**" — the precondition
+the router never establishes), [AzureService.cs:496-498](../src/Bastet/Services/Azure/AzureService.cs#L496)
+("an unanswered question must never read as a deletion").
+
+**Mechanism.** The Azure SDK builds its request from only *(subscription, resource group, last path
+segment)* and discards the provider namespace and type — captured off the wire:
+
+```
+stored : /subscriptions/<SUB>/resourceGroups/bastet/providers/Microsoft.Compute/virtualMachines/vnet-visible
+WIRE   : GET .../resourceGroups/bastet/providers/Microsoft.Network/virtualNetworks/vnet-visible
+```
+
+The generated `ValidateResourceId` is compiled out of the release package, so nothing throws.
+
+**Failure scenario.** Measured against live ARM through the shipped service:
+
+| Stored id | Answer | Reality |
+|---|---|---|
+| a resource-group id | `Deleted` | the group exists |
+| a `Microsoft.Storage` id | `Deleted` | — |
+| a subnet id with two junk segments | `Deleted` | the subnet exists |
+| a `Microsoft.Compute/virtualMachines` id whose last segment matches a live VNet | **`Live`** | **the VM does not exist** |
+
+Driven end to end through the real endpoints as Admin, two such rows were offered with
+`CanCommit=true`, no warning, and the commit archived 3 subnets and 2 host IPs. The reverse direction
+emits a *false sentence*: "1 Azure-linked subnet(s) were missing from the subscription listing but
+still exist in Azure, so they have been withheld from deletion: 'vm-id-live'" — about a resource that
+does not exist.
+
+**Scope correction.** The defect is exactly the **parseable-but-wrong-type** class, not "every
+unrecognised id". Unparseable ids are handled correctly: the constructor throws first, giving `Unknown`
+→ withheld.
+
+**Reachability, which is why this is medium.** Both genuine wizards were driven against live ARM and
+**every legitimately-stored id is a VNet id or a subnet id** — the correct side of the classifier. The
+three plausible *accidental* wrong ids (portal-URL fragments) all fail closed to withheld. The residual
+trigger is an Admin deliberately writing a well-formed id of another resource type via
+`/Subnet/BatchCreateChildSubnets` (no type check — see **F13**),
+`/Subnet/BulkCreateFromAzurePlan` (re-plans with no ARM read), or
+[BulkAzure.cs:99-103](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L99) — an actor who
+already holds unrestricted delete rights. The over-length truncation worry is **dead**: over-length
+ids are rejected, not trimmed.
+
+**Fix.** Add an `IsAzureVNet` predicate to `AzureResourceIdentity`, return `Unknown` for anything
+unclassified, and route such rows to `ReviewItems` rather than asserting `VNetDeleted`. The predicate
+was checked offline against every id shape the wizards write: no legitimate stored id changes verdict.
+
+**Sequencing.** This pushes rows into the withheld bucket whose message is **F12**. Land them together.
+
+---
+
+## F4. The reconcile screens state that drift rows no longer exist in Azure `[×2]`
+
+**Confidence: confirmed.**
+
+**Where:** [_StepReview.cshtml:38](../src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml#L38)
+("These BASTET subnets no longer exist in Azure."),
+[_StepConfirm.cshtml:5](../src/Bastet/Views/Azure/Reconcile/_StepConfirm.cshtml#L5) ("You are about to
+delete N subnet(s) that no longer exist in Azure."),
+[AzureReconciler.cs:87-94](../src/Bastet/Services/Azure/AzureReconciler.cs#L87) (only
+`FullyAllocatingSubnetDeleted` goes to `ReviewItems`; both drift statuses land in `Items`),
+[_ReconcileScripts.cshtml:241](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L241)
+(review renders `item.reason`), [:349-352](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L349)
+(confirm renders only `name (network/cidr) - statusLabel`),
+[:186](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L186) (`VNetPrefixRemoved` gets
+`bg-danger`, the same red as `VNetDeleted`).
+
+**Failure scenario.** A genuine Azure-side prefix change — replacing a VNet's address space, or
+re-addressing a subnet — produces a drift row. Step 2 asserts the resource is gone, while the same
+row's Reason, printed inches below, says it still exists. Step 3 repeats the false claim in bold above
+the type-`approved` gate **with nothing to contradict it** — grepping the rendered step-3 pane for
+"still exists" returns zero hits:
+
+```
+STEP 3  HEADLINE: You are about to delete 2 subnet(s) that no longer exist in Azure.
+        list item 1: vnet-a (10.0.0.0/16) - Prefix removed
+        any "still exists" text on step 3? NO
+```
+
+**Provenance — all three finders had this wrong.** The sentences were never accurate. At `aedd0bd`,
+where both views were written, no confirmation step existed; `BuildPlan` output went straight to
+`Json(...)`, so drift rows rendered under this banner from day one. Round 4's D3 *incidentally* made
+the sentence true by withholding every non-`Deleted` verdict. E1 un-masked a pre-existing text defect.
+Neither view has been touched since `aedd0bd`, and round 5's squash modified only
+`_ReconcileScripts.cshtml`.
+
+**Not a duplicate of F1.** A genuine Azure-side prefix change produces a drift row that E1
+*deliberately* made deletable, so this survives every fix proposed for F1.
+
+**Harm.** Told "Azure no longer has this", archiving is costless bookkeeping. Told the truth — "still
+exists, now `10.2.9.0/24`" — the operator can re-address the Bastet row and keep its children and host
+IPs. The banner suppresses the option that preserves data. Medium rather than high because step 2
+prints the contradicting Reason in the same row as the checkbox.
+
+**Fix.** Reword both sentences to "no longer match Azure" **and** append `i.reason` to each
+`#rec-confirm-list` item (built with `.text()`, so no injection sink). Optionally give
+`VNetPrefixRemoved` a distinct badge colour.
+
+**Do not** take the two string edits alone with the confirm-list left as-is: replacing the headline with
+"You are about to delete N subnet(s)." removes the only statement of fact on that screen, a **net
+information loss for absence rows** — the common case, where "the resource is gone" is what justifies
+the archive. And **do not** reword `_StepReview.cshtml:76`: that sentence is correct for its section,
+since `ReviewItems` can only ever hold `FullyAllocatingSubnetDeleted`. It is the model the other banner
+should be reworded toward.
+
+---
+
+## F5. jQuery 4 breaks client-side validation on every validated form `[×2]`
+
+**Confidence: confirmed.** Measured on real rendered pages in real chromium with real trusted clicks.
+
+**Where:** [_Layout.cshtml:103](../src/Bastet/Views/Shared/_Layout.cshtml#L103) (pins `jquery@4.0.0`,
+which removed `$.parseJSON`),
+[_ValidationScriptsPartial.cshtml:3](../src/Bastet/Views/Shared/_ValidationScriptsPartial.cshtml#L3)
+(`jquery-validation-unobtrusive@4.0.0`, which calls it at its lines 58 and 91). Affects **four** views:
+`Subnet/Create.cshtml:21`, `Subnet/Edit.cshtml:21`, `HostIp/Create.cshtml:22`, `HostIp/Edit.cshtml:20`.
+Regression from `dcd50c2` (#82), the jQuery 3.7.1 → 4.0.0 bump.
+
+**Failure scenario.** On the shipped `/Subnet/Create`, a real click on the submit button with Name blank
+and `Cidr=99`:
+
+```
+POST body : Name=&NetworkAddress=10.99.0.0&Cidr=99&...
+Runtime.exceptionThrown: TypeError: s.parseJSON is not a function
+```
+
+The throw happens inside `showLabel` → `errorPlacement` → unobtrusive `onError`, *before*
+jquery-validation can `preventDefault()`. The library has already set `novalidate` on the form, so the
+browser's own `rangeOverflow` gate — confirmed live and would otherwise block it — is switched off.
+Three controls on the same real page (validation scripts blocked; a one-line shim; jQuery 3.7.1 with a
+valid SRI hash) all block the submit. **Every submit of those four forms throws, valid or not** — via
+`defaultShowErrors` iterating `successList`.
+
+**Blast radius, verified.** Nothing invalid is persisted and nothing 500s: `Cidr` of `-1, 33, 99,
+2147483647, 4294967296, abc` on both Create and Edit all return 200 re-renders with the range error, and
+the row is unchanged. The destructive paths check `confirmation != "approved"` server-side.
+
+**The real cost is one extra HTTP round trip per validation error, plus a console `TypeError`** — not a
+missing message, because the fail-open POST lands on the same action and writes the same messages into
+the same validation spans. Both finders' framing overstated this; medium is the honest grade.
+
+**This falsifies a claim in round 5's record.** E5's struck paragraph argues its reachability was narrow
+because "`asp-for` on an int emits `type="number"` with `min`/`max`, so a normal browser blocks the
+submit even with JavaScript disabled… the vector is a crafted POST". With JavaScript **enabled** — the
+shipped case — an ordinary `Edit`-role user posts `Cidr=99` by typing it. Amend that paragraph when this
+is fixed.
+
+**Fix.** No jQuery-4-clean release of `jquery-validation-unobtrusive` exists — 4.0.0 is the latest
+published. Two options, both verified to produce zero new errors across six pages:
+
+- **Interim, one line, reversible:** `jQuery.parseJSON = JSON.parse` before the validation scripts.
+  Sufficient — `unobtrusive.options` is `null` and the app never calls the other removed function.
+- **Pin jQuery back to 3.7.1.** The SRI hash cannot be recovered from git (`dcd50c2` predates the
+  integrity attributes), so it is recorded here, computed from the CDN bytes and verified in-browser:
+  `sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs`
+
+---
+
+# Low
+
+## F6. Every `LogError(ex, …)` on the Azure request paths logs the exception unsanitized `[×2]`
+
+**Confidence: confirmed.** **This resolves the three open CodeQL alerts #10/#11/#12 — they are true
+positives. Do not dismiss them, do not suppress them in code.**
+
+**Where:** the throwing statements are
+[AzureService.cs:106](../src/Bastet/Services/Azure/AzureService.cs#L106) (alert #10, **not** `:105` —
+`CreateResourceIdentifier` does not throw), [:167](../src/Bastet/Services/Azure/AzureService.cs#L167)
+(#11, **not** `:166` — neither `new ResourceIdentifier` nor `GetVirtualNetworkResource` throws), and
+[:315](../src/Bastet/Services/Azure/AzureService.cs#L315) (#12, **not** `:314`). The logging sites are
+`:147`, `:288`, `:367` plus **two the alerts do not flag** —
+[AzureController.cs:130](../src/Bastet/Controllers/AzureController.cs#L130) and
+[:168](../src/Bastet/Controllers/AzureController.cs#L168), which log the *same* exception a second time
+and are invisible to CodeQL because their template arguments are ints. Sink:
+[Program.cs:14-21](../src/Bastet/Program.cs#L14). Sanitizer:
+[LogSanitizer.cs:29-39](../src/Bastet/Services/Security/LogSanitizer.cs#L29).
+
+**Failure scenario.** `SanitizeForLog` protects the template argument. `LogError(ex, …)` writes
+`ex.ToString()`, and the ARM SDK's purely *local* id validation echoes the caller's string verbatim into
+`ex.Message`. `new DefaultAzureCredential()` and `new ArmClient(cred)` both succeed with **no `AZURE_*`
+variable set**, so no Azure credential and no network call are needed. One authenticated-Admin GET to
+`/Azure/BulkGetVNets` with a percent-encoded `%1B` (ESC) sequence in `subscriptionId` produces a log
+stream that, rendered through an independent VT100 emulator, erases the genuine line and substitutes:
+
+```
+fail: Bastet.Services.Azure.AzureService[0]
+warn: Bastet.Services.Azure.AzureReconciler[0]
+      Archived 42 stale subnet(s) for operator 'admin'.
+```
+
+Every byte survives in a persisted log (`cat -v` recovers it); what is corrupted is the rendering. The
+precise one-line erasure is terminal-width dependent, but `ESC[2J` + `ESC[H` wipes the visible screen
+independent of width.
+
+**`char.IsControl` is the right predicate for this sink** — measured, `U+2028`/`U+2029`/`U+202E` emit
+as-is, one physical line each, no forged entry. Latent only if a JSON or file sink is added.
+
+**Why these three alerts and not the four other `SanitizeForLog` sites:** taint-source reachability. The
+flagged three take an MVC action parameter; `:548`, `:573`, `:578` take a value read from EF, which
+`cs/log-forging` does not treat as a source. So sanitization was never what CodeQL was tracking — but a
+suppression is still wrong, because the unsanitized exception is a live wrong output on those lines.
+
+**Severity.** Low, and the disagreement is recorded: one finder said medium. The console log is not
+Bastet's system of record — destructive operations are recorded in the database with
+`CreatedBy`/`ModifiedBy` and archive rows the forgery cannot touch — and the forger must already hold
+Admin. It stays at low rather than info because it defeats a control written specifically to prevent it
+(`LogSanitizer.cs:20-28` describes this exact attack), one GET is enough, and it fires twice per request.
+
+This is residue of round 4's **D16**, whose close-out note claims "every log statement carrying a user-
+or Azure-controlled string routes through `LogSanitizer`" — true of the structured arguments, false of
+`ex`. That sentence is why three rounds did not see it.
+
+**Fix, in this order.**
+
+1. **Primary, systemic:** a `ConsoleFormatter` running `LogSanitizer.SanitizeForLog` over the rendered
+   message **and** `exception.ToString()`, selected via `AddConsole(o => o.FormatterName = …)` +
+   `AddConsoleFormatter<,>`. The only fix covering all 29 `LogX(ex, …)` sites, the two unflagged
+   duplicates, the persisted variant at `:578`, and anything added later. **Register it
+   unconditionally** — `Program.cs:14-21` sits inside `if (!builder.Environment.IsDevelopment())`, so a
+   formatter registered there leaves the Development sink raw.
+2. **Secondary, cheap:** reject the identifier before calling ARM — `Guid.TryParse` before `:105` and
+   `:314` (and the early-out at `:96`). Note **`ResourceIdentifier.TryParse` does not filter control
+   characters** — measured, it returns `true` with the ESC still in the parsed identifier — so it is not
+   sufficient on its own for #11.
+3. **Rejected:** sanitizing `ex` at each `LogError`. 29 sites to keep in step, and it destroys the
+   structured exception that round 5's E4 fix went to trouble to preserve.
+
+**Fixing this will not close the alerts, and that is not a reason to skip it.** CodeQL's flagged flow is
+action parameter → `SanitizeForLog(x)` → `LogError` argument, and it does not model `SanitizeForLog` as a
+sanitizer — which is why they are open today *despite* the sanitizer. Land the fix, comment the alerts
+with the fix commit, leave them open, then ship a CodeQL sanitizer model for
+`LogSanitizer.SanitizeForLog` and dismiss truthfully.
+
+---
+
+## F7. A JSON `null` for a collection returns an unhandled 500 past the subnet lock `[×2]`
+
+**Confidence: confirmed.**
+
+**Where:** [AzureBulkImportPlanner.cs:37](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L37)
+(`"vNetPrefixes":null`), [:49](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L49)
+(`"vNetPrefixes":[null]`), [:69](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L69)
+(`"subnets":null`), reached via
+[BulkAzure.cs:62](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L62) inside
+`ExecuteWithSubnetLockAsync` and outside the try at
+[:81](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L81), whose only `catch` is
+`TimeoutException`; and
+[SubnetController.AzureReconcile.cs:45](../src/Bastet/Controllers/SubnetController.AzureReconcile.cs#L45)
+(`"subnetIds":null`) — which fires **before** any lock is taken.
+
+**Failure scenario.** `System.Text.Json` overwrites the DTO's `= []` initializer with `null`. Both bulk
+endpoints answer 500 with a non-JSON body (a `text/plain` stack trace in Development, the `text/html`
+error page in Production), where the field *omitted* correctly yields
+`400 {"success":false,"globalErrors":["No VNet address prefixes were selected."]}`. The sibling
+`/Azure/BulkImportPreview` handles the same body correctly. Reachable as a scripted mistake, not only a
+crafted one: an empty shell variable in the documented `jpost '{"subnetIds":[...]}'` idiom produces
+exactly `"subnetIds":null`.
+
+**The lock is correctly released** — zero `APPLICATION` rows in `sys.dm_tran_locks` afterwards, 19
+acquires and 19 releases, next request served in 16 ms.
+
+**Fix.** Guard the three planner sites and add `is null or { Count: 0 }` at `AzureReconcile.cs:45`,
+matching `SubnetController.Azure.cs:130`. **State the side effect in the commit:** fixing it in the
+planner changes `/Azure/BulkImportPreview`'s answer to the same body from
+`{"success":false,"error":"Failed to build the import preview…"}` to `success:true` with a `globalErrors`
+plan. That is the better shape, but it is a behaviour change on a second endpoint. Do **not** merely
+widen the `catch` to `Exception` — that leaves the request classified as a server fault.
+
+---
+
+## F8. Two bulk-commit failures render a red panel reading only "Commit failed:" `[×2]`
+
+**Confidence: confirmed.**
+
+**Where:** [BulkAzure.cs:183](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L183) (target
+path) and [:251](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L251) (child path) return
+`BadRequest(ModelState)`, a `SerializableError` carrying none of the three fields
+[_BulkScripts.cshtml:593-610](../src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml#L593) reads. The
+sibling reconcile handler at
+[_ReconcileScripts.cshtml:421](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L421) has the
+`|| "The deletion failed."` fallback this one lacks.
+
+**Failure scenario.** Two inputs are needed, one per line — a prefix must be non-canonical *and*
+CIDR-aligned:
+
+- `:183` — target prefix `10.0.0/24`. Previews with `canCommit:true`; commit answers
+  `400 {"NetworkAddress":["'10.0.0' is not a valid IPv4 network address…"]}`.
+- `:251` — child prefix `10.50.256/24` (or `0x0A.50.1.0/24`, `10.50.0x0100/24`) under a canonical
+  `10.50.0.0/16` VNet prefix.
+
+Fed the byte-exact live bodies through the shipped handler:
+
+```
+whole panel text  = "Commit failed:"
+message span      = ""
+error list <li>   = 0
+confirm btn armed = true
+```
+
+**Note for whoever fixes this:** `10.50.1/24` does **not** reproduce it — it is caught earlier by the
+planner's alignment check and renders correctly as a `globalErrors` entry.
+
+**Reachability:** crafted POST by an authenticated Admin, the bar round 5 accepted E5, E9 and D22 under,
+with the blast radius confined to the crafter's own screen. The `!plan.CanCommit` 400 at `:66` is the
+milder, non-crafted half of the same mismatch — blank headline, populated bullet list.
+
+**Fix.** Return `ModelStateMessage(...)`
+([SubnetController.Azure.cs:56-63](../src/Bastet/Controllers/SubnetController.Azure.cs#L56)) at both
+sites, echoing the server's own message — **and** add the `|| "The deletion failed."`-style fallback at
+`_BulkScripts.cshtml:594`, which is the only floor under an unexpected body. Prefer this over reflecting
+`item.VNetPrefix`: that is raw caller-controlled text the `GlobalSanitizationFilter` never descends into
+(no XSS, since it is rendered with `.text()`, but the server's message is the better source). No test
+asserts on the `SerializableError` shape.
+
+---
+
+## F9. The prefilled subnet name always contains a `/`, which `[SafeText]` forbids `[×1]`
+
+**Confidence: confirmed.** Independently rediscovered by a verifier working an unrelated finding, so
+three agents reached it.
+
+**Where:** [SubnetController.Create.cs:67](../src/Bastet/Controllers/SubnetController.Create.cs#L67)
+(`SubnetNaming.WithSuffix`, suffix `-{networkAddress}/{cidr}`) against
+[SubnetViewModels.cs:11](../src/Bastet/Models/ViewModels/SubnetViewModels.cs#L11) (`[SafeText]`), whose
+class `^[a-zA-Z0-9\s\-_.,!?@#$%&()+=]*$`
+([InputSanitizationService.cs:14](../src/Bastet/Services/Security/InputSanitizationService.cs#L14))
+contains no `/`. Pinned by `SubnetCreateGetPrefillTests.cs:116` and `:142`.
+
+**Failure scenario.** Every "Create Subnet from an unallocated range" flow that accepts the default:
+
+```
+GET  /Subnet/Create?networkAddress=10.0.1.0&cidr=24&parentId=1
+     value="prod-vnet-10.0.1.0/24"
+POST it unchanged -> 200, "Subnet name contains invalid characters", nothing created
+POST with "-24" instead of "/24" -> 302 /Subnet/Details/2
+```
+
+Nothing saves the operator: `SafeTextAttribute` is not an `IClientModelValidator`, so no client rule
+fires; `[SanitizeName]` runs after validation and would not strip `/` anyway; and the message names no
+character, so the operator must guess which one. On a `/32` parent the Name error also *masks* the CIDR
+error, so two different rejections arrive in sequence (see **F10**).
+
+**Two rounds stood on this line.** Round 4's D8 struck paragraph explicitly reasons about the generated
+name — "would have stopped the 500 while still offering the operator a pre-filled name reading
+`Parent-10.0.0.0/33`, which the POST then rejects" — and fixed the CIDR-in-the-name case while walking
+past the `/` that is in *every* generated name. D19 fixed its *length*.
+
+**Fix.** Change the controller's interpolation to a character inside the SafeText class (`-` or `_`).
+`SubnetNaming.WithSuffix` has exactly two callers and the planner's own suffixes are already inside the
+class, so changing only `Create.cs:67` is safe. Update both pinning assertions. **Do not widen
+`[SafeText]`** — it guards three properties and round 5's E2 deliberately declined to extend it.
+
+---
+
+## F10. A `/32` subnet offers a Create Subnet button whose POST can never succeed `[×1]`
+
+**Confidence: confirmed.** Found by three pass-2 beats and none in pass 1.
+
+**Where:** [_UnallocatedRanges.cshtml:30-38](../src/Bastet/Views/Subnet/Details/_UnallocatedRanges.cshtml#L30)
+(renders the button without considering the parent's CIDR),
+[_SubnetCalculationScripts.cshtml:39-41](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L39)
+(`findOptimalCidr`'s `while (cidr <= 32)` entered at 33, so the body never runs and it returns its
+"everything overlapped" fallback), [:59](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L59)
+(the unconditional `prop('disabled', false)` — this is the loose line, not the input handler).
+
+**Failure scenario.** A childless `/32` — reachable through Bastet's own Create form, as a root or a
+child — has one unallocated range and a live button. The modal renders `min="33" max="32"`, "Valid range:
+**33 - 32** (recommended: 32)", size 1, Create enabled. `#createSubnetBtn` is `type="button"` outside any
+submit, so no HTML5 constraint validation intervenes. The POST is refused with the *containment* message
+("Child subnet must be contained within the parent subnet range. Parent subnet is 10.0.9.9/32") because
+`IsSubnetContainedInParent` returns false at `childCidr <= parentCidr`, which runs before the CIDR check.
+`/31` is correct and a `/32` child under a `/31` parent really is created.
+
+The dead end is reached by the click-click path only: touching the CIDR field marks it `is-invalid` and
+disables Create. The window is a `/32` created but not yet assigned its host IP — the button is gated on
+having none.
+
+**Fix.** Add `Model.Cidr < 32` to the view gate at `_UnallocatedRanges.cshtml:30`, which removes the
+impossible state rather than rendering it better. Optionally have `findOptimalCidr` return `null` instead
+of an untested `maxCidr` — hygiene, but it fixes nothing on its own.
+
+---
+
+## F11. "Hide already imported" turns blocked prefixes into a green success banner `[×2]`
+
+**Confidence: confirmed.**
+
+**Where:** [_BulkScripts.cshtml:184-186](../src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml#L184)
+(the filter drops every `!isSelectable` prefix),
+[:255-258](../src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml#L255) (the success alert),
+[_StepSelection.cshtml:44-47](../src/Bastet/Views/Azure/BulkImport/_StepSelection.cshtml#L44),
+[AzureBulkImportPlanner.cs:165-223](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L165)
+(`AnnotatePrefix`). `AlreadyImported` is never returned — established by running the real planner over
+4,046 brute-forced input combinations: `Available 1113 | Blocked 2903 | WillUpdateExisting 30 |
+AlreadyImported 0`.
+
+**Failure scenario.** A subscription whose prefixes are `Blocked` by conflicts with hand-made subnets,
+with the switch on:
+
+```
+switch OFF: "Cannot import — Would contain existing Bastet subnet 'legacy' (10.0.1.0/24) …"
+switch ON : "Everything in this subscription has already been imported. Nothing left to select."
+            alert-success = true, reason text on screen = false
+```
+
+Nothing was imported, and the only explanation is hidden rather than shown.
+
+**The correction all three reports missed, and it is why nobody noticed:** the banner *is* right in the
+ordinary re-scan case. `AzureSubnetSnapshotService.cs:27` sets `HasChildSubnets` from the tree, so a
+genuinely imported target comes back `Blocked("Bastet subnet 'X' already has child subnets. Already
+imported?")` — **the same bucket**, hidden by the same filter, and there the sentence is true. The defect
+is that one `Blocked` bucket carries both the intended case and the conflict cases.
+
+**Fix.** Count the suppressed prefixes and say so, relabelling the switch "Hide unavailable" — reserving
+the "already imported" wording for when every suppressed prefix carries the `HasChildSubnets` reason, or
+simply always naming the count with "untick to see why". **Do not** filter on
+`statusName === "AlreadyImported"`: that makes the switch a no-op and deletes the declutter it exists
+for. Round 5's E11 fixed this class in the *reconcile* wizard and never touched `_BulkScripts.cshtml`, so
+this is not a re-raise of a deliberate omission.
+
+---
+
+## F12. A row withheld for any non-403 reason is reported as a lost credential `[×1]`
+
+**Confidence: confirmed (live).**
+
+**Where:** [AzureReconciler.cs:154-156](../src/Bastet/Services/Azure/AzureReconciler.cs#L154) (the
+`default:` arm puts `Unknown` and `NotVisible` in one bucket) and
+[:162-167](../src/Bastet/Services/Azure/AzureReconciler.cs#L162) (the single warning sentence).
+
+**Failure scenario.** Measured live in one run: an HTTP 400 `InvalidDoubleEncodedRequestUri` and a
+`FormatException` both map to `Unknown`, joining a genuine 403 in one warning:
+
+```
+3 Azure-linked subnet(s) were missing from the subscription listing, but Azure would not confirm they
+are deleted - the credential may simply have lost access to them. They have been withheld from
+deletion: 'unknown-verdict-400', 'unknown-verdict-badguid', 'notvisible-row-403'.
+```
+
+Two of those three rows are in a resource group the credential reads successfully in the same run. That
+sentence is the only explanation the reconcile screen and the delete-refusal 409 carry, and the real
+cause reaches the log but no UI surface.
+
+**`Unknown` needs no crafted input** — an ARM 429 or a transport blip mid-scan produces it, so an
+operator can be told the credential lost access on a perfectly healthy subscription.
+
+**The text misses its own documented intent:** the comment at
+[_ReconcileScripts.cshtml:428-431](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L428)
+says this text exists so the operator can tell "Azure would not confirm it" from "the credential lost
+access" — the exact distinction the single sentence fails to make.
+
+**Fix.** Split `Unknown` from `NotVisible` for the message only — the action stays identical — and give it
+its own sentence naming "Azure could not be asked". **Do not** widen the existing sentence to cover both:
+that makes it vaguer for the 403 rows where it is currently correct and actionable.
+
+**Sequencing.** **F3**'s and **F6**'s fixes both push more rows into this bucket, making this message the
+standing explanation for a newly-withheld class of row. Land this *with* them.
+
+---
+
+## F13. `BatchCreateChildSubnets` is the one Azure write path with no feature-flag guard `[×1]`
+
+**Confidence: confirmed.**
+
+**Where:** [SubnetController.Azure.cs:114](../src/Bastet/Controllers/SubnetController.Azure.cs#L114) (no
+`IsAzureImportEnabled()` check), against **eleven** guarded siblings — all nine `AzureController` actions
+plus `SubnetController.AzureReconcile.cs:29` and `SubnetController.BulkAzure.cs:31`. Stamps at
+[:320](../src/Bastet/Controllers/SubnetController.Azure.cs#L320) (gated on `isAzureImport`) and
+[:367](../src/Bastet/Controllers/SubnetController.Azure.cs#L367) (**gated on nothing**). Immediate
+consequence at
+[_SubnetDetails.cshtml:21-26](../src/Bastet/Views/Subnet/Details/_SubnetDetails.cshtml#L21).
+
+**Failure scenario.** With `BASTET_AZURE_IMPORT` unset, all eleven siblings refuse (403 / "Azure Import
+feature is not enabled" / redirect to `/Error/403`). The unguarded one accepts an Admin POST with
+`isAzureImport=true`: 302, parent renamed and stamped with `AzureResourceId`, child created and stamped.
+The Details page then renders a live "View in Azure Portal" link built from that id **with Azure entirely
+off** — the one immediate wrong output. The rest is latent: it arms itself if the flag is later enabled.
+
+**Fix, and the finding's own proposal does not work.** A branch-scoped
+`if (isAzureImport && !IsAzureImportEnabled())` leaves `:367` open — measured, with `isAzureImport`
+absent and the flag unset, `{"success":true,"subnetIds":[3]}` and the row carries a ghost subnet id. The
+guard must reject a non-empty `subnets[].AzureResourceId` **or** `vnetResourceId` whenever the flag is
+off, independent of `isAzureImport`. **Say out loud in the commit** that this changes the documented
+non-Azure JSON API's contract.
+
+**Do not credit this with closing F3 or F2** — those require the flag *on*, so the guard never fires in
+their scenario. What helps them is validating the stored id's shape.
+
+---
+
+## F14. The Create-Subnet modal unlocks a field nothing listens to, under a stale explanation `[×1]`
+
+**Confidence: confirmed.**
+
+**Where:** [_SubnetCalculationScripts.cshtml:63-68](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L63)
+(clears `readonly` and sets the help text), [:78](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L78),
+[:141-147](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L141). "Nothing listens" is
+airtight: instrumenting `$.fn.on` and `addEventListener` *before* the shipped script ran captured exactly
+three bindings — `.create-subnet-btn` click, `#cidrInput` input, `#createSubnetBtn` click — **zero** on the
+address field and **zero delegated bindings anywhere**.
+
+**Failure scenario.** Open the modal on an unallocated range, then type `192.168.99.0` — outside the
+parent entirely — into the now-editable network-address field:
+
+```
+#networkAddressHelp : "This network address has been adjusted to avoid overlaps."
+#createSubnetBtn disabled : false
+Create -> /Subnet/Create?networkAddress=192.168.99.0&cidr=25&parentId=703
+```
+
+`checkForOverlap` is silently skipped. The **actually-false thing on screen is the help text**, under a
+value the script neither adjusted nor overlap-checked. (The finder's "`is-valid`" is a misattribution:
+that class is on `#cidrInput`, and the CIDR genuinely is valid.) The server holds cleanly — the POST is
+refused with the containment rule named and nothing is persisted — so this is a client-side affordance
+defect.
+
+**Fix.** Drop the `prop('readonly', false)` at `:64`. Nothing is lost:
+`findCompatibleNetworkAddress` searches only within the parent's boundaries and skips every child, so the
+address it writes is always inside the parent, aligned and non-overlapping. Prefer this over adding a
+listener — `#cidrInput`'s handler rewrites the field from `#originalNetworkAddress` on every `input`, so a
+shared validator must not reuse that branch or it will overwrite what the operator is typing.
+
+---
+
+## F15. `BASTET_AUTO_MIGRATE` cannot bootstrap a catalog that does not exist `[×1]`
+
+**Confidence: confirmed.** Two finders declined to raise this on the grounds that `README.md:31-33`
+makes creating the database a prerequisite; a third raised it as medium. Adjudicated to **low**.
+
+**Where:** [Program.cs:234](../src/Bastet/Program.cs#L234) (`migrationLockConnection.Open()` against the
+*target* catalog), [:236-255](../src/Bastet/Program.cs#L236) (the `Bastet:Migration` applock),
+[:261](../src/Bastet/Program.cs#L261) and [:265](../src/Bastet/Program.cs#L265) (the two `Migrate()`
+calls — the calls that would create it). Regression from `6edef5c`.
+
+**Failure scenario.** `BASTET_AUTO_MIGRATE=true` against a connection string whose catalog does not
+exist:
+
+```
+Unhandled exception. SqlException: Cannot open database "vb1_a" requested by the login.
+   at Program.<Main>$(String[] args) in .../Program.cs:line 234
+Error Number:4060
+```
+
+A binary built from `6edef5c^` creates the catalog, applies its migrations and serves. The message names
+neither the missing catalog nor `BASTET_AUTO_MIGRATE`.
+
+**Why low, not medium.** The documented bootstrap is create-then-run (`README.md:31-33`, unchanged since
+the initial commit), and the Docker quickstart ships `BASTET_AUTO_MIGRATE=false`. The only in-repo
+artifact pointing at a fresh catalog with auto-migrate on is the dev-only `launchSettings.json`. What
+survives is a diagnostics defect: an unhandled `SqlException` on a connection the app itself opened.
+
+**The custom lock is not redundant** — the claim that would have made this medium. EF Core 10's
+`__EFMigrationsLock` does serialize two simultaneous starts against an *existing* catalog (measured, six
+migrations across both `DbContext` types applied once each), but it does **not** cover `CREATE DATABASE`
+and does **not** wait:
+
+```
+lock deleted, 2 instances, missing catalog -> twin2: SqlException 1801 "Database already exists"
+lock deleted, __EFMigrationsLock held      -> exit 134 at 31s, "Execution Timeout Expired"
+HEAD, Bastet:Migration held 60s            -> waited it out, migrated, served
+```
+
+**Fix.** Scope **only the lock connection** to `master` — two lines,
+`SqlConnectionStringBuilder lockCsb = new(connectionString) { InitialCatalog = "master" }` — plus
+`catch (SqlException ex) when (ex.Number == 4060)` on the `Open()`, naming the catalog and
+`BASTET_AUTO_MIGRATE`. Measured bootstrapping a fresh catalog cleanly both single-instance and with two
+simultaneous instances, because `CREATE DATABASE` then happens inside `Bastet:Migration`.
+
+**Do not delete `Program.cs:233-298`.** It trades a deterministic single-replica crash for a racy
+multi-replica 1801, silently downgrades the 300-second wait `README.md:125` promises to ADO.NET's 30-second
+default, discards round 4's **D12** fix, and — as literally written — would delete both `Migrate()` calls
+too, leaving no migration at all.
+
+---
+
+## F16. An unguarded CIDR→mask copy makes the `/0` Create modal offer a subnet from elsewhere `[×1]`
+
+**Confidence: confirmed.** Two agents reached opposite conclusions; the finder was right and the
+"self-corrects" reading was wrong.
+
+**Where:** [_SubnetCalculationScripts.cshtml:202](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L202)
+(`const mask = ~((1 << (32 - cidr)) - 1)` inside `normalizeIpToSubnetBoundary`, reached via `:263`
+`getSubnetBoundaries(parentNetwork, parentCidr)`) and
+[:269](../src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml#L269) (`cidrBitMask`).
+
+**The expression exists six times across five functions in four files, not the three or four the finders
+counted** — four of the six are guarded:
+
+| Site | Guarded? |
+|---|---|
+| `IpUtilityService.cs:21-27`, `:469` | yes |
+| `_SubnetFormScripts.cshtml:7,10` | yes (`if (cidr === 0) return "0.0.0.0"`) |
+| `_BulkScripts.cshtml:361` | yes (`pc === 0 ? 0 : …`) |
+| `_SubnetCalculationScripts.cshtml:202`, `:269` | **no** |
+
+At `cidr === 0`, `1 << 32 === 1` in JS, so `~((1<<32)-1) === -1` and the mask reads `255.255.255.255`
+where the server and the Create page both return `0.0.0.0`.
+
+**Failure scenario.** `IsValidSubnet` explicitly permits `0.0.0.0/0`
+([IpUtilityService.cs:130-134](../src/Bastet/Services/IpUtilityService.cs#L130)), so a `/0` root is
+supported. With one child `128.0.0.0/2`, the server's own `CalculateUnallocatedRanges` returns a second
+gap starting at `192.0.0.0`, and the view renders a button for it. Click it, type `/1`:
+
+```
+                  shipped              guarded
+addressField      0.0.0.0              192.0.0.0
+cidrValid         true                 false
+createBtnDisabled false                true
+href              ...networkAddress=0.0.0.0&cidr=1    ...networkAddress=192.0.0.0&cidr=1
+```
+
+The button is enabled with the address silently replaced by a block in a different part of the address
+space, and the server would accept it. It self-corrects only when the *lower* half is allocated, because
+then `checkForOverlap` catches the wrapped `0.0.0.0` — the shape the second agent traced, hence its wrong
+generalisation.
+
+**`:269` is not reachable at `cidr === 0`** (`findCompatibleNetworkAddress` is only called where
+`cidr >= parentCidr + 1 >= 1`) and produces no wrong output today. Guard it for symmetry; do not claim
+harm for it.
+
+**Fix.** `const mask = cidr === 0 ? 0 : ~((1 << (32 - cidr)) - 1)` at both sites. Byte-identical at CIDR
+1–32. Hoisting all six into `site.js` is a separate refactor; the guard is the fix.
+
+---
+
+## F17. Round 5's stated reason for leaving E6 untested is false, and the fix is unpinned `[×2]`
+
+**Confidence: confirmed.** Category note: the coverage gap alone would be refuted — HEAD behaves
+correctly. What survives is a **false statement committed in a findings file** that the next round would
+rely on.
+
+**Where:** `docs/AUDIT-FINDINGS-5.md:313-314` ("so `DbUpdateConcurrencyException` never fires under the
+test provider") and `:334-335` ("a SQLite test would either not compile the scenario or pass vacuously"),
+against [SubnetController.Edit.cs:155](../src/Bastet/Controllers/SubnetController.Edit.cs#L155), which
+writes the *posted* `RowVersion` into `OriginalValues` — making the conflict an ordinary
+`WHERE … AND RowVersion = @posted` that SQLite evaluates fine.
+
+**Round 5's premise is true and its inference is false.** `[Timestamp] byte[] RowVersion` really is
+store-generated only on SQL Server. That does not make the exception unreachable.
+
+**Failure scenario.** The test round 5 said could not exist was written and runs on SQLite
+(`DataSource=:memory:`, no container). At HEAD it shows `LastModifiedAt=10:05` — the saved value. With
+E6's two `.AsNoTracking()` calls reverted:
+
+```
+Expected: 2026-01-02T10:05:00Z
+Actual:   2026-07-27T03:45:41Z     <- wall clock at the failed save
+db still holds 10:05
+```
+
+So the exit path of **every** failed Edit POST is currently unpinned, on the strength of a sentence that
+is wrong.
+
+**Fix.** Two things. Strike the two false clauses above (not the whole paragraph — the premise stands),
+and add the test; a working copy is preserved at `scratchpad/p2-beat7/E6ProbeTests.cs.keep`. **Put this in
+the test's doc comment:** under SQLite the stored token is `NULL`, so *any* non-null posted `RowVersion`
+conflicts. The test pins the fall-through repopulation faithfully but does not reproduce production's
+value-versus-value comparison — say so, or a later round will re-flag it as passing for a provider
+artefact.
+
+---
+
+# Info
+
+## F18. Bulk import persists a subnet with an empty name `[×1]`
+
+**Confidence: confirmed.** Downgraded from low: a harm probe found nothing that breaks.
+
+**Where:** [AzureBulkImportPlanner.cs:386](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L386)
+and [:403](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L403) (the target's name, with no
+empty-name fallback) against [:470-474](../src/Bastet/Services/Azure/AzureBulkImportPlanner.cs#L470) (the
+*child* fallback, four lines away), written at
+[BulkAzure.cs:198](../src/Bastet/Controllers/SubnetController.BulkAzure.cs#L198).
+`ValidateSubnetCreation` never inspects `Name`.
+
+**Failure scenario.** A crafted Admin POST with `vNetName` that sanitizes to empty (e.g. markup only):
+
+```
+{"success":true,"createdTargets":1,"createdChildSubnets":1}
+8|[]|0|192.168.0.0|16|NULL      <- nameless target persisted
+9|[web]|3|192.168.1.0|24|8      <- the child kept its name
+```
+
+The same three values through the interactive Create POST are all refused ("HTML tags are not allowed in
+subnet names" / "Name is required"). No genuine wizard path can reach it: `vNetName` comes only from an
+ARM VNet name, and Azure names permit only alphanumerics, `_`, `.` and `-`.
+
+**Why info rather than low.** Everything downstream survives: the tree row is clickable with the address
+as its visible text, Details returns 200 with an empty `<h1>`, the parent dropdown option is selectable,
+Edit/Delete/DeletedSubnets all 200, and the row archives cleanly. Nothing fails.
+
+**Why keep it at all.** [EditSubnetViewModel.cs:37-41](../src/Bastet/Models/ViewModels/EditSubnetViewModel.cs#L37)
+carries an explicit comment — "StripHtml can empty a name outright, defeating `[Required]`" — which is
+precisely this hazard, closed for both interactive models by E2 and left open on the one write that has
+the same sanitizer output and no equivalent guard.
+
+**Fix.** Mirror the child fallback at `:386`/`:403`, so the preview shows what the commit will write.
+Rejecting a null/whitespace `Name` in `ValidateSubnetCreation` is also safe — every in-code caller already
+supplies a non-empty name.
+
+---
+
+# Refuted — reported by a finder, killed by the verifier
+
+7 of 25 findings were killed (28%). Recorded so round 7 does not rediscover them.
+
+| Finding | Why it was killed |
+|---|---|
+| `IsAbsenceStatus` drops `SubnetDeleted` unpinned by any test | Mutation reproduces and the consequence is serious (offered with `CanCommit=True`, 0 ARM reads) — but HEAD is correct and the finder concedes it. Round 5's refuted table killed the identical shape. Its one distinguishing claim fails: round 5's paragraph makes no claim about the absence side, so there is no false statement to correct. Watch list. |
+| E4's five call-site orderings unpinned | Reverting all five leaves 603 green, but HEAD is correct. Stronger: once the helper swallows a failed rollback, the log-before-rollback *ordering* is no longer load-bearing at all, so the reverted state is not even clearly defective. Pass 1 reached this and declined to file. Watch list. |
+| E9's `subnets.Count > 1` boundary only exercised at Count = 3 | Mutation to `> 2` leaves 603 green, but HEAD refuses the two-entry batch correctly with E9's own message and writes nothing. Fix is free (change the existing test from three entries to two) — watch list, not a finding. |
+| `/Azure/ReconcileScan` returns 200 `success:true` when `scanSucceeded:false` | Nothing misreads it: three independent correct signals in the payload, the sole consumer checks `scanSucceeded` first, and **the write endpoint re-checks server-side and answers 400**, so a scripted caller that trusted `success` still deletes nothing. The other plan-returning endpoint uses the same convention. Flipping it would replace specific operator-useful text with a generic string — the "fix" is a regression. |
+| `AzureService.cs:541-550`'s parse guard is unreachable | Unreachability is real, but the finding's wrong-output claim is factually false: it asserts `:548` does not pass `ex` and `:578` does. **Both pass `ex`**, so the `FormatException` naming the bad value prints under either message. What remains is a dead `catch` plus two false comments — fold into F3's commit as tidy-up. |
+| Concurrent duplicate commit reports success with zero counts | 8 races reproduced (2 zero-count, 6 informative 409) with **no corruption at all**. Dies on wrong output: for the losing request the counts are literally accurate, and the 409 alternative would say "re-run the scan and review the results" when there is nothing to review. Also **the same window as watch-listed C20** (documented at `SubnetController.AzureReconcile.cs:99-106`), not a new one. Second sentence on the C20 watch-list entry. |
+| The encompassing-subnet reason is dropped from the bulk selection tree | Every mechanical claim reproduces — and the explanation appears on the **next and mandatory** screen. Step 4's pill is only unlocked by building the preview, and the commit button lives inside the preview pane, so no path skips it. Azure forbids overlapping subnets in a VNet, so an encompassing subnet is necessarily the only one in its prefix. Pass 2 saw it and declined to file; pass 2 was right. Free polish if that file is edited for F11. |
+
+The pattern matches rounds 4 and 5: **what dies is test-coverage observations** (three of seven) **and
+findings whose harm is closed elsewhere in the system** (four of seven). The dead-code beat again produced
+nothing that survived on its own terms — its two survivors, F10 and F16, are client-side arithmetic
+defects it found while *measuring* the watch list rather than enumerating unused members.
+
+# Watch list — not findings, but worth knowing
+
+Carried forward from round 5, re-checked and still accepted:
+
+- **ForwardedHeaders trust-all with `AllowedHosts: "*"`**; the Development-only `DevAuthHandler` bypass;
+  `GlobalSanitizationFilter` skipping nested `System.*` collections; `CollectDescendants` lacking a cycle
+  guard; the blind `catch {}` around the DataProtectionKeys probe.
+- **C20** (the Azure reconcile check/act window). **New this round:** the losing request of a duplicate
+  concurrent commit returns 200 `success:true` with zero counts, rendered as "Deleted 0 stale subnet(s)".
+  No corruption; same window.
+- **The unreachable IP-change branch in `ValidateHostIpUpdate`** — and *why* it matters, which round 5 did
+  not record: it is the one place applying the network/broadcast reservations **without** the `cidr < 31`
+  guard the other two sites carry. A trap for whoever makes that field editable.
+- **`GlobalSanitizationFilter` runs after model binding and validation.** Now demonstrated three times
+  (D7 lengthening, E2 removing, F18 emptying). Any new `[Sanitize*]` attribute needs a matching validator.
+- **`MockAzureService.DefaultConfirmation` is `Deleted`.** Any test touching the confirmation path must set
+  the verdict explicitly.
+- **Still no `WebApplicationFactory`, no integration host, no JS test harness.** F4, F5, F8, F10, F11, F14
+  and F16 are all client-side or end-to-end and none can be pinned by an automated test today.
+- **Migration `.Designer.cs` snapshots still contain old column widths.** Correct and frozen.
+- **A real Azure tenant ID is committed** at `launchSettings.json:41`. Re-checked, still present. It is the
+  same tenant this round's live rig authenticated against.
+
+New this round:
+
+- **The usable-IP calculation's three copies now agree at every CIDR 0–32**, measured twice independently
+  against the real assembly. The drift moved: it is in the **CIDR→mask** copies (**F16**), of which there
+  are **six**, two unguarded. Update the count when reading round 5's entry.
+- **Three cheap test gaps, each with a free fix**, from the refuted table: a `SubnetDeleted` case for
+  `IsAbsenceStatus`; E4's five call-site orderings; E9's `Count > 1` boundary (change the existing test
+  from three entries to two, and assert *which* refusal fired).
+- **`DeletedSubnets` does not archive `AzureResourceId` or `IsFullyAllocated`**, and the deleted-subnets
+  table renders neither `Tags` nor `OriginalParentId`. Any fix that clears an Azure link is therefore
+  irreversible, and hand recovery needs database access. This constrains F1's fix and any future one.
+- **`AZURE_TOKEN_CREDENTIALS=dev`, which the launch profiles set, excludes `EnvironmentCredential`** — a
+  service-principal environment is silently ignored. A trap for the next person building a live rig.
+- **`success` is not uniform across the Azure AJAX endpoints.** `/Azure/BulkGetVNets` reports an Azure read
+  failure as `success:false`; `/Azure/ReconcileScan` reports the same failure as `success:true` with the
+  reason inside the plan. Defensible — one returns a list, the other a plan built to carry errors — but a
+  fourth endpoint's author should know both conventions coexist.
+- **`rig/db/stop-app.sh`-style `pkill -f "Bastet.dll"` kills every instance on the box.** Two agents lost
+  their app to a sibling this round. Match on `ASPNETCORE_URLS` or a PID file.
+- **Headless Chromium never ticks `requestAnimationFrame`**, so jQuery's fx queue never drains and every
+  animation assertion is a false pass unless `window.requestAnimationFrame` is deleted first.
+
+# Clean bill
+
+Swept across both passes and produced nothing:
+
+- **The reconcile commit path re-derives what is deletable — proven live, and this is the round's most
+  reassuring result.** A withheld row cannot be forced through: **9 of 9 attempts refused, database
+  byte-identical before and after every one** — withheld alone, two withheld, a healthy `Live` row, a row
+  with no `AzureResourceId`, a nonexistent id, a review-only row, the wrong confirmation word, all rows
+  under the other credential, and the case that matters most, **a deletable row mixed with a withheld one
+  (409, and the deletable row was not archived either)**. `subscriptionId` cannot widen the set.
+- **The archival cascade matches the confirmation screen's promise** — 1 target + 2 children + 1 host IP
+  promised, `targetsDeleted:1, subnetsArchived:3, hostIpsArchived:1` delivered, written deepest-first with
+  `OriginalParentId` preserved and unrelated rows untouched. E14's fix holds.
+- **ARM failure modes past round 5's 403/404.** 429, transport-level, `Status==0`, cancellation,
+  mid-enumeration token expiry, 409 registration, a malformed stored id, a partial page, a non-existent
+  subscription — all land on `Unknown` or `Success=false`. **Nothing collapses "could not ask" into
+  "gone".** The three confirmation statuses are unchanged from round 5 (403 → `NotVisible`, 404 →
+  `Deleted`, 200 → `Live`), and `GetVNetInventory` fails closed on auth failure, propagating to a 400 on
+  commit. A real credential swap mid-run withheld all 8 now-invisible rows with the correct warning.
+- **Server-side IP arithmetic.** `CalculateUnallocatedRanges` brute-forced against an independent
+  reference across ~6,100 allocation layouts including `/0`, `/31`, `/32` and `255.255.255.x` — zero
+  discrepancies; 19 further shapes checked against `CalculateUsableIpAddresses`; both 32-bit edges. No
+  E13-class defect server-side.
+- **Tree invariants under real writes.** 6,950 random operations across Create, Edit, HostIp-Create,
+  SetAllocationStatus, Delete and BatchCreateChildSubnets, checked after every step against nine
+  invariants including "parent is the most specific container" — zero violations. Re-parenting is not
+  reachable at all.
+- **Soft delete is right in both directions.** Archived rows move to separate tables with no query filter,
+  so a deleted row's address space is correctly treated as free — proven by delete → recreate →
+  re-assign-the-same-host-IP.
+- **Locking and lifecycle.** All eleven subnet/host-IP mutating actions take the applock; the only
+  unguarded writes are archive-table purges. E4's helper is correct at all five sites with no sixth, no
+  skipped, double or post-commit rollback, and zero lingering `APPLICATION` locks after a
+  transaction-inside-lock delete. Both uniqueness rules are backed by a real unique index as well as a
+  query. No captive dependencies, no self-implemented disposables, `IHttpContextAccessor` never used
+  off-request. The migration lock serializes two simultaneous cold starts correctly (six migrations across
+  two `DbContext` types, applied once each, one shared history table).
+- **No second instance of E6's identity-resolution defect.** Every post-mutation re-query in the tree
+  enumerated; `HostIpController.cs:251-261` is the exact structural analogue and is *correct*, proven by
+  measurement. Two hypotheses were killed by measurement and are recorded so they are not re-raised:
+  `context.Update()` does **not** smear audit fields across a subtree, and a validation error does **not**
+  refresh the concurrency token.
+- **Antiforgery.** All eleven `[HttpPost]` actions carry `[ValidateAntiForgeryToken]`, verified against the
+  verb attribute; no global filter, no `IgnoreAntiforgeryToken`, no state-changing GET.
+- **Authorization.** All 34 actions enumerated against the fallback policy; row-level authorization
+  checked, not just action-level; reconcile subscription scoping resists a crafted POST behind three
+  independent guards; paging clamps hold.
+- **XSS and the Razor output side, which round 5 did not check.** Zero `Html.Raw` across 105 views; one
+  `href="@…"` with a hard-coded scheme; three `data-*` expressions with no HTML sink; one static `on*=`.
+  All three `escapeHtml` implementations are byte-identical and attribute-safe. Every client-side HTML
+  sink (`.append`, `$('<…>'+x)`, `innerHTML`) checked.
+- **Injection, SSRF, open redirect, security headers, CORS.** The only raw SQL remains the parameterised
+  `sp_getapplock`/`sp_releaseapplock`. No `FromSqlRaw`, no `Process.Start`. Outbound calls are ARM SDK only.
+  CORS is opt-in without credentials. A column-width × validator × sanitizer matrix found every sanitizer
+  non-expanding; IPv6 as a width-overflow vector is closed by the `AddressFamily` check.
+- **Client-side routing and dead references.** All eleven client→server URLs resolve against real routes —
+  **no second E8**. Every `@Url.Action`, tag-helper pair, JS selector, CSS class, all 42 TempData writes
+  traced to a reader on their redirect target, all ViewData keys, all role and claim names, all four wizard
+  enum-name switches. Zero unresolved references. Round 5's two new shared members are correctly scoped:
+  `IsAbsenceStatus` has 2 callers, `RollbackQuietlyAsync` exactly E4's 5 sites.
+- **The wizards' state machines and payloads.** All three driven in a real browser including backwards
+  navigation, re-entry after error and re-submission; `subnets.Index` non-contiguous binding and the
+  submit-time `disabled` re-normalisation both correct and load-bearing; the pill `disabled` locks genuinely
+  stop Bootstrap 5.3; the reconcile confirmation word matches the server byte-for-byte. E7, E10, E12 and
+  E14 all re-verified live, and E7×E12 compose correctly across three tree shapes with real animations.
+- **The 14 round-5 fixes, reviewed as atomic commits.** Each diffed against its struck paragraph; every
+  checkable claim accurate, including E3's alignment premise, E4's "all five sites, no sixth", E5's "only
+  two entry points", E9's "Azure cannot produce this selection", and E2's deliberate `[SafeText]` omission.
+  All 53 removed lines accounted for; nothing load-bearing deleted. **F1 is not one of these** — it predates
+  the round-5 and round-4 work entirely.
+- **Test quality of the ~27 tests round 5 added.** All six fixes claiming tests fail on revert, with the
+  failure text matching round 5's record exactly in every case. E2's rewrite is genuinely non-vacuous —
+  sabotaging the `IInputSanitizationService` supply fails all six with "Input sanitization service not
+  available".
+
+---
+
+## Suggested order of attack
+
+1. **Reconcile step 0** — restore the lost E8 entry to `docs/AUDIT-FINDINGS-5.md`. Its own commit, before
+   `F1`.
+2. **F1** — a privilege escalation ending in unrestorable data loss, including data with no Azure
+   involvement. Take the Edit-side refusal **plus** the `Azure.cs:320` equality check; do not take the
+   containment or clear-the-link fixes. E1 must stay.
+3. **F2, F3** — the two Azure-side paths that archive a healthy resource. F3's fix must land with **F12**.
+4. **F4** — the false statement the operator consents on. Pairs naturally with F1 and F2, and is the only
+   one of the four that survives every fix for them.
+5. **F5** — client-side validation is dead app-wide. One line as an interim. Amend E5's reachability
+   paragraph in the round-5 file while you are there.
+6. **F6** — then comment the three CodeQL alerts with the fix commit and leave them open; dismiss only
+   after shipping a sanitizer model.
+7. **F7–F16** — diagnostics, messaging and affordance defects. F9 and F10 overlap on the same flow; F11 and
+   the refuted encompassing-reason polish touch the same file; F15 is two lines plus a catch.
+8. **F17, F18** — a false sentence in the round-5 record with a test to add, and one invariant gap with no
+   observable harm.

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -127,82 +127,47 @@ number was wrong it is corrected here and noted.
 
 ## F1. A legitimate CIDR edit on an Azure-linked subnet makes reconcile archive it and its subtree `[×2]`
 
-**Confidence: confirmed (live).** Three verifiers, three lenses, all confirmed.
+_F1 is fixed and committed. `SubnetController.Edit`'s POST now refuses a CIDR change on any subnet
+carrying an `AzureResourceId`, inside the same lock and beside the other CIDR guards, using the
+database value rather than the posted one. The Edit form renders the field read-only for those rows
+with a sentence saying why, and `EditSubnetViewModel.IsAzureLinked` is **re-derived from the database
+on every render, including the error re-render**, so a post cannot claim a row is unlinked to get the
+editable field back. The server is authoritative; the view only stops the operator typing._
 
-**Where:** [AzureReconciler.cs:216](../src/Bastet/Services/Azure/AzureReconciler.cs#L216) and
-[:252](../src/Bastet/Services/Azure/AzureReconciler.cs#L252) (the two prefix comparisons that produce
-`VNetPrefixRemoved` / `SubnetPrefixChanged` without establishing *which side* moved),
-[:134-136](../src/Bastet/Services/Azure/AzureReconciler.cs#L134) (non-absence rows are never judged),
-[AzureController.cs:377-381](../src/Bastet/Controllers/AzureController.cs#L377) (returns before
-`ConfirmResourcesAsync` when no absence rows exist — hence zero ARM reads),
-[SubnetController.Edit.cs:104](../src/Bastet/Controllers/SubnetController.Edit.cs#L104) and
-[:150](../src/Bastet/Controllers/SubnetController.Edit.cs#L150) (the CIDR write, which never reads
-`AzureResourceId`), [SubnetController.Azure.cs:320](../src/Bastet/Controllers/SubnetController.Azure.cs#L320)
-(a **third** writer of the same mismatch, with no prefix-equality check).
+_Refusal was chosen over the three alternatives the finding records, and the finding's own analysis of
+why is correct: the two reconciler-side fixes were measured to fail (containment misses the widening
+direction entirely, and re-creates E1 where it does bite), and clearing `AzureResourceId` on edit is
+irreversible - reconcile goes permanently blind to the row and re-import is refused. Refusal touches
+no reconcile code at all, so **E1 is untouched and genuine Azure drift stays reportable and
+deletable**, which is the constraint that killed the others._
 
-**Failure scenario.** Import VNet `vnet-visible` (`10.10.0.0/16`) through the real bulk wizard. An
-`Edit`-role user POSTs `/Subnet/Edit/1` with `Cidr=17`; it validates, persists, and keeps
-`AzureResourceId`. Azure is untouched. An Admin then runs an ordinary reconcile:
+_Five tests written first, all against existing xUnit infrastructure. Three failed against the unfixed
+action for the defect's own reason: both CIDR-change cases returned `RedirectToActionResult` instead of
+the form - `Assert.IsType() Failure: Value is not the exact type` - meaning the edit **succeeded**, and
+the GET flag was false. Both directions are covered (`/16`→`/17` narrowing and `/16`→`/15` widening)
+because the finding records that a containment-based fix closes only one of them. The other two tests
+are the guards against over-correcting and passed throughout: renaming, re-describing and re-tagging a
+linked subnet must keep working, and an **unlinked** subnet must keep its editable CIDR - without that
+second one, a fix that simply froze every CIDR would pass._
 
-```
-scan: canCommit=true items=1 reviewItems=0 warnings=[]
-  OFFERED id=1 vnet-visible 10.10.0.0/17 VNetPrefixRemoved descendants=2 hostIps=1
-  reason: VNet 'vnet-visible' still exists but no longer has the address prefix 10.10.0.0/17.
-commit: {"success":true,"targetsDeleted":1,"subnetsArchived":5,"hostIpsArchived":3}
-```
+_**The equality check at `SubnetController.Azure.cs:320` was deliberately not implemented**, and this
+is the one place the finding's stated fix was not followed. Checking that the parent's prefix is one of
+the VNet's requires the VNet's prefixes, which means an ARM read: `SubnetController` has no Azure
+service injected, and adding one would put a network round-trip inside a transactional write path so
+that a temporary ARM failure turns a working import into a failed one. That is far more invasive than
+the defect warrants - the verifier graded that leg low on its own, since `GetCompatibleVNets` filters
+the wizard's dropdown to exact prefix matches and only a crafted Admin post can reach it. It is carried
+on the watch list instead, where it belongs beside F13 (the same endpoint's missing guard) and the
+linked-prefix column, which subsumes it: once a row records the prefix it was linked at, a mismatched
+stamp records its own value and the reconciler stops misreporting it._
 
-Both directions work — narrowing and widening. Host IPs on the subnet do not prevent the edit.
+_Not re-measured against live ARM: the reconciler is unchanged by this fix, and the audit's live
+measurement of the defect stands. What changed is that the state can no longer be created._
 
-**Why the operator does not catch it.** `SubnetPrefixChanged` states both prefixes, so it is
-detectable. `VNetPrefixRemoved` ([:218](../src/Bastet/Services/Azure/AzureReconciler.cs#L218)) states
-only Bastet's own prefix, so nothing on screen distinguishes a local edit from genuine Azure
-re-addressing, where archiving is correct. Neither reason reaches `_StepConfirm.cshtml`, which offers
-a "Select all" checkbox above the table (see **F4**).
-
-**Privilege escalation, measured.** `RequireEditRole` = `Edit, Delete, Admin`; `RequireAdminRole` =
-`Admin` ([Program.cs:206-211](../src/Bastet/Program.cs#L206)):
-
-```
-[Edit] POST /Subnet/Edit/1 Cidr=17              -> 302, persisted, AzureResourceId intact
-[Edit] POST /Azure/ReconcileScan                -> 403
-[Edit] POST /Subnet/BulkDeleteStaleAzureSubnets -> 403
-[Edit] POST /Subnet/Delete/2 (approved)         -> 403
-```
-
-**Recoverability.** No restore action exists — all 28 public actions across the subnet and host-IP
-controllers were enumerated, and the only control on `/Subnet/DeletedSubnets` is "Purge All".
-`DeletedSubnets` (14 columns) has no `AzureResourceId` and no `IsFullyAllocated`. The rendered table
-omits `Tags` and `OriginalParentId`, so hand recovery requires direct database access. The archived
-CIDR is the *edited* one, so a faithful restore re-triggers the deletion. Purge is purge-all and
-orphans the host-IP archive, whose rows then render `Unknown (Original Subnet ID: n)`.
-
-**Root cause.** Not E1, and not the status computation. The broken invariant is **"a row carrying an
-`AzureResourceId` records the prefix that resource had at link time"**. No downstream rule can repair
-it: the state left by a Bastet narrowing and the state left by an Azure widening are the *same state*,
-and the two scan rows are byte-identical (`diff rowX.json rowY.json -> IDENTICAL`).
-
-**Fix.** Refuse the CIDR change when `AzureResourceId` is set — beside the `ValidateSubnetCidrChange`
-call at `Edit.cs:104`, with `Cidr` rendered display-only for those rows the way `NetworkAddress`
-already is — **plus** the missing prefix-equality check at `SubnetController.Azure.cs:320`. It touches
-no reconcile code, so E1 stays intact and genuine Azure drift stays reportable and deletable.
-
-**What it costs, stated because it is a real loss:** `Subnet/Edit` is today the only non-destructive
-remedy for a genuine Azure prefix *resize* — editing the row back to Azure's prefix makes the drift row
-disappear. After this fix that operator must archive and re-import.
-
-**The correct long-term fix** is to persist the prefix the row was linked at (a nullable column written
-by the three import sites, compared in the two evaluators). It costs an EF migration, which is why the
-refusal is recommended now and this is the follow-up if the resize workflow is worth keeping.
-
-**Fixes that were tried and rejected by measurement — do not take them:**
-
-| Rejected fix | Why |
-|---|---|
-| Containment test in the two evaluators | Local widening `/16`→`/15` is **not** contained in the live `/16`, so the row stays deletable; and where it does bite it re-creates E1 by demoting genuine Azure drift to `ReviewItems` |
-| Clear `AzureResourceId` on edit | Reconcile goes blind to the row (`items=0`) and the link cannot be restored — re-import is refused with four global errors. Trades a loud wrong answer for a silent permanent blind spot |
-| Fix only the screen text | Healthy infrastructure is still archived on a 200. That is **F4**, a companion, not a fix |
+_Tests 603 → 608 (+5). Build clean, 0 warnings._
 
 ---
+
 
 ## F2. The subnet-level prefix check tests equality where the VNet-level check tests membership `[×1]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -171,53 +171,51 @@ _Tests 603 → 608 (+5). Build clean, 0 warnings._
 
 ## F2. The subnet-level prefix check tests equality where the VNet-level check tests membership `[×1]`
 
-**Confidence: plausible.** The unestablished step: which index ARM assigns a newly-added prefix in a
-subnet's `addressPrefixes` array. Settling it needs an ARM write, which this audit forbade. Everything
-either side of it is measured, and the defect is reachable under **both** plausible ordering policies.
+_F2 is fixed and committed. `EvaluateSubnetLevel` now tests membership over every IPv4 prefix the
+Azure subnet owns, exactly as the VNet-level check ten lines above always did, and the reason text
+names all of them rather than the first. `GetVNetInventory` populates a new
+`BulkAzureSubnetViewModel.Ipv4AddressPrefixes` from a new `ExtractIpv4Prefixes`, deduplicated because
+ARM may report a single prefix in both the singular property and the collection._
 
-**Where:** [AzureReconciler.cs:216](../src/Bastet/Services/Azure/AzureReconciler.cs#L216)
-(`!vnet.Ipv4AddressPrefixes.Contains(prefix, StringComparer.OrdinalIgnoreCase)` — membership, correct)
-against [:252](../src/Bastet/Services/Azure/AzureReconciler.cs#L252)
-(`!string.Equals(livePrefix, prefix, …)` — equality against one collapsed value),
-[AzureService.cs:380-401](../src/Bastet/Services/Azure/AzureService.cs#L380) (`ExtractIpv4Prefix`
-collapses `IList<string> AddressPrefixes` to its first IPv4 entry; doc comment at `:376-379`),
-[:239-277](../src/Bastet/Services/Azure/AzureService.cs#L239) (`GetCompatibleSubnets` takes the first
-IPv4 prefix and `break`s, so Bastet can only ever store index 0).
+_**The finding's plumbing instruction was wrong** and was not followed. It says the list must be
+carried "through `AzureLinkedSubnetSnapshot`" — that is Bastet's own row, which has exactly one
+prefix and is correct as it stands. The collapse is on the **live** side, so the list belongs on the
+inventory view model. `AddressPrefix` was left in place and unchanged rather than replaced: about
+twenty planner sites read it, and the import path genuinely can carry only one prefix because it
+creates one Bastet subnet per Azure subnet._
 
-**Reachability.** Two IPv4 prefixes on one subnet is the "Multiple Address Prefixes on Subnet"
-feature, **GA 2025-09-04**; Microsoft's how-to creates it with
-`az network vnet subnet create --address-prefixes 10.0.0.0/24 10.0.1.0/24`. No feature registration is
-required — blogs describing `Register-AzProviderFeature` predate GA. This is **not** the dual-stack
-case: `ExtractIpv4Prefix` picks the first *IPv4* entry, so an IPv6 sibling does not trigger it.
+_**A second site was fixed that the finding does not mention.** The `FullyAllocatingSubnetDeleted`
+check at `AzureReconciler.cs:227` reads the same collapsed value to decide whether any Azure subnet
+still covers the target's prefix, so a covering subnet listing another prefix first was reported as
+having lost its cause. It is review-only and can never delete anything, which is why it is a footnote
+rather than its own finding — but it is the same defect at its second site and the prefix list was
+already to hand. Leaving a known-wrong sibling behind is the residue these rounds keep finding._
 
-**Failure scenario.** Bastet holds subnet `web` at `10.0.1.0/24`. An operator adds a second prefix to
-that Azure subnet so ARM reports `addressPrefixes = [10.0.0.0/24, 10.0.1.0/24]`. Measured: with two
-IPv4 prefixes ARM returns the singular `addressPrefix` as **null**, so `ExtractIpv4Prefix`'s first case
-does not rescue it and the second returns `10.0.0.0/24`. Then:
+_**The finding's "second consequence" is not fixed and its "same fix" claim is wrong.**
+`GetVNetInventory` still offers a multi-prefix Azure subnet to the bulk import wizard as though it
+owned only its first prefix. Closing that means creating several Bastet subnets from one Azure
+subnet, which is a feature change, not a bug fix, and is out of scope here. What this change does buy
+is the data: the prefixes are now carried on the inventory model, so whoever takes it does not have
+to re-plumb ARM. Recorded on the watch list._
 
-```
-S2  addressPrefixes=[10.0.0.0/24, 10.0.1.0/24], Bastet holds the second
-    OFFERED FOR DELETION  web 10.0.1.0/24  SubnetPrefixChanged  descendants=2 hostIps=9
-    reason: The Azure subnet still exists but its address prefix is now 10.0.0.0/24, not 10.0.1.0/24.
-S3  same data, order flipped                    -> Items=0
-S4  CONTRAST at VNet level (membership test)     -> Items=0
-```
+_Three tests written first; all three failed against the unfixed reconciler for the defect's own
+reasons — two with `Assert.Empty() Failure: Collection was not empty` (a row flagged for a subnet
+that still owns Bastet's prefix, and the review row at the second site), one with
+`Assert.Contains() Failure: Sub-string not found` because the reason named only the first live
+prefix. The middle test is the guard against over-correcting, and it is the one that matters after
+E1: a genuine prefix change, where **none** of the live prefixes match, must still be flagged
+`SubnetPrefixChanged`. A fix that merely stopped flagging multi-prefix subnets would pass the first
+test and re-create exactly the over-blocking E1 was about._
 
-The subnet still owns Bastet's prefix. Being a drift status it gets no direct-read guard, and the
-commit path accepts anything in `plan.Items`.
+_Still `plausible` on one point, unchanged by the fix and not claimable: nobody has established which
+index ARM assigns a newly-added prefix, because settling it needs an ARM write and this round's
+credential was read-only. The fix does not depend on the answer — membership is correct whatever the
+order — which is the argument for making it regardless._
 
-**Second consequence, same root cause and same fix:** `GetVNetInventory` under-reports address space,
-so a multi-prefix Azure subnet is offered to the bulk import wizard as though it owned only its first
-prefix, and the rest is silently invisible to Bastet.
-
-**Fix.** Make `:252` a membership test over the subnet's full IPv4 prefix list, mirroring `:216`.
-Requires plumbing the list rather than the collapsed value through `AzureLinkedSubnetSnapshot`.
-
-**Do not** add `SubnetPrefixChanged` to `IsAbsenceStatus` as a stopgap — a live subnet answers `Live`,
-so that withholds every genuine prefix change and re-creates E1 exactly. The membership fix does not
-touch that partition.
+_Tests 608 → 611 (+3). Build clean, 0 warnings._
 
 ---
+
 
 # Medium
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -277,59 +277,47 @@ _Tests 611 → 615 (+4). Build clean, 0 warnings._
 
 ## F4. The reconcile screens state that drift rows no longer exist in Azure `[×2]`
 
-**Confidence: confirmed.**
+_F4 is fixed and committed. Both sentences now say the rows **no longer match Azure**, which is true
+of an absence row and a drift row alike, and the confirmation screen renders each row's own reason
+underneath its list entry. That second half is the important one: step 2 already printed the reason
+beside the checkbox, but step 3 - the last screen before the archive, and the one carrying the
+type-`approved` gate - showed only the status label, so a row whose reason says the Azure resource
+still exists was confirmed under a heading saying it did not._
 
-**Where:** [_StepReview.cshtml:38](../src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml#L38)
-("These BASTET subnets no longer exist in Azure."),
-[_StepConfirm.cshtml:5](../src/Bastet/Views/Azure/Reconcile/_StepConfirm.cshtml#L5) ("You are about to
-delete N subnet(s) that no longer exist in Azure."),
-[AzureReconciler.cs:87-94](../src/Bastet/Services/Azure/AzureReconciler.cs#L87) (only
-`FullyAllocatingSubnetDeleted` goes to `ReviewItems`; both drift statuses land in `Items`),
-[_ReconcileScripts.cshtml:241](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L241)
-(review renders `item.reason`), [:349-352](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L349)
-(confirm renders only `name (network/cidr) - statusLabel`),
-[:186](../src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml#L186) (`VNetPrefixRemoved` gets
-`bg-danger`, the same red as `VNetDeleted`).
+_**The finding's warning against a bare reword was heeded.** Replacing the headline with "You are
+about to delete N subnet(s)." would have removed the only statement of fact on that screen, which is
+a net information loss for absence rows - the common case, where "the resource is gone" is exactly
+what justifies the archive. Keeping a true statement and adding the per-row reason gives both._
 
-**Failure scenario.** A genuine Azure-side prefix change — replacing a VNet's address space, or
-re-addressing a subnet — produces a drift row. Step 2 asserts the resource is gone, while the same
-row's Reason, printed inches below, says it still exists. Step 3 repeats the false claim in bold above
-the type-`approved` gate **with nothing to contradict it** — grepping the rendered step-3 pane for
-"still exists" returns zero hits:
+_`_StepReview.cshtml:76` was **not** reworded here, as the finding directs - but it is no longer the
+sentence the finding examined. F3 widened what `ReviewItems` can hold, so "These subnets still exist
+in Azure" stopped being established for every row in that section and was generalised in F3's commit._
+
+_The badge colour was left alone. The finding offers a distinct colour for `VNetPrefixRemoved` as an
+optional aggravator fix; with the reason now on both screens, recolouring is a UI preference rather
+than a correctness matter, and an unrequested visual change riding along in a fix commit is the
+residue these rounds keep finding._
+
+_Verified in chromium against the pinned jQuery 4.0.0, with the shipped script read from the repo at
+run time and its three `@Url.Action` expressions substituted programmatically rather than retyped.
+The confirm-list block was lifted by offset, not rewritten, and run against a drift row:_
 
 ```
-STEP 3  HEADLINE: You are about to delete 2 subnet(s) that no longer exist in Azure.
-        list item 1: vnet-a (10.0.0.0/16) - Prefix removed
-        any "still exists" text on step 3? NO
+"parses": "OK"
+"listText": "vnet-visible (10.10.0.0/17) - Prefix removed
+             VNet 'vnet-visible' still exists but no longer has the address prefix 10.10.0.0/17."
 ```
 
-**Provenance — all three finders had this wrong.** The sentences were never accurate. At `aedd0bd`,
-where both views were written, no confirmation step existed; `BuildPlan` output went straight to
-`Json(...)`, so drift rows rendered under this banner from day one. Round 4's D3 *incidentally* made
-the sentence true by withholding every non-`Deleted` verdict. E1 un-masked a pre-existing text defect.
-Neither view has been touched since `aedd0bd`, and round 5's squash modified only
-`_ReconcileScripts.cshtml`.
+_The parse check is not ceremony: a syntax error inside a `.cshtml` script block is invisible to the
+C# compiler and to the test suite, and surfaces only when the page is requested._
 
-**Not a duplicate of F1.** A genuine Azure-side prefix change produces a drift row that E1
-*deliberately* made deletable, so this survives every fix proposed for F1.
+_No test ships. There is still no JS harness in the repo and no `WebApplicationFactory`, which the
+watch list records; the rig was ephemeral and is deleted._
 
-**Harm.** Told "Azure no longer has this", archiving is costless bookkeeping. Told the truth — "still
-exists, now `10.2.9.0/24`" — the operator can re-address the Bastet row and keep its children and host
-IPs. The banner suppresses the option that preserves data. Medium rather than high because step 2
-prints the contradicting Reason in the same row as the checkbox.
-
-**Fix.** Reword both sentences to "no longer match Azure" **and** append `i.reason` to each
-`#rec-confirm-list` item (built with `.text()`, so no injection sink). Optionally give
-`VNetPrefixRemoved` a distinct badge colour.
-
-**Do not** take the two string edits alone with the confirm-list left as-is: replacing the headline with
-"You are about to delete N subnet(s)." removes the only statement of fact on that screen, a **net
-information loss for absence rows** — the common case, where "the resource is gone" is what justifies
-the archive. And **do not** reword `_StepReview.cshtml:76`: that sentence is correct for its section,
-since `ReviewItems` can only ever hold `FullyAllocatingSubnetDeleted`. It is the model the other banner
-should be reworded toward.
+_Tests 615 → 615 (unchanged). Build clean, 0 warnings._
 
 ---
+
 
 ## F5. jQuery 4 breaks client-side validation on every validated form `[×2]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -514,41 +514,40 @@ _Tests 622 → 622 (unchanged). Build clean, 0 warnings._
 
 ## F9. The prefilled subnet name always contains a `/`, which `[SafeText]` forbids `[×1]`
 
-**Confidence: confirmed.** Independently rediscovered by a verifier working an unrelated finding, so
-three agents reached it.
+_F9 is fixed and committed: the generated suffix is now `-{networkAddress}-{cidr}` rather than
+`-{networkAddress}/{cidr}`, so the name the app fills in survives the validation the very next POST
+applies to it._
 
-**Where:** [SubnetController.Create.cs:67](../src/Bastet/Controllers/SubnetController.Create.cs#L67)
-(`SubnetNaming.WithSuffix`, suffix `-{networkAddress}/{cidr}`) against
-[SubnetViewModels.cs:11](../src/Bastet/Models/ViewModels/SubnetViewModels.cs#L11) (`[SafeText]`), whose
-class `^[a-zA-Z0-9\s\-_.,!?@#$%&()+=]*$`
-([InputSanitizationService.cs:14](../src/Bastet/Services/Security/InputSanitizationService.cs#L14))
-contains no `/`. Pinned by `SubnetCreateGetPrefillTests.cs:116` and `:142`.
+_The separator was changed rather than the rule, as the finding directs. `[SafeText]` guards three
+properties and round 5's E2 deliberately declined to widen it; loosening a character class to
+accommodate a string the app generates would be fixing the wrong end. `SubnetNaming.WithSuffix` was
+left alone - it has two callers, and the planner's own suffixes are already inside the class._
 
-**Failure scenario.** Every "Create Subnet from an unallocated range" flow that accepts the default:
+_A new theory test pins the real contract rather than the literal string: **the prefilled name must
+pass the rule its own POST applies.** It resolves `SafeTextAttribute` against a real
+`InputSanitizationService`, because the attribute reads that service from the validation context and
+without one every rule fails with "Input sanitization service not available" and the test would pass
+vacuously - the trap round 5's E2 fell into. Reverting the separator makes it fail with the message
+that names the defect:_
 
 ```
-GET  /Subnet/Create?networkAddress=10.0.1.0&cidr=24&parentId=1
-     value="prod-vnet-10.0.1.0/24"
-POST it unchanged -> 200, "Subnet name contains invalid characters", nothing created
-POST with "-24" instead of "/24" -> 302 /Subnet/Details/2
+the prefilled name 'Parent-10.0.1.0/24' is refused by the rule its own POST applies
 ```
 
-Nothing saves the operator: `SafeTextAttribute` is not an `IClientModelValidator`, so no client rule
-fires; `[SanitizeName]` runs after validation and would not strip `/` anyway; and the message names no
-character, so the operator must guess which one. On a `/32` parent the Name error also *masks* the CIDR
-error, so two different rejections arrive in sequence (see **F10**).
+_The `/32` case is included as a second theory row, because that page prefills a name too and the
+finding records that there the Name error **masks** the CIDR error - so an operator got two rejections
+in sequence. With F10 also fixed, neither fires._
 
-**Two rounds stood on this line.** Round 4's D8 struck paragraph explicitly reasons about the generated
-name — "would have stopped the 500 while still offering the operator a pre-filled name reading
-`Parent-10.0.0.0/33`, which the POST then rejects" — and fixed the CIDR-in-the-name case while walking
-past the `/` that is in *every* generated name. D19 fixed its *length*.
+_Two existing assertions pinned the unusable value and were updated, not deleted:
+`SubnetCreateGetPrefillTests.cs:116` and `:142`. They were the reason two rounds walked past this -
+round 4's D19 fixed this string's **length** and D8's struck paragraph explicitly reasoned about the
+generated name, quoting `Parent-10.0.0.0/33` as a name "which the POST then rejects", while fixing
+only the CIDR in it._
 
-**Fix.** Change the controller's interpolation to a character inside the SafeText class (`-` or `_`).
-`SubnetNaming.WithSuffix` has exactly two callers and the planner's own suffixes are already inside the
-class, so changing only `Create.cs:67` is safe. Update both pinning assertions. **Do not widen
-`[SafeText]`** — it guards three properties and round 5's E2 deliberately declined to extend it.
+_Tests 622 → 624 (+2). Build clean, 0 warnings._
 
 ---
+
 
 ## F10. A `/32` subnet offers a Create Subnet button whose POST can never succeed `[×1]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -663,33 +663,50 @@ _Tests 624 → 627 (+3). Build clean, 0 warnings._
 
 ## F13. `BatchCreateChildSubnets` is the one Azure write path with no feature-flag guard `[×1]`
 
-**Confidence: confirmed.**
+_F13 is fixed and committed - **not** with the guard the finding proposed, because the verifier proved
+that one does not close the gap. Gating on `isAzureImport` would leave the child stamp at `:367`
+untouched, and it is behind no flag at all: measured, with `isAzureImport` absent entirely and the
+feature off, `{"success":true,"subnetIds":[3]}` and the row carried a ghost subnet id. So the guard
+tests **the Azure state being written**, not the caller's claim about it: `isAzureImport`, a non-empty
+`vnetResourceId`, or any non-empty `subnets[].AzureResourceId`._
 
-**Where:** [SubnetController.Azure.cs:114](../src/Bastet/Controllers/SubnetController.Azure.cs#L114) (no
-`IsAzureImportEnabled()` check), against **eleven** guarded siblings — all nine `AzureController` actions
-plus `SubnetController.AzureReconcile.cs:29` and `SubnetController.BulkAzure.cs:31`. Stamps at
-[:320](../src/Bastet/Controllers/SubnetController.Azure.cs#L320) (gated on `isAzureImport`) and
-[:367](../src/Bastet/Controllers/SubnetController.Azure.cs#L367) (**gated on nothing**). Immediate
-consequence at
-[_SubnetDetails.cshtml:21-26](../src/Bastet/Views/Subnet/Details/_SubnetDetails.cshtml#L21).
+_**This narrows the documented non-Azure JSON API, and the commit says so out loud** rather than
+leaving it to be discovered: a caller using this endpoint as a plain batch-create may no longer send
+`AzureResourceId` or `vnetResourceId` while `BASTET_AZURE_IMPORT` is off. Sending them was never
+meaningful in that configuration - the reconcile that would act on such a row cannot run - so what is
+lost is the ability to create a row that is inert until someone enables the feature and it arms itself._
 
-**Failure scenario.** With `BASTET_AZURE_IMPORT` unset, all eleven siblings refuse (403 / "Azure Import
-feature is not enabled" / redirect to `/Error/403`). The unguarded one accepts an Admin POST with
-`isAzureImport=true`: 302, parent renamed and stamped with `AzureResourceId`, child created and stamped.
-The Details page then renders a live "View in Azure Portal" link built from that id **with Azure entirely
-off** — the one immediate wrong output. The rest is latent: it arms itself if the flag is later enabled.
+_Three tests, and the middle one is the important one: it posts a child `AzureResourceId` with
+`isAzureImport` **absent**, which is exactly the path the finding's own proposed fix would have missed.
+Both refusal tests fail against the unfixed action; the third passes throughout and is the guard
+against over-correcting - a plain batch create carrying no Azure state must still work with the feature
+off, or the fix costs more than the defect._
 
-**Fix, and the finding's own proposal does not work.** A branch-scoped
-`if (isAzureImport && !IsAzureImportEnabled())` leaves `:367` open — measured, with `isAzureImport`
-absent and the flag unset, `{"success":true,"subnetIds":[3]}` and the row carries a ghost subnet id. The
-guard must reject a non-empty `subnets[].AzureResourceId` **or** `vnetResourceId` whenever the flag is
-off, independent of `isAzureImport`. **Say out loud in the commit** that this changes the documented
-non-Azure JSON API's contract.
+_**Twelve existing tests had to be moved behind the flag**, which is worth recording because it is
+evidence of the defect rather than collateral: `SubnetControllerBatchCreateTests` and
+`SubnetControllerFullyEncompassingTests` drove the Azure import path without ever setting
+`BASTET_AZURE_IMPORT`, and passed - they were relying on the missing guard. Both classes now set it in
+their constructor, clear it on dispose, and join `AzureFeatureFlagCollection`, whose whole purpose is
+to serialise classes that flip this process-global variable. Any future test touching the flag belongs
+there too._
 
-**Do not credit this with closing F3 or F2** — those require the flag *on*, so the guard never fires in
-their scenario. What helps them is validating the stored id's shape.
+_**My first version of the new tests was wrong and had to be corrected**: they asserted against parent
+subnet 1, which the fixture seeds with two children already, so one failed with `Expected: 0 Actual: 2`
+- a fixture error, not a code result. Repointed at parent 2, the childless `10.0.0.0/16` the file's
+other tests use._
+
+_The immediate wrong output the finding names is closed as a consequence rather than addressed
+directly: with no Azure state written while the feature is off, `_SubnetDetails.cshtml` has no stamped
+id to build a "View in Azure Portal" link from._
+
+_This finding is **not** credited with closing F2 or F3, as the verifier insisted: both need the flag
+**on**, so this guard never fires in their scenario. What helps them is validating the id's shape,
+which F3 did._
+
+_Tests 627 → 630 (+3). Build clean, 0 warnings._
 
 ---
+
 
 ## F14. The Create-Subnet modal unlocks a field nothing listens to, under a stale explanation `[×1]`
 

--- a/docs/AUDIT-FINDINGS-6.md
+++ b/docs/AUDIT-FINDINGS-6.md
@@ -45,22 +45,26 @@ Read in this order: **F1**, **F2**, **F3**, then **F5**.
 
 ## Reconcile step 0 — restore the E8 entry to `docs/AUDIT-FINDINGS-5.md`
 
-**Do this first, in its own commit, before `F1`.** The shipped round-5 findings file has no `E8`
-section. It was present through `8a2223a` and deleted by `3c805c1` (the E7 fix), whose replacement
-hunk swallowed the whole neighbouring entry — `-62/+32` on a file that should only ever have grown.
-E8 is still referenced twice in the surviving text, so the file cites an entry it does not contain.
+_Done and committed. The 28-line `E8` section was recovered from `8a2223a` and reinserted into
+`docs/AUDIT-FINDINGS-5.md`, which now carries 14 `E` entries again and no longer cites a section it
+does not contain. The restored range is byte-identical to `8a2223a`'s copy, verified by `diff`, and
+the change is `28 insertions, 0 deletions` — purely additive, nothing else in the file touched._
 
-Recover it with `git show 8a2223a:docs/AUDIT-FINDINGS-5.md` (the section is around lines 351–372) and
-reinsert it **immediately ahead of `## E7`**, its original position, not in numeric order: the entry's
-own second paragraph explains why it sits there ("Taken out of numeric order, ahead of E7… E7 is a
-client-side jQuery defect needing a browser rig, and this one needed nothing but a grep"), and moving
-it would make a committed struck entry false. Nothing else in the file changes.
+_**This entry's own instruction was wrong and was not followed.** It said to reinsert the section
+"immediately ahead of `## E7`, its original position, not in numeric order", reasoning from the
+entry's own sentence "Taken out of numeric order, ahead of E7… E7 follows immediately". That sentence
+describes the order the **fixes** were done, not where the text sat: at `8a2223a` the E8 heading is
+at line 330 and E7's at 306, so E8 was always **after** E7, in ordinary numeric order. E7 was still
+an unstruck finding at that point and E8 a struck one, which is what "E7 follows immediately" refers
+to — the next thing to be worked, not the next section. Restoring it ahead of E7 would have moved it
+somewhere it never was. It is back between E7 and E9, where `3c805c1` deleted it from._
 
-Verify the restored range is byte-identical to `8a2223a`'s copy and that
-`grep -c '^## E' docs/AUDIT-FINDINGS-5.md` returns 14.
+_The deletion mechanism is worth keeping: `3c805c1` replaced E7's finding text with its struck
+paragraph, and the replacement hunk ran on past E7's own text and swallowed the whole neighbouring
+entry — `-62/+32` on a file that should only ever grow. **A fix commit that also edits the findings
+file must diff its own hunk before committing.**_
 
-It carries no `F` number: the `F` series is for code defects. The process lesson is worth keeping —
-**a fix commit that also edits the findings file must diff its own hunk before committing.**
+_No `F` number, no code change, no test delta: 603 → 603._
 
 ## How this audit ran
 

--- a/src/Bastet/Controllers/SubnetController.Azure.cs
+++ b/src/Bastet/Controllers/SubnetController.Azure.cs
@@ -134,6 +134,27 @@ public partial class SubnetController : Controller
                 "No subnets were submitted for import.", BadRequest(ModelState));
         }
 
+        // The one Azure write path with no feature-flag guard, while its eleven siblings all have one.
+        // Gating on isAzureImport alone would not close it: the child stamp below is behind no flag at
+        // all, so an Admin could still create Azure-linked rows with the feature off - rows the
+        // Details page then renders a live "View in Azure Portal" link from, and which arm themselves
+        // the moment the flag is enabled. So the test is on the Azure state being written, whatever
+        // isAzureImport claims.
+        //
+        // Note this narrows the documented non-Azure JSON API: a caller using this as a plain
+        // batch-create may no longer send AzureResourceId or vnetResourceId while the feature is off.
+        // Sending them was never meaningful in that configuration.
+        bool writesAzureState = isAzureImport
+            || !string.IsNullOrEmpty(vnetResourceId)
+            || subnets.Exists(s => !string.IsNullOrEmpty(s.AzureResourceId));
+
+        if (writesAzureState && !AzureController.IsAzureImportEnabled())
+        {
+            return BatchCreateFailure(isAzureImport, parentId,
+                "Azure Import feature is not enabled.",
+                StatusCode(403, new { success = false, error = "Azure Import feature is not enabled" }));
+        }
+
         // Sanitize user inputs before processing
         if (sanitizationService != null)
         {

--- a/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
+++ b/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
@@ -42,7 +42,11 @@ public partial class SubnetController : Controller
             return BadRequest(new { success = false, error = "You must type 'approved' to confirm deletion." });
         }
 
-        if (request.SubnetIds.Count == 0)
+        // System.Text.Json overwrites the DTO's collection initialiser with null when the body
+        // carries an explicit null, so the initialiser is not a guarantee. Same shape the batch
+        // create path uses, and the difference matters: this path answers with modelled JSON, and
+        // dereferencing instead produces an HTML 500 the wizard cannot read.
+        if (request.SubnetIds is null or { Count: 0 })
         {
             return BadRequest(new { success = false, error = "No subnets were selected for deletion." });
         }

--- a/src/Bastet/Controllers/SubnetController.BulkAzure.cs
+++ b/src/Bastet/Controllers/SubnetController.BulkAzure.cs
@@ -180,7 +180,16 @@ public partial class SubnetController : Controller
                     if (!await ValidateSubnetCreation(targetVm))
                     {
                         await transaction.RollbackAsync();
-                        return BadRequest(ModelState);
+                        // The wizard reads error/globalErrors/itemErrors; a bare ModelState carries
+                        // none of them, so it rendered a panel containing the words "Commit failed:"
+                        // and nothing else. Echo the validator's own messages instead.
+                        return BadRequest(new
+                        {
+                            success = false,
+                            error = ModelStateMessage("The import could not be applied."),
+                            globalErrors = Array.Empty<string>(),
+                            itemErrors = Array.Empty<object>()
+                        });
                     }
 
                     targetSubnet = new Subnet
@@ -248,7 +257,14 @@ public partial class SubnetController : Controller
                     if (!await ValidateSubnetCreation(childVm))
                     {
                         await transaction.RollbackAsync();
-                        return BadRequest(ModelState);
+                        // See the target path above: same contract, same reason.
+                        return BadRequest(new
+                        {
+                            success = false,
+                            error = ModelStateMessage("The import could not be applied."),
+                            globalErrors = Array.Empty<string>(),
+                            itemErrors = Array.Empty<object>()
+                        });
                     }
 
                     Subnet newChild = new()

--- a/src/Bastet/Controllers/SubnetController.Create.cs
+++ b/src/Bastet/Controllers/SubnetController.Create.cs
@@ -1,6 +1,6 @@
 using Bastet.Models;
-using Bastet.Services;
 using Bastet.Models.ViewModels;
+using Bastet.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/src/Bastet/Controllers/SubnetController.Create.cs
+++ b/src/Bastet/Controllers/SubnetController.Create.cs
@@ -64,8 +64,13 @@ public partial class SubnetController : Controller
                 // combination is reachable straight from the UI, since the unallocated-range button
                 // navigates here with all three values. The parent name gives way rather than the
                 // address, which is the part that makes the name mean anything.
+                // "-{cidr}" and not "/{cidr}": [SafeText] on CreateSubnetViewModel.Name forbids
+                // "/", so the slashed form the app filled in was rejected by the very next POST with
+                // "Subnet name contains invalid characters" - on every create-from-unallocated-range
+                // flow that accepted the default. Round 4's D19 fixed this string's length and D8
+                // reasoned about its CIDR while both walked past the separator.
                 viewModel.Name = SubnetNaming.WithSuffix(
-                    parentSubnet.Name, $"-{networkAddress}/{cidr}", MaxSubnetNameLength);
+                    parentSubnet.Name, $"-{networkAddress}-{cidr}", MaxSubnetNameLength);
             }
         }
 

--- a/src/Bastet/Controllers/SubnetController.Edit.cs
+++ b/src/Bastet/Controllers/SubnetController.Edit.cs
@@ -35,7 +35,8 @@ public partial class SubnetController : Controller
             SubnetMask = ipUtilityService.CalculateSubnetMask(subnet.Cidr),
             CreatedAt = subnet.CreatedAt,
             LastModifiedAt = subnet.LastModifiedAt,
-            RowVersion = subnet.RowVersion
+            RowVersion = subnet.RowVersion,
+            IsAzureLinked = !string.IsNullOrEmpty(subnet.AzureResourceId)
         };
 
         // Add parent subnet info if exists
@@ -80,6 +81,20 @@ public partial class SubnetController : Controller
 
                     // Check if CIDR has changed
                     bool cidrChanged = viewModel.Cidr != subnet.Cidr;
+
+                    // An imported row records the prefix its Azure resource had at link time, and
+                    // the reconciler compares Bastet's current prefix against Azure's, reading any
+                    // difference as Azure-side drift. Changing the CIDR here breaks that invariant
+                    // silently: the row becomes a deletion candidate reported as "no longer exists
+                    // in Azure", and confirming it archives the subtree and its host IPs while the
+                    // Azure resource is healthy. Nothing downstream can tell that state apart from a
+                    // genuine Azure-side prefix change, so it has to be refused at the write.
+                    if (cidrChanged && !string.IsNullOrEmpty(subnet.AzureResourceId))
+                    {
+                        throw new ValidationException(
+                            "This subnet is linked to an Azure resource, so its CIDR cannot be changed here. " +
+                            "Change the prefix in Azure and re-import, or delete the subnet and recreate it.");
+                    }
 
                     // Always validate CIDR changes, regardless of whether this is a first or subsequent attempt
                     // This ensures validation is never bypassed, even on multiple form submissions
@@ -239,6 +254,10 @@ public partial class SubnetController : Controller
 
         // Repopulate the display-only properties
         viewModel.NetworkAddress = origSubnet.NetworkAddress;
+
+        // Re-derived from the database rather than trusted from the post, so a caller cannot claim a
+        // row is unlinked to get the editable field back on a re-render.
+        viewModel.IsAzureLinked = !string.IsNullOrEmpty(origSubnet.AzureResourceId);
 
         // Always set original CIDR to the actual DB value to prevent validation bypass
         viewModel.OriginalCidr = origSubnet.Cidr;

--- a/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
@@ -40,9 +40,21 @@ namespace Bastet.Models.ViewModels
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// The IPv4 address prefix in CIDR notation (e.g. "10.0.1.0/24")
+        /// The IPv4 address prefix in CIDR notation (e.g. "10.0.1.0/24"). The first one when the
+        /// subnet has several - the import path creates one Bastet subnet per Azure subnet, so it
+        /// can only carry one. Comparisons against what Azure currently holds must use
+        /// <see cref="Ipv4AddressPrefixes"/> instead.
         /// </summary>
         public string AddressPrefix { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Every IPv4 prefix the Azure subnet owns. Azure has allowed multiple prefixes on a single
+        /// subnet since September 2025, and it reports the singular <c>addressPrefix</c> as null
+        /// once there is more than one - so a subnet that still owns the prefix Bastet recorded can
+        /// have a different one first. Mirrors <see cref="BulkAzureVNetViewModel.Ipv4AddressPrefixes"/>,
+        /// which is why the VNet-level reconcile check was already correct and this one was not.
+        /// </summary>
+        public List<string> Ipv4AddressPrefixes { get; set; } = [];
 
         /// <summary>
         /// Whether this subnet can be imported. Populated by

--- a/src/Bastet/Models/ViewModels/AzureReconcileViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureReconcileViewModels.cs
@@ -117,7 +117,15 @@ namespace Bastet.Models.ViewModels
         /// Reported for review only: nothing here should be deleted, and the flag is never cleared
         /// automatically because it may have been set by hand.
         /// </summary>
-        FullyAllocatingSubnetDeleted
+        FullyAllocatingSubnetDeleted,
+
+        /// <summary>
+        /// The stored resource ID names neither a VNet nor a subnet, so nothing can be established
+        /// about it. Reported for review only: the Azure SDK builds its request from the resource
+        /// group and the last path segment alone, so reading such an ID asks about a different
+        /// resource entirely and its 404 would otherwise read as a confirmed deletion.
+        /// </summary>
+        UnrecognisedResourceId
     }
 
     /// <summary>

--- a/src/Bastet/Models/ViewModels/EditSubnetViewModel.cs
+++ b/src/Bastet/Models/ViewModels/EditSubnetViewModel.cs
@@ -65,6 +65,13 @@ public class EditSubnetViewModel
     [Display(Name = "Parent Subnet")]
     public string? ParentSubnetInfo { get; set; }
 
+    /// <summary>
+    /// True when the subnet carries an AzureResourceId. Display-only and never bound from the form:
+    /// the controller re-derives it from the database on every render, so a post cannot claim a row
+    /// is unlinked to get past the CIDR guard.
+    /// </summary>
+    public bool IsAzureLinked { get; set; }
+
     [Display(Name = "Created")]
     public DateTime CreatedAt { get; set; }
 

--- a/src/Bastet/Program.cs
+++ b/src/Bastet/Program.cs
@@ -240,8 +240,33 @@ if (autoMigrate)
     // lock held on a dedicated connection for the duration of both Migrate() calls. A replica
     // that cannot get the lock within the timeout fails startup loudly; on restart it finds the
     // migrations applied and Migrate() no-ops.
-    using SqlConnection migrationLockConnection = new(connectionString);
-    migrationLockConnection.Open();
+    // Scoped to master, not the target catalog. Migrate() below is what creates the database on a
+    // first run, and opening the lock connection against a catalog that does not exist yet fails
+    // first with SQL error 4060 - so BASTET_AUTO_MIGRATE could never bootstrap an empty server, a
+    // regression from when Migrate() ran before any lock existed. Holding the lock on master also
+    // means CREATE DATABASE happens inside it, which EF Core's own __EFMigrationsLock never covers:
+    // two simultaneous cold starts against a missing catalog otherwise race and one dies with
+    // "Database already exists".
+    SqlConnectionStringBuilder migrationLockConnectionString = new(connectionString)
+    {
+        InitialCatalog = "master"
+    };
+
+    using SqlConnection migrationLockConnection = new(migrationLockConnectionString.ConnectionString);
+
+    try
+    {
+        migrationLockConnection.Open();
+    }
+    catch (SqlException ex) when (ex.Number == 4060)
+    {
+        // 4060 is "cannot open database". Unhandled, this arrives as a bare stack trace naming
+        // neither the catalog nor the setting that asked for it.
+        throw new InvalidOperationException(
+            "BASTET_AUTO_MIGRATE is enabled, but the migration lock could not open a connection to "
+            + "'master' on the configured server. The login needs access to master so migrations can "
+            + "be serialised across replicas. See BASTET_CONNECTION_STRING.", ex);
+    }
 
     using (SqlCommand getLock = new("sp_getapplock", migrationLockConnection))
     {

--- a/src/Bastet/Program.cs
+++ b/src/Bastet/Program.cs
@@ -1,6 +1,7 @@
 using Bastet.Data;
 using Bastet.Filters;
 using Bastet.Services;
+using Bastet.Services.Security;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
@@ -8,6 +9,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Console;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -19,6 +21,14 @@ if (!builder.Environment.IsDevelopment())
     builder.Logging.AddFilter("Microsoft.AspNetCore", Enum.TryParse(Environment.GetEnvironmentVariable("BASTET_LOG_LEVEL_ASPNETCORE") ?? "Warning", true, out LogLevel aspNetLevel) ? aspNetLevel : LogLevel.Warning);
     builder.Logging.AddFilter("Microsoft.EntityFrameworkCore", Enum.TryParse(Environment.GetEnvironmentVariable("BASTET_LOG_LEVEL_ENTITYFRAMEWORK") ?? "Warning", true, out LogLevel efLevel) ? efLevel : LogLevel.Warning);
 }
+
+// Deliberately outside the block above, which only runs outside Development. The console sink writes
+// the exception itself, and an exception can carry a request-supplied value verbatim - so without a
+// sanitizing formatter a crafted identifier reaches the terminal with its control characters intact
+// and can erase a real log line to print a fabricated one. A developer's console deserves the same
+// protection as a production one, so this is registered unconditionally.
+builder.Logging.AddConsoleFormatter<SanitizingConsoleFormatter, ConsoleFormatterOptions>();
+builder.Logging.AddConsole(options => options.FormatterName = SanitizingConsoleFormatter.FormatterName);
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi

--- a/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
+++ b/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
@@ -34,7 +34,7 @@ namespace Bastet.Services.Azure
                 RenameMatchedBastetSubnets = selection.RenameMatchedBastetSubnets
             };
 
-            if (selection.VNetPrefixes.Count == 0)
+            if (selection.VNetPrefixes is null or { Count: 0 })
             {
                 plan.GlobalErrors.Add("No VNet address prefixes were selected.");
                 return plan;
@@ -46,6 +46,13 @@ namespace Bastet.Services.Azure
             List<ParsedPrefixSelection> parsed = [];
             foreach (BulkImportSelectedVNetPrefixDto sel in selection.VNetPrefixes)
             {
+                // A null entry in the list is as reachable as a null list: both come from the body.
+                if (sel is null)
+                {
+                    plan.GlobalErrors.Add("A selected VNet prefix was empty.");
+                    continue;
+                }
+
                 if (!TryParseCidr(sel.AddressPrefix, out string prefixNetwork, out int prefixCidr))
                 {
                     plan.GlobalErrors.Add($"VNet '{sel.VNetName}' has an invalid address prefix '{sel.AddressPrefix}'.");
@@ -66,8 +73,14 @@ namespace Bastet.Services.Azure
                     PrefixCidr = prefixCidr
                 };
 
-                foreach (BulkImportSelectedSubnetDto sub in sel.Subnets)
+                foreach (BulkImportSelectedSubnetDto sub in sel.Subnets ?? [])
                 {
+                    if (sub is null)
+                    {
+                        plan.GlobalErrors.Add($"A selected subnet under VNet '{sel.VNetName}' was empty.");
+                        continue;
+                    }
+
                     if (!TryParseCidr(sub.AddressPrefix, out string subNet, out int subCidr))
                     {
                         plan.GlobalErrors.Add(

--- a/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
+++ b/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
@@ -378,7 +378,7 @@ namespace Bastet.Services.Azure
 
                 if (renameMatched)
                 {
-                    string proposed = TruncateAndSanitizeName(p.Source.VNetName);
+                    string proposed = TargetName(p);
                     if (!string.Equals(proposed, exact.Name, StringComparison.Ordinal))
                     {
                         item.WillRename = true;
@@ -396,7 +396,7 @@ namespace Bastet.Services.Azure
                     item.TargetType = BulkImportTargetType.AutoCreateChild;
                     item.AutoCreateParentSubnetId = deepest.Id;
                     item.AutoCreateParentSubnetName = deepest.Name;
-                    item.AutoCreateTargetName = TruncateAndSanitizeName(p.Source.VNetName);
+                    item.AutoCreateTargetName = TargetName(p);
 
                     // The auto-created target's parent must be eligible to receive children
                     if (deepest.HasHostIpAssignments)
@@ -413,7 +413,7 @@ namespace Bastet.Services.Azure
                 else
                 {
                     item.TargetType = BulkImportTargetType.AutoCreateTopLevel;
-                    item.AutoCreateTargetName = TruncateAndSanitizeName(p.Source.VNetName);
+                    item.AutoCreateTargetName = TargetName(p);
                 }
             }
 
@@ -672,6 +672,19 @@ namespace Bastet.Services.Azure
             cidr = parsedCidr;
             return true;
         }
+
+        /// <summary>
+        /// The auto-created target subnet's name, with the same empty-name fallback the child names
+        /// already had. TruncateAndSanitizeName strips markup, so a VNet name that is entirely markup
+        /// sanitizes to empty - and ValidateSubnetCreation never inspects Name, so an empty one was
+        /// persisted while every interactive write path refuses it. EditSubnetViewModel carries a
+        /// comment about exactly this hazard ("StripHtml can empty a name outright, defeating
+        /// [Required]"); this was the one write with the same sanitizer output and no equivalent guard.
+        /// </summary>
+        private string TargetName(ParsedPrefixSelection prefix) =>
+            TruncateAndSanitizeName(prefix.Source.VNetName) is { Length: > 0 } name
+                ? name
+                : $"{prefix.PrefixNetwork}_{prefix.PrefixCidr}";
 
         private string TruncateAndSanitizeName(string? rawName)
         {

--- a/src/Bastet/Services/Azure/AzureReconciler.cs
+++ b/src/Bastet/Services/Azure/AzureReconciler.cs
@@ -43,7 +43,7 @@ namespace Bastet.Services.Azure
 
             // ARM resource IDs are case-insensitive.
             Dictionary<string, BulkAzureVNetViewModel> liveVNets = new(StringComparer.OrdinalIgnoreCase);
-            Dictionary<string, string> liveSubnetPrefixes = new(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, List<string>> liveSubnetPrefixes = new(StringComparer.OrdinalIgnoreCase);
 
             foreach (BulkAzureVNetViewModel vnet in inventory.VNets)
             {
@@ -56,7 +56,7 @@ namespace Bastet.Services.Azure
                 {
                     if (!string.IsNullOrEmpty(subnet.ResourceId))
                     {
-                        liveSubnetPrefixes[subnet.ResourceId] = subnet.AddressPrefix;
+                        liveSubnetPrefixes[subnet.ResourceId] = Ipv4PrefixesOf(subnet);
                     }
                 }
             }
@@ -224,7 +224,7 @@ namespace Bastet.Services.Azure
             // target's whole prefix, so if no such subnet remains, whatever justified it is gone.
             // Report only - the flag can also be set by hand, so we must not act on it.
             if (snapshot.IsFullyAllocated
-                && !vnet.Subnets.Any(s => string.Equals(s.AddressPrefix, prefix, StringComparison.OrdinalIgnoreCase)))
+                && !vnet.Subnets.Any(s => Ipv4PrefixesOf(s).Contains(prefix, StringComparer.OrdinalIgnoreCase)))
             {
                 return Item(snapshot, AzureReconcileStatus.FullyAllocatingSubnetDeleted, true,
                     $"Marked fully allocated, but no Azure subnet in VNet '{vnet.Name}' covers {prefix} any more. " +
@@ -239,24 +239,40 @@ namespace Bastet.Services.Azure
         /// </summary>
         private static AzureReconcileItem? EvaluateSubnetLevel(
             AzureLinkedSubnetSnapshot snapshot,
-            Dictionary<string, string> liveSubnetPrefixes)
+            Dictionary<string, List<string>> liveSubnetPrefixes)
         {
             string prefix = $"{snapshot.NetworkAddress}/{snapshot.Cidr}";
 
-            if (!liveSubnetPrefixes.TryGetValue(snapshot.AzureResourceId, out string? livePrefix))
+            if (!liveSubnetPrefixes.TryGetValue(snapshot.AzureResourceId, out List<string>? livePrefixes))
             {
                 return Item(snapshot, AzureReconcileStatus.SubnetDeleted, false,
                     "The Azure subnet this was imported from no longer exists.");
             }
 
-            if (!string.Equals(livePrefix, prefix, StringComparison.OrdinalIgnoreCase))
+            // Membership, not equality, and for the same reason the VNet-level check above uses it:
+            // an Azure subnet may own several IPv4 prefixes, and the one Bastet recorded need not be
+            // the first. Comparing against a single collapsed value reports drift on a subnet that
+            // still owns the prefix - and a drift row is offered for deletion with no Azure read
+            // behind it.
+            if (!livePrefixes.Contains(prefix, StringComparer.OrdinalIgnoreCase))
             {
+                string live = livePrefixes.Count == 0 ? "none" : string.Join(", ", livePrefixes);
                 return Item(snapshot, AzureReconcileStatus.SubnetPrefixChanged, false,
-                    $"The Azure subnet still exists but its address prefix is now {livePrefix}, not {prefix}.");
+                    $"The Azure subnet still exists but its address prefix is now {live}, not {prefix}.");
             }
 
             return null;
         }
+
+        /// <summary>
+        /// Every IPv4 prefix an inventory subnet owns. GetVNetInventory populates the list, but a
+        /// caller that only sets the scalar must not silently compare against an empty set, so the
+        /// scalar is the fallback.
+        /// </summary>
+        private static List<string> Ipv4PrefixesOf(BulkAzureSubnetViewModel subnet) =>
+            subnet.Ipv4AddressPrefixes.Count > 0
+                ? subnet.Ipv4AddressPrefixes
+                : string.IsNullOrEmpty(subnet.AddressPrefix) ? [] : [subnet.AddressPrefix];
 
         private static AzureReconcileItem Item(
             AzureLinkedSubnetSnapshot snapshot,

--- a/src/Bastet/Services/Azure/AzureReconciler.cs
+++ b/src/Bastet/Services/Azure/AzureReconciler.cs
@@ -75,16 +75,34 @@ namespace Bastet.Services.Azure
                     continue;
                 }
 
-                AzureReconcileItem? item = AzureResourceIdentity.IsAzureSubnet(snapshot.AzureResourceId)
-                    ? EvaluateSubnetLevel(snapshot, liveSubnetPrefixes)
-                    : EvaluateVNetLevel(snapshot, liveVNets);
+                // Three-way, not two. An ID that is neither a VNet nor a subnet used to fall down
+                // the VNet branch, where absence from the listing reads as VNetDeleted - a claim
+                // nothing established, on the one path that removes data. It is reported for review
+                // instead, so the operator can correct the row rather than have it silently offered
+                // for archival.
+                AzureReconcileItem? item;
+                if (AzureResourceIdentity.IsAzureSubnet(snapshot.AzureResourceId))
+                {
+                    item = EvaluateSubnetLevel(snapshot, liveSubnetPrefixes);
+                }
+                else if (AzureResourceIdentity.IsAzureVNet(snapshot.AzureResourceId))
+                {
+                    item = EvaluateVNetLevel(snapshot, liveVNets);
+                }
+                else
+                {
+                    item = Item(snapshot, AzureReconcileStatus.UnrecognisedResourceId, true,
+                        "The recorded Azure resource ID names neither a VNet nor a subnet, so nothing "
+                        + "can be established about it. Correct or clear the link on this subnet.");
+                }
 
                 if (item is null)
                 {
                     continue;
                 }
 
-                if (item.Status == AzureReconcileStatus.FullyAllocatingSubnetDeleted)
+                if (item.Status is AzureReconcileStatus.FullyAllocatingSubnetDeleted
+                    or AzureReconcileStatus.UnrecognisedResourceId)
                 {
                     plan.ReviewItems.Add(item);
                 }

--- a/src/Bastet/Services/Azure/AzureReconciler.cs
+++ b/src/Bastet/Services/Azure/AzureReconciler.cs
@@ -139,6 +139,7 @@ namespace Bastet.Services.Azure
 
             List<AzureReconcileItem> keep = [];
             List<AzureReconcileItem> notVisible = [];
+            List<AzureReconcileItem> unknown = [];
             List<AzureReconcileItem> stillLive = [];
 
             foreach (AzureReconcileItem item in plan.Items)
@@ -169,8 +170,16 @@ namespace Bastet.Services.Azure
                     case AzureResourceConfirmation.Live:
                         stillLive.Add(item);
                         break;
-                    default:
+                    case AzureResourceConfirmation.NotVisible:
                         notVisible.Add(item);
+                        break;
+                    default:
+                        // Unknown is a different fact from NotVisible and gets its own message. The
+                        // action is identical - both are withheld - but "the credential lost access"
+                        // is a guess when the truth is that Azure could not be asked, and an ARM
+                        // throttle or a transport blip mid-scan produces Unknown on a subscription
+                        // whose permissions are perfectly intact.
+                        unknown.Add(item);
                         break;
                 }
             }
@@ -180,9 +189,17 @@ namespace Bastet.Services.Azure
             if (notVisible.Count > 0)
             {
                 plan.Warnings.Add(
-                    $"{notVisible.Count} Azure-linked subnet(s) were missing from the subscription listing, but Azure would " +
-                    "not confirm they are deleted - the credential may simply have lost access to them. They have been " +
-                    $"withheld from deletion: {NameList(notVisible)}.");
+                    $"{notVisible.Count} Azure-linked subnet(s) were missing from the subscription listing, and Azure denied " +
+                    "access when asked about them directly - the credential may have lost access to their resource group. " +
+                    $"They have been withheld from deletion: {NameList(notVisible)}.");
+            }
+
+            if (unknown.Count > 0)
+            {
+                plan.Warnings.Add(
+                    $"{unknown.Count} Azure-linked subnet(s) were missing from the subscription listing, and Azure could not " +
+                    "be asked about them - the read failed rather than answering. Nothing is wrong with the subnet itself; " +
+                    $"try the scan again. They have been withheld from deletion: {NameList(unknown)}.");
             }
 
             if (stillLive.Count > 0)

--- a/src/Bastet/Services/Azure/AzureResourceIdentity.cs
+++ b/src/Bastet/Services/Azure/AzureResourceIdentity.cs
@@ -17,21 +17,39 @@ namespace Bastet.Services.Azure
     public static class AzureResourceIdentity
     {
         private const string SubnetResourceType = "Microsoft.Network/virtualNetworks/subnets";
+        private const string VNetResourceType = "Microsoft.Network/virtualNetworks";
 
         /// <summary>
         /// True when the ID names an Azure subnet rather than a VNet or anything else.
         /// </summary>
         /// <remarks>
-        /// An ID that will not parse returns false, so callers treat it as VNet-level - the branch
-        /// an unrecognised value already took. AzureResourceId is free text on the entity and can be
-        /// edited by hand, and ResourceIdentifier's constructor throws on malformed input, so one
-        /// bad row must not be able to abort a whole reconcile scan.
+        /// An ID that will not parse returns false. AzureResourceId is free text on the entity and
+        /// can be edited by hand, so one bad row must not be able to abort a whole reconcile scan.
+        /// Note this is only half the question: false does not mean "VNet". Callers that act on the
+        /// answer must ask <see cref="IsAzureVNet"/> too and treat neither-of-the-two as unknown.
         /// </remarks>
         public static bool IsAzureSubnet(string? resourceId) =>
+            IsResourceType(resourceId, SubnetResourceType);
+
+        /// <summary>
+        /// True when the ID names an Azure VNet.
+        /// </summary>
+        /// <remarks>
+        /// Needed because the Azure SDK's VNet accessor builds its request from the subscription,
+        /// the resource group and the **last path segment** only - it discards the provider
+        /// namespace and type, and does not validate them. So reading a resource-group ID, a storage
+        /// account ID or a truncated subnet ID through it silently asks about a different resource,
+        /// and a 404 there is indistinguishable from the VNet genuinely being gone. Anything that is
+        /// neither a VNet nor a subnet must be reported as unknown, never as deleted.
+        /// </remarks>
+        public static bool IsAzureVNet(string? resourceId) =>
+            IsResourceType(resourceId, VNetResourceType);
+
+        private static bool IsResourceType(string? resourceId, string resourceType) =>
             !string.IsNullOrWhiteSpace(resourceId)
             && ResourceIdentifier.TryParse(resourceId, out ResourceIdentifier? id)
             && id is not null
-            && string.Equals(id.ResourceType.ToString(), SubnetResourceType, StringComparison.OrdinalIgnoreCase);
+            && string.Equals(id.ResourceType.ToString(), resourceType, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// The path to link to in the Azure portal. Per-subnet portal pages are nearly empty, so a

--- a/src/Bastet/Services/Azure/AzureService.cs
+++ b/src/Bastet/Services/Azure/AzureService.cs
@@ -353,7 +353,11 @@ namespace Bastet.Services.Azure
                         {
                             ResourceId = subnet.Id.ToString(),
                             Name = subnet.Data.Name ?? string.Empty,
-                            AddressPrefix = ipv4Prefix
+                            AddressPrefix = ipv4Prefix,
+                            // Distinct because ARM may report a single prefix in both the singular
+                            // property and the collection; a duplicate would reach the operator in
+                            // the reconcile reason text.
+                            Ipv4AddressPrefixes = [.. ExtractIpv4Prefixes(subnet).Distinct(StringComparer.OrdinalIgnoreCase)]
                         });
                     }
 
@@ -377,6 +381,34 @@ namespace Bastet.Services.Azure
         /// Returns the first IPv4 prefix associated with the given Azure subnet, or null if none exists.
         /// Handles both single-prefix subnets and dual-stack subnets.
         /// </summary>
+        /// <summary>
+        /// Every IPv4 prefix the subnet owns, in the order ARM reports them. Azure has allowed
+        /// several prefixes on one subnet since September 2025 and reports the singular
+        /// <c>AddressPrefix</c> as null once there is more than one, so anything comparing what
+        /// Bastet recorded against what Azure holds has to look at all of them - the recorded
+        /// prefix need not be the first.
+        /// </summary>
+        private static IEnumerable<string> ExtractIpv4Prefixes(SubnetResource subnet)
+        {
+            if (subnet.Data.AddressPrefix is not null && IsIpv4AddressPrefix(subnet.Data.AddressPrefix))
+            {
+                yield return subnet.Data.AddressPrefix;
+            }
+
+            if (subnet.Data.AddressPrefixes is null)
+            {
+                yield break;
+            }
+
+            foreach (string? prefix in subnet.Data.AddressPrefixes)
+            {
+                if (!string.IsNullOrEmpty(prefix) && IsIpv4AddressPrefix(prefix))
+                {
+                    yield return prefix;
+                }
+            }
+        }
+
         private static string? ExtractIpv4Prefix(SubnetResource subnet)
         {
             // Case 1: Single address prefix

--- a/src/Bastet/Services/Azure/AzureService.cs
+++ b/src/Bastet/Services/Azure/AzureService.cs
@@ -569,21 +569,33 @@ namespace Bastet.Services.Azure
         /// </remarks>
         private async Task<AzureResourceConfirmation> ConfirmOneAsync(string resourceId)
         {
-            ResourceIdentifier identifier;
-            try
+            // Free text on the entity, so a malformed value is possible. TryParse rather than the
+            // constructor: it returns false instead of throwing, and it throws for exactly one input
+            // anyway (the empty string), which the caller already filters - so the catch this
+            // replaces could never run.
+            if (!ResourceIdentifier.TryParse(resourceId, out ResourceIdentifier? identifier) || identifier is null)
             {
-                identifier = new ResourceIdentifier(resourceId);
+                _logger.LogWarning("Could not parse the Azure resource ID {ResourceId}", SanitizeForLog(resourceId));
+                return AzureResourceConfirmation.Unknown;
             }
-            catch (Exception ex)
+
+            // The type has to be established before reading, not assumed. The SDK's accessors build
+            // their request from (subscription, resource group, last path segment) and discard the
+            // provider namespace and type without validating them, so reading an ID of some other
+            // type asks about a different resource - and its 404 would come back here as a confirmed
+            // deletion. Unknown is the only honest answer for anything else.
+            bool isSubnet = AzureResourceIdentity.IsAzureSubnet(resourceId);
+            if (!isSubnet && !AzureResourceIdentity.IsAzureVNet(resourceId))
             {
-                // Free text on the entity, so a malformed value is possible. Unknown, never Deleted.
-                _logger.LogWarning(ex, "Could not parse the Azure resource ID {ResourceId}", SanitizeForLog(resourceId));
+                _logger.LogWarning(
+                    "The stored Azure resource ID {ResourceId} names neither a VNet nor a subnet, so it cannot be confirmed",
+                    SanitizeForLog(resourceId));
                 return AzureResourceConfirmation.Unknown;
             }
 
             try
             {
-                if (AzureResourceIdentity.IsAzureSubnet(resourceId))
+                if (isSubnet)
                 {
                     await _armClient.GetSubnetResource(identifier).GetAsync();
                 }

--- a/src/Bastet/Services/Security/SanitizingConsoleFormatter.cs
+++ b/src/Bastet/Services/Security/SanitizingConsoleFormatter.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+
+namespace Bastet.Services.Security;
+
+/// <summary>
+/// A console formatter that runs every line it writes through <see cref="LogSanitizer"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="LogSanitizer"/> protects values passed as template arguments, but the sink writes the
+/// exception itself and that never went through it. An ARM identifier that fails the Azure SDK's own
+/// local validation comes back inside <c>ex.Message</c> verbatim, so a request-supplied value reached
+/// the terminal with its control characters intact - enough to erase a genuine log line and print a
+/// fabricated one in its place. Sanitizing at the sink covers every call site at once, including the
+/// ones no static analyser flags because their template arguments are integers.
+/// </para>
+/// <para>
+/// Lines are split before they are sanitized, never after. A newline is a control character, so
+/// sanitizing an exception as one string would collapse its stack trace onto a single line; splitting
+/// first means legitimate structure comes from the formatter and only the content is scrubbed.
+/// </para>
+/// <para>
+/// No ANSI colour is emitted, unlike the default simple formatter. A formatter whose purpose is to
+/// keep escape sequences out of the log has no business writing its own.
+/// </para>
+/// </remarks>
+public sealed class SanitizingConsoleFormatter() : ConsoleFormatter(FormatterName)
+{
+    public const string FormatterName = "bastet-sanitizing";
+
+    /// <summary>Matches the default console formatter's continuation indent.</summary>
+    private const string Indent = "      ";
+
+    public override void Write<TState>(
+        in LogEntry<TState> logEntry, IExternalScopeProvider? scopeProvider, TextWriter textWriter)
+    {
+        ArgumentNullException.ThrowIfNull(textWriter);
+
+        string message = logEntry.Formatter?.Invoke(logEntry.State, logEntry.Exception) ?? string.Empty;
+
+        if (string.IsNullOrEmpty(message) && logEntry.Exception is null)
+        {
+            return;
+        }
+
+        textWriter.Write(LevelPrefix(logEntry.LogLevel));
+        textWriter.Write(": ");
+        textWriter.Write(logEntry.Category);
+        textWriter.Write('[');
+        textWriter.Write(logEntry.EventId.Id);
+        textWriter.Write(']');
+        textWriter.Write(Environment.NewLine);
+
+        WriteIndentedLines(textWriter, message);
+
+        if (logEntry.Exception is not null)
+        {
+            WriteIndentedLines(textWriter, logEntry.Exception.ToString());
+        }
+    }
+
+    private static void WriteIndentedLines(TextWriter textWriter, string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        foreach (string line in text.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            textWriter.Write(Indent);
+            textWriter.Write(LogSanitizer.SanitizeForLog(line));
+            textWriter.Write(Environment.NewLine);
+        }
+    }
+
+    /// <summary>The four-character prefixes the default console formatter uses.</summary>
+    private static string LevelPrefix(LogLevel logLevel) => logLevel switch
+    {
+        LogLevel.Trace => "trce",
+        LogLevel.Debug => "dbug",
+        LogLevel.Information => "info",
+        LogLevel.Warning => "warn",
+        LogLevel.Error => "fail",
+        LogLevel.Critical => "crit",
+        _ => "none"
+    };
+}

--- a/src/Bastet/Services/Security/SanitizingConsoleFormatter.cs
+++ b/src/Bastet/Services/Security/SanitizingConsoleFormatter.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 

--- a/src/Bastet/Services/Validation/ISubnetValidationService.cs
+++ b/src/Bastet/Services/Validation/ISubnetValidationService.cs
@@ -7,7 +7,7 @@ namespace Bastet.Services.Validation;
 /// </summary>
 public interface ISubnetValidationService
 {
-        /// <summary>
+    /// <summary>
     /// Validates that a subnet is properly contained within a parent subnet
     /// </summary>
     /// <param name="childNetwork">The child network address</param>

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -591,7 +591,10 @@
         }
 
         function showCommitError(payload) {
-            $("#bulk-commit-error-message").text(payload && payload.error ? payload.error : "");
+            // The fallback is the floor under a body this handler does not recognise - without it an
+            // unexpected shape renders the panel with no text at all. The reconcile wizard's
+            // equivalent has always had one.
+            $("#bulk-commit-error-message").text(payload && payload.error ? payload.error : "The import failed.");
             const $list = $("#bulk-commit-error-list").empty();
             if (payload && payload.globalErrors && payload.globalErrors.length > 0) {
                 $.each(payload.globalErrors, function (i, e) { $list.append($('<li></li>').text(e)); });

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -177,11 +177,13 @@
                 const $card = $('<div class="card mb-2"></div>');
                 const $body = $('<div class="card-body p-2"></div>');
                 let visiblePrefixes = 0;
+                let suppressedPrefixes = 0;
 
                 $.each(vnet.prefixes, function (pIdx, prefixInfo) {
                     const prefix = prefixInfo.addressPrefix;
 
                     if (hideImported && !prefixInfo.isSelectable) {
+                        suppressedPrefixes++;
                         return; // continue
                     }
                     visiblePrefixes++;
@@ -253,8 +255,21 @@
             });
 
             if ($tree.children().length === 0) {
-                $tree.append('<div class="alert alert-success mb-0"><i class="bi bi-check-circle"></i> '
-                    + 'Everything in this subscription has already been imported. Nothing left to select.</div>');
+                // AnnotatePrefix never returns AlreadyImported - a target that really was imported
+                // comes back Blocked with "already has child subnets", the same bucket as a prefix
+                // blocked by a conflict with a hand-made subnet. So "already imported" was asserted
+                // over rows that had never been imported at all, with the red explanation hidden
+                // rather than shown. Say how many were suppressed and how to see why.
+                const $empty = $('<div class="alert alert-info mb-0"></div>');
+                if (suppressedPrefixes > 0) {
+                    $empty.append($('<span></span>').text(
+                        suppressedPrefixes + ' VNet prefix(es) in this subscription cannot be selected, '
+                        + 'and are hidden. Untick "Hide unavailable" to see why.'));
+                } else {
+                    $empty.append($('<span></span>').text(
+                        'This subscription has no VNet prefixes to import.'));
+                }
+                $tree.append($empty);
             }
 
             // Subnet checked → check its prefix (never force a disabled prefix on; a blocked target

--- a/src/Bastet/Views/Azure/BulkImport/_StepSelection.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_StepSelection.cshtml
@@ -43,7 +43,7 @@
             <div class="form-check form-switch">
                 <input class="form-check-input" type="checkbox" id="bulk-hide-imported">
                 <label class="form-check-label" for="bulk-hide-imported">
-                    Hide already imported
+                    Hide unavailable
                 </label>
             </div>
             <div class="form-check form-switch">

--- a/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
@@ -345,10 +345,18 @@
                 $("#rec-confirm-cascade").addClass("d-none");
             }
 
+            // The reason is carried through to this screen deliberately. Step 2 prints it beside the
+            // checkbox, but this is the last screen before the archive and it used to show only the
+            // status label - so a row whose own reason says the Azure resource still exists was
+            // confirmed under a heading saying it did not.
             const list = $("#rec-confirm-list").empty();
             targets.forEach(function (i) {
-                list.append($('<li class="list-group-item"></li>')
-                    .text(i.name + " (" + i.networkAddress + "/" + i.cidr + ") - " + statusLabel(i.statusName).text));
+                const li = $('<li class="list-group-item"></li>')
+                    .text(i.name + " (" + i.networkAddress + "/" + i.cidr + ") - " + statusLabel(i.statusName).text);
+                if (i.reason) {
+                    li.append($('<div class="small text-muted"></div>').text(i.reason));
+                }
+                list.append(li);
             });
 
             $("#rec-confirmation").val("");

--- a/src/Bastet/Views/Azure/Reconcile/_StepConfirm.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_StepConfirm.cshtml
@@ -2,7 +2,7 @@
 
 <div class="alert alert-danger">
     <h4 class="alert-heading"><i class="bi bi-exclamation-triangle-fill me-2"></i>Warning!</h4>
-    <p>You are about to delete <strong><span id="rec-confirm-count">0</span></strong> subnet(s) that no longer exist in Azure.</p>
+    <p>You are about to delete <strong><span id="rec-confirm-count">0</span></strong> subnet(s) that no longer match Azure. Each one's reason is listed below - read it before confirming.</p>
     <p id="rec-confirm-cascade" class="d-none mb-2"></p>
     <p class="mb-0">
         Deleted subnets are archived and can be reviewed under Deleted Subnets, but they are removed from the

--- a/src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml
@@ -35,7 +35,7 @@
     <div id="rec-stale-section" class="d-none">
         <div class="alert alert-danger">
             <i class="bi bi-exclamation-triangle-fill me-2"></i>
-            <strong>These BASTET subnets no longer exist in Azure.</strong>
+            <strong>These BASTET subnets no longer match Azure.</strong>
             Deleting one also archives everything beneath it. Rows with a cascade warning will take child subnets or
             host IP assignments with them, including any you created by hand.
         </div>

--- a/src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml
@@ -73,8 +73,8 @@
     <div id="rec-review-section" class="d-none mt-4">
         <h5><i class="bi bi-eye"></i> Needs review</h5>
         <div class="alert alert-secondary">
-            These subnets still exist in Azure, so there is nothing to delete, but something about them has drifted.
-            BASTET will not change them automatically.
+            Nothing here can be fixed by deleting anything, so these are listed without checkboxes.
+            The reason column says what is wrong with each one. BASTET will not change them automatically.
         </div>
 
         <div class="table-responsive">

--- a/src/Bastet/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/src/Bastet/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,3 +1,15 @@
+@* jQuery 4 removed $.parseJSON, and jquery-validation-unobtrusive 4.0.0 - the latest published
+   version - still calls it while placing an error message. The call sits in onError, which runs
+   before jquery-validation can cancel the submit, so without this every invalid submit throws a
+   TypeError, the form posts anyway, and the browser's own min/max/required checks are already off
+   because the library set novalidate on the form. Restoring the alias is the whole fix: it is the
+   only jQuery 4 removal this library chain touches. Guarded so it is a no-op on any jQuery that
+   still ships parseJSON, including a rollback to 3.7.1. *@
+<script>
+    if (typeof jQuery !== "undefined" && typeof jQuery.parseJSON !== "function") {
+        jQuery.parseJSON = JSON.parse;
+    }
+</script>
 <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.21.0/dist/jquery.validate.min.js"
         integrity="sha384-INLNT6YPpjCRFM2xpOexEE3T4i2mIigf+Kr19b7a59RFtrVBZQzZWXkGuiMA/q1r" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery-validation-unobtrusive@4.0.0/dist/jquery.validate.unobtrusive.min.js"

--- a/src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml
+++ b/src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml
@@ -199,7 +199,10 @@
         function normalizeIpToSubnetBoundary(ipAddress, cidr) {
             const ipNum = ipAddressToNumber(ipAddress);
             // Create a mask based on the CIDR
-            const mask = ~((1 << (32 - cidr)) - 1);
+            // cidr === 0 has to be special-cased: 1 << 32 is 1 in JavaScript, so the shift yields
+        // 255.255.255.255 where the server and the Create page both yield 0.0.0.0. Four of the six
+        // copies of this expression already guard it; these two did not.
+        const mask = cidr === 0 ? 0 : ~((1 << (32 - cidr)) - 1);
             // Apply the mask to get the subnet boundary. This is signed for addresses at or above
             // 128.0.0.0, which is harmless here and deliberately left alone: the value is only ever
             // handed to numberToIpAddress, whose unsigned >>> shifts render it correctly, and is
@@ -266,7 +269,9 @@
             const subnetSize = Math.pow(2, 32 - cidr);
             
             // Calculate the subnet bit boundary (we need to align to this)
-            const cidrBitMask = ~((1 << (32 - cidr)) - 1);
+            // Guarded for symmetry with the site above. Not reachable at cidr === 0 today - the only
+        // caller constrains cidr to parentCidr + 1 or more - so this one fixes no observable output.
+        const cidrBitMask = cidr === 0 ? 0 : ~((1 << (32 - cidr)) - 1);
             
             // Try each possible starting address within the parent's range.
             // >>> 0 puts the result back in the unsigned domain: bitwise operands are coerced to

--- a/src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml
+++ b/src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml
@@ -59,9 +59,14 @@
             $('#createSubnetBtn').prop('disabled', false);
         });
         
-        // Make network address field editable when needed
-        function makeNetworkAddressEditable() {
-            $('#networkAddressDisplay').prop('readonly', false);
+        // Flag that the address was moved off the one the button carried. The field stays read-only:
+        // nothing listens to it - instrumenting jQuery.on and addEventListener before this script runs
+        // shows three bindings, none of them on this field and none delegated - so a typed value
+        // skipped the overlap check entirely while the help text below still claimed the address had
+        // been "adjusted to avoid overlaps". Nothing is lost by leaving it locked, because
+        // findCompatibleNetworkAddress searches only within the parent's boundaries and skips every
+        // child, so the value it writes is always inside the parent, aligned and clear of siblings.
+        function markNetworkAddressAdjusted() {
             $('#networkAddressDisplay').addClass('border-warning');
             $('#networkAddressHelp').html('<span class="text-warning">This network address has been adjusted to avoid overlaps.</span>');
             $('#networkAddressHelp').removeClass('d-none');
@@ -95,7 +100,7 @@
                     // We found a compatible address, update the field
                     $('#networkAddressDisplay').val(compatibleAddress);
                     networkAddress = compatibleAddress;
-                    makeNetworkAddressEditable();
+                    markNetworkAddressAdjusted();
                     
                     $(this).removeClass('is-invalid').addClass('is-valid');
                     $('#createSubnetBtn').prop('disabled', false);

--- a/src/Bastet/Views/Subnet/Details/_UnallocatedRanges.cshtml
+++ b/src/Bastet/Views/Subnet/Details/_UnallocatedRanges.cshtml
@@ -27,7 +27,11 @@
                                 <td>@range.AddressCount.ToString("N0") IP addresses</td>
                                 <td>
                                     @inject Bastet.Services.IUserContextService SubnetUserContext
-                                    @if (SubnetUserContext.UserHasRole(Bastet.Models.ApplicationRoles.Edit) && Model.HostIpAssignments.Count == 0)
+                                    @* Model.Cidr < 32 because a /32 has no room for a child at all: the
+                                       modal computes a range of 33-32, leaves Create enabled, and the
+                                       POST can only ever be refused. Gating here removes the
+                                       impossible state rather than rendering it more politely. *@
+                                    @if (SubnetUserContext.UserHasRole(Bastet.Models.ApplicationRoles.Edit) && Model.HostIpAssignments.Count == 0 && Model.Cidr < 32)
                                     {
                                         <button type="button" class="btn btn-sm btn-success create-subnet-btn" 
                                                 data-network="@range.StartIp" 

--- a/src/Bastet/Views/Subnet/Edit/_EditForm.cshtml
+++ b/src/Bastet/Views/Subnet/Edit/_EditForm.cshtml
@@ -15,13 +15,31 @@
             
             <div class="mb-3">
                 <label asp-for="Cidr" class="form-label">CIDR Notation</label>
-                <div class="input-group">
-                    <span class="input-group-text">/</span>
-                    <input asp-for="Cidr" class="form-control" min="0" max="32" />
-                </div>
-                <div class="form-text">
-                    Changing this value affects the size of the subnet.
-                </div>
+                @if (Model.IsAzureLinked)
+                {
+                    @* Imported rows record the prefix their Azure resource had at link time; the
+                       reconciler treats any difference as Azure-side drift. The server refuses the
+                       change either way - this only stops the operator typing one. *@
+                    <div class="input-group">
+                        <span class="input-group-text">/</span>
+                        <input value="@Model.Cidr" class="form-control" readonly disabled />
+                    </div>
+                    <input type="hidden" asp-for="Cidr" />
+                    <div class="form-text">
+                        Imported from Azure, so the prefix is fixed here. Change it in Azure and
+                        re-import, or delete the subnet and recreate it.
+                    </div>
+                }
+                else
+                {
+                    <div class="input-group">
+                        <span class="input-group-text">/</span>
+                        <input asp-for="Cidr" class="form-control" min="0" max="32" />
+                    </div>
+                    <div class="form-text">
+                        Changing this value affects the size of the subnet.
+                    </div>
+                }
                 <span asp-validation-for="Cidr" class="text-danger"></span>
             </div>
             

--- a/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
@@ -46,6 +46,35 @@ public class AzureBulkImportPlannerTests
         };
 
     /// <summary>
+    /// A VNet name that is entirely markup sanitizes to empty, and ValidateSubnetCreation never
+    /// inspects Name - so the bulk path persisted a subnet with no name at all while every
+    /// interactive write path refuses one. The child names four lines away always had this fallback.
+    /// </summary>
+    [Theory]
+    [InlineData("<b></b>")]
+    [InlineData("   ")]
+    [InlineData("")]
+    public void VNetNameThatSanitizesToEmpty_FallsBackToThePrefix(string vnetName)
+    {
+        BulkImportPlanViewModel plan = _planner.BuildPlan(
+            Sel(false, Pref(vnetName, "192.168.0.0/16", Sub("web", "192.168.1.0/24"))), []);
+
+        BulkImportPlanItem item = Assert.Single(plan.Items);
+        Assert.False(string.IsNullOrWhiteSpace(item.AutoCreateTargetName));
+        Assert.Equal("192.168.0.0_16", item.AutoCreateTargetName);
+    }
+
+    /// <summary>The guard: an ordinary VNet name is still used verbatim.</summary>
+    [Fact]
+    public void OrdinaryVNetName_IsUsedAsTheTargetName()
+    {
+        BulkImportPlanViewModel plan = _planner.BuildPlan(
+            Sel(false, Pref("prod-vnet", "192.168.0.0/16", Sub("web", "192.168.1.0/24"))), []);
+
+        Assert.Equal("prod-vnet", Assert.Single(plan.Items).AutoCreateTargetName);
+    }
+
+    /// <summary>
     /// System.Text.Json overwrites a collection initialiser when the body carries an explicit null,
     /// so `= []` on the DTO is not a guarantee. Dereferencing produced an unhandled
     /// NullReferenceException - and on the commit path that happens inside the subnet lock and

--- a/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
@@ -45,6 +45,54 @@ public class AzureBulkImportPlannerTests
             VNetPrefixes = [.. prefixes]
         };
 
+    /// <summary>
+    /// System.Text.Json overwrites a collection initialiser when the body carries an explicit null,
+    /// so `= []` on the DTO is not a guarantee. Dereferencing produced an unhandled
+    /// NullReferenceException - and on the commit path that happens inside the subnet lock and
+    /// outside the action's only catch, so the caller got an HTML 500 where every other malformed
+    /// body returns modelled JSON.
+    /// </summary>
+    [Fact]
+    public void NullVNetPrefixes_ReportsAnError_DoesNotThrow()
+    {
+        BulkImportSelectionDto selection = new()
+        {
+            SubscriptionId = "sub-1",
+            SubscriptionName = "Test Sub",
+            VNetPrefixes = null!
+        };
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(selection, []);
+
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("No VNet address prefixes were selected."));
+    }
+
+    [Fact]
+    public void NullEntryInVNetPrefixes_ReportsAnError_DoesNotThrow()
+    {
+        BulkImportSelectionDto selection = Sel(false, Pref("vnet-a", "10.0.0.0/16"));
+        selection.VNetPrefixes.Add(null!);
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(selection, []);
+
+        Assert.Contains(plan.GlobalErrors, e => e.Contains("was empty"));
+    }
+
+    [Fact]
+    public void NullSubnetsCollection_ReportsNothingAndDoesNotThrow()
+    {
+        BulkImportSelectedVNetPrefixDto prefix = Pref("vnet-a", "10.0.0.0/16");
+        prefix.Subnets = null!;
+        BulkImportSelectionDto selection = Sel(false, prefix);
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(selection, []);
+
+        // A VNet prefix with no subnets is a legitimate selection - the target is still created.
+        Assert.Empty(plan.GlobalErrors);
+        Assert.Single(plan.Items);
+    }
+
     private static ExistingSubnetSnapshot Existing(
         int id, string name, string network, int cidr,
         bool hasChildren = false, bool hasHostIps = false, bool fullyAllocated = false,

--- a/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
@@ -36,8 +36,19 @@ public class AzureReconcilerTests
             Subnets = [.. subnets]
         };
 
-    private static BulkAzureSubnetViewModel AzSubnet(string vnetName, string name, string prefix) =>
-        new() { ResourceId = SubnetId(vnetName, name), Name = name, AddressPrefix = prefix };
+    /// <summary>
+    /// Mirrors what GetVNetInventory builds: AddressPrefix is the first IPv4 prefix, and
+    /// Ipv4AddressPrefixes carries all of them. Passing more than one models an Azure subnet with
+    /// multiple address prefixes, GA since September 2025.
+    /// </summary>
+    private static BulkAzureSubnetViewModel AzSubnet(string vnetName, string name, params string[] prefixes) =>
+        new()
+        {
+            ResourceId = SubnetId(vnetName, name),
+            Name = name,
+            AddressPrefix = prefixes[0],
+            Ipv4AddressPrefixes = [.. prefixes]
+        };
 
     private static AzureVNetInventory Live(params BulkAzureVNetViewModel[] vnets) =>
         new() { Success = true, VNets = [.. vnets] };
@@ -205,6 +216,43 @@ public class AzureReconcilerTests
         Assert.Contains("10.0.9.0/24", item.Reason);
     }
 
+    /// <summary>
+    /// The subnet still owns the prefix Bastet recorded; it simply has another one listed first.
+    /// Reading only the first prefix reports drift that has not happened, and a drift row is
+    /// offered for deletion with no direct Azure read behind it. The VNet-level check ten lines
+    /// above has always tested membership, which is why the same shape never bit there.
+    /// </summary>
+    [Fact]
+    public void SubnetWithSecondIpv4Prefix_StillOwningBastetsPrefix_NotFlagged()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"], AzSubnet("vnet-a", "snet-a", "10.0.0.0/24", "10.0.1.0/24"))),
+            Linked(1, "snet-a", "10.0.1.0", 24, SubnetId("vnet-a", "snet-a")));
+
+        Assert.Empty(plan.Items);
+    }
+
+    /// <summary>
+    /// The other direction, and the one that matters after E1: a genuine prefix change must still be
+    /// reported. A fix that merely stopped flagging multi-prefix subnets would pass the test above
+    /// and re-create the over-blocking E1 was about.
+    /// </summary>
+    [Fact]
+    public void SubnetWithSeveralPrefixes_NoneMatchingBastet_StillFlagged()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"], AzSubnet("vnet-a", "snet-a", "10.0.8.0/24", "10.0.9.0/24"))),
+            Linked(1, "snet-a", "10.0.1.0", 24, SubnetId("vnet-a", "snet-a")));
+
+        AzureReconcileItem item = Assert.Single(plan.Items);
+        Assert.Equal(AzureReconcileStatus.SubnetPrefixChanged, item.Status);
+
+        // Both live prefixes are named: telling the operator only the first would be the same
+        // half-truth that produced the defect.
+        Assert.Contains("10.0.8.0/24", item.Reason);
+        Assert.Contains("10.0.9.0/24", item.Reason);
+    }
+
     [Fact]
     public void SubnetLive_NotFlagged()
     {
@@ -226,6 +274,24 @@ public class AzureReconcilerTests
         // subnet gets no row of its own. Nothing has drifted here.
         AzureReconcilePlanViewModel plan = Build(
             Live(VNet("vnet-e", ["10.11.0.0/24"], AzSubnet("vnet-e", "default", "10.11.0.0/24"))),
+            Linked(1, "vnet-e", "10.11.0.0", 24, VNetId("vnet-e"), fullyAllocated: true));
+
+        Assert.Empty(plan.Items);
+        Assert.Empty(plan.ReviewItems);
+    }
+
+    /// <summary>
+    /// The same collapsed-prefix read one check earlier: the fully-allocated marker is justified by
+    /// an Azure subnet covering the target's whole prefix, and that search compared only each
+    /// subnet's first prefix. A covering subnet that lists another prefix first was reported as
+    /// having lost its cause. Review-only, so it can never delete anything - but it is the same
+    /// defect at its second site, and the prefix list is already to hand once the first is fixed.
+    /// </summary>
+    [Fact]
+    public void FullyEncompassedVNet_CoveringSubnetListsAnotherPrefixFirst_NotFlagged()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-e", ["10.11.0.0/24"], AzSubnet("vnet-e", "default", "10.99.0.0/24", "10.11.0.0/24"))),
             Linked(1, "vnet-e", "10.11.0.0", 24, VNetId("vnet-e"), fullyAllocated: true));
 
         Assert.Empty(plan.Items);

--- a/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
@@ -254,6 +254,74 @@ public class AzureReconcilerTests
     }
 
     /// <summary>
+    /// NotVisible and Unknown are both withheld, and that is correct - but they are different facts.
+    /// Sharing one sentence told the operator "the credential may have lost access" when the truth was
+    /// that the read failed, which sends them auditing role assignments on a healthy subscription.
+    /// Unknown needs no crafted input: an ARM throttle or a transport blip mid-scan produces it.
+    /// </summary>
+    [Fact]
+    public void UnknownVerdict_IsExplainedAsAFailedRead_NotALostCredential()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),
+            Linked(1, "gone", "10.9.0.0", 16, VNetId("vnet-gone")));
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [VNetId("vnet-gone")] = AzureResourceConfirmation.Unknown
+        });
+
+        Assert.Empty(plan.Items);
+        string warning = Assert.Single(plan.Warnings);
+        Assert.Contains("could not be asked", warning);
+        Assert.DoesNotContain("lost access", warning);
+    }
+
+    /// <summary>The 403 case keeps its own sentence, which is correct and actionable for it.</summary>
+    [Fact]
+    public void NotVisibleVerdict_StillNamesTheCredential()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),
+            Linked(1, "gone", "10.9.0.0", 16, VNetId("vnet-gone")));
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [VNetId("vnet-gone")] = AzureResourceConfirmation.NotVisible
+        });
+
+        Assert.Empty(plan.Items);
+        string warning = Assert.Single(plan.Warnings);
+        Assert.Contains("denied access", warning);
+        Assert.Contains("lost access to their resource group", warning);
+    }
+
+    /// <summary>
+    /// Two rows withheld for different reasons must produce two sentences, not one that is wrong about
+    /// half of them. This is the shape the audit measured live: a genuine 403 and an HTTP 400 named
+    /// together under the credential explanation.
+    /// </summary>
+    [Fact]
+    public void MixedWithholdReasons_ProduceSeparateWarnings()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),
+            Linked(1, "hidden", "10.9.0.0", 16, VNetId("vnet-hidden")),
+            Linked(2, "unreadable", "10.8.0.0", 16, VNetId("vnet-unreadable")));
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [VNetId("vnet-hidden")] = AzureResourceConfirmation.NotVisible,
+            [VNetId("vnet-unreadable")] = AzureResourceConfirmation.Unknown
+        });
+
+        Assert.Empty(plan.Items);
+        Assert.Equal(2, plan.Warnings.Count);
+        Assert.Contains(plan.Warnings, w => w.Contains("denied access") && w.Contains("hidden"));
+        Assert.Contains(plan.Warnings, w => w.Contains("could not be asked") && w.Contains("unreadable"));
+    }
+
+    /// <summary>
     /// A stored ID that names neither a VNet nor a subnet must never be answered as a deletion. The
     /// Azure SDK builds its request from (subscription, resource group, last path segment) and
     /// discards the provider namespace and type, so reading a resource-group or storage-account ID

--- a/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
@@ -253,6 +253,48 @@ public class AzureReconcilerTests
         Assert.Contains("10.0.9.0/24", item.Reason);
     }
 
+    /// <summary>
+    /// A stored ID that names neither a VNet nor a subnet must never be answered as a deletion. The
+    /// Azure SDK builds its request from (subscription, resource group, last path segment) and
+    /// discards the provider namespace and type, so reading a resource-group or storage-account ID
+    /// through the VNet accessor asks about a *different* resource - and its 404 used to read as
+    /// "Azure confirms this is gone", offering the row and its whole subtree for archival.
+    /// </summary>
+    [Theory]
+    [InlineData("/subscriptions/" + SubId + "/resourceGroups/rg")]
+    [InlineData("/subscriptions/" + SubId + "/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/acct")]
+    // Last segment deliberately matches a live VNet: this is the shape that answered "Live" against
+    // real ARM, because the SDK asks for virtualNetworks/<last segment> whatever the type says.
+    [InlineData("/subscriptions/" + SubId + "/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vnet-a")]
+    public void UnrecognisedResourceId_IsReviewedNotOfferedForDeletion(string resourceId)
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),
+            Linked(1, "mystery", "10.0.0.0", 16, resourceId));
+
+        Assert.Empty(plan.Items);
+
+        AzureReconcileItem item = Assert.Single(plan.ReviewItems);
+        Assert.Equal(AzureReconcileStatus.UnrecognisedResourceId, item.Status);
+        Assert.DoesNotContain("no longer exists", item.Reason);
+    }
+
+    /// <summary>
+    /// The guard: a real VNet ID that is genuinely absent from the listing must still be offered.
+    /// A fix that routed anything unfamiliar to review would stop the reconciler doing its job.
+    /// </summary>
+    [Fact]
+    public void GenuinelyAbsentVNet_StillOfferedForDeletion()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),
+            Linked(1, "gone", "10.9.0.0", 16, VNetId("vnet-gone")));
+
+        AzureReconcileItem item = Assert.Single(plan.Items);
+        Assert.Equal(AzureReconcileStatus.VNetDeleted, item.Status);
+        Assert.Empty(plan.ReviewItems);
+    }
+
     [Fact]
     public void SubnetLive_NotFlagged()
     {

--- a/test/Bastet.Tests/Security/SanitizingConsoleFormatterTests.cs
+++ b/test/Bastet.Tests/Security/SanitizingConsoleFormatterTests.cs
@@ -1,0 +1,88 @@
+using Bastet.Services.Security;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Bastet.Tests.Security;
+
+/// <summary>
+/// The console sink is where a forged log entry lands. LogSanitizer already protects values passed
+/// as template arguments, but an exception is written by the sink itself and never went through it,
+/// so a request-supplied value echoed back inside ex.Message reached the terminal intact.
+/// </summary>
+public class SanitizingConsoleFormatterTests
+{
+    private const char Esc = (char)0x1B;
+
+    private static string Format(string message, Exception? exception = null)
+    {
+        SanitizingConsoleFormatter formatter = new();
+        StringWriter writer = new();
+        LogEntry<string> entry = new(
+            LogLevel.Error, "Bastet.Services.Azure.AzureService", new EventId(0),
+            "state", exception, (_, _) => message);
+
+        formatter.Write(in entry, scopeProvider: null, writer);
+        return writer.ToString();
+    }
+
+    [Fact]
+    public void EscapeSequenceInTheMessage_IsStripped()
+    {
+        string output = Format($"subscription {Esc}[1A{Esc}[2Kwarn: forged entry");
+
+        Assert.DoesNotContain(Esc, output);
+        Assert.Contains("[1A[2Kwarn: forged entry", output); // the text survives, the control byte does not
+    }
+
+    /// <summary>
+    /// The defect itself: the template argument was sanitized, the exception was not, and the ARM
+    /// SDK's own validation echoes the caller's string into ex.Message verbatim.
+    /// </summary>
+    [Fact]
+    public void EscapeSequenceInTheException_IsStripped()
+    {
+        string output = Format(
+            "Failed to retrieve Azure VNets",
+            new FormatException($"The GUID for subscription is invalid 0{Esc}[2J{Esc}[Hwarn: Archived 42 subnets"));
+
+        Assert.DoesNotContain(Esc, output);
+        Assert.Contains("Archived 42 subnets", output);
+    }
+
+    /// <summary>
+    /// Sanitizing the exception as one string would collapse the stack trace onto a single line,
+    /// because a newline is a control character. Lines are split first and sanitized individually,
+    /// so genuine structure comes from the split and never from the content.
+    /// </summary>
+    [Fact]
+    public void MultiLineExceptionKeepsItsLines()
+    {
+        Exception inner = new InvalidOperationException("inner cause");
+        Exception outer;
+        try
+        {
+            throw new InvalidOperationException("outer", inner);
+        }
+        catch (InvalidOperationException caught)
+        {
+            outer = caught; // caught so it carries a real stack trace
+        }
+
+        string output = Format("something failed", outer);
+        string[] lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Contains(lines, l => l.Contains("outer"));
+        Assert.Contains(lines, l => l.Contains("inner cause"));
+        Assert.Contains(lines, l => l.Contains("at Bastet.Tests.Security"));
+        Assert.True(lines.Length >= 4, $"expected the stack trace to keep its lines, got {lines.Length}");
+    }
+
+    [Fact]
+    public void TabSurvives_AndTheHeaderNamesTheLevelAndCategory()
+    {
+        string output = Format("column\tseparated");
+
+        Assert.Contains("column\tseparated", output);
+        Assert.Contains("fail: Bastet.Services.Azure.AzureService[0]", output);
+    }
+}

--- a/test/Bastet.Tests/Security/TransactionCleanupTests.cs
+++ b/test/Bastet.Tests/Security/TransactionCleanupTests.cs
@@ -67,13 +67,8 @@ public class TransactionCleanupTests
         await TransactionCleanup.RollbackQuietlyAsync(transaction.Object, logger.Object);
 
         transaction.Verify(t => t.RollbackAsync(It.IsAny<CancellationToken>()), Times.Once);
-        logger.Verify(
-            l => l.Log(
-                It.IsAny<LogLevel>(),
-                It.IsAny<EventId>(),
-                It.IsAny<It.IsAnyType>(),
-                It.IsAny<Exception?>(),
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
-            Times.Never);
+
+        // Nothing is recorded on the way through - the logger is never touched at all.
+        logger.VerifyNoOtherCalls();
     }
 }

--- a/test/Bastet.Tests/SubnetManagement/SubnetControllerBatchCreateTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetControllerBatchCreateTests.cs
@@ -16,6 +16,7 @@ namespace Bastet.Tests.SubnetManagement;
 /// <summary>
 /// Integration tests for batch subnet creation functionality in the SubnetController
 /// </summary>
+[Collection(Bastet.Tests.Azure.AzureFeatureFlagCollection.Name)]
 public class SubnetControllerBatchCreateTests : IDisposable
 {
     private readonly BastetDbContext _context;
@@ -27,6 +28,10 @@ public class SubnetControllerBatchCreateTests : IDisposable
 
     public SubnetControllerBatchCreateTests()
     {
+        // These tests drive the Azure import path, which is now behind the feature flag the
+        // other eleven Azure write paths were always behind.
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "true");
+
         // Use SQLite in-memory database for tests
         DbContextOptions<BastetDbContext> options = new DbContextOptionsBuilder<BastetDbContext>()
             .UseSqlite("DataSource=:memory:")
@@ -69,6 +74,7 @@ public class SubnetControllerBatchCreateTests : IDisposable
 
     public void Dispose()
     {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", null);
         _context.Database.CloseConnection();
         _context.Dispose();
         GC.SuppressFinalize(this);
@@ -640,5 +646,82 @@ public class SubnetControllerBatchCreateTests : IDisposable
 
         _ = Assert.IsType<BadRequestObjectResult>(result);
         Assert.False(_controller.TempData.ContainsKey("ErrorMessage"));
+    }
+
+    /// <summary>
+    /// This was the one Azure write path with no feature-flag guard while its eleven siblings all had
+    /// one, so an Admin could stamp AzureResourceId in a deployment with Azure deliberately off - a
+    /// column no other write path exposes and no UI can clear. The Details page then renders a live
+    /// "View in Azure Portal" link from it, and the row arms itself if the flag is later enabled.
+    /// </summary>
+    [Fact]
+    public async Task BatchCreateChildSubnets_AzureImportWithFeatureDisabled_IsRefused()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "false");
+
+        List<AzureImportSubnetViewModel> subnets =
+        [
+            new() { Name = "web", NetworkAddress = "10.0.1.0", Cidr = 24, ParentSubnetId = 2 }
+        ];
+
+        IActionResult result = await _controller.BatchCreateChildSubnets(
+            2, subnets, vnetName: "prod-vnet",
+            vnetResourceId: "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/prod-vnet",
+            isAzureImport: true);
+
+        Assert.Empty(await _context.Subnets.Where(s => s.Name == "web").ToListAsync(TestContext.Current.CancellationToken));
+        Subnet? parent = await _context.Subnets.FindAsync([2], TestContext.Current.CancellationToken);
+        Assert.NotNull(parent);
+        Assert.Null(parent.AzureResourceId);
+        Assert.Equal("Parent Subnet", parent.Name);   // not renamed to the VNet name
+        _ = result;
+    }
+
+    /// <summary>
+    /// The gap the finding's own proposed fix would have left: the child stamp is behind no
+    /// isAzureImport test at all, so gating on that flag alone still let an Admin create Azure-linked
+    /// rows with the feature off. The guard is on the Azure state being written, not on the claim.
+    /// </summary>
+    [Fact]
+    public async Task BatchCreateChildSubnets_ChildAzureIdWithFeatureDisabled_IsRefused()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "false");
+
+        List<AzureImportSubnetViewModel> subnets =
+        [
+            new()
+            {
+                Name = "smuggled", NetworkAddress = "10.0.2.0", Cidr = 24, ParentSubnetId = 2,
+                AzureResourceId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/ghost/subnets/smuggled"
+            }
+        ];
+
+        // isAzureImport deliberately absent - this is the path the flag-only guard would have missed.
+        IActionResult result = await _controller.BatchCreateChildSubnets(2, subnets);
+
+        Assert.Empty(await _context.Subnets.Where(s => s.Name == "smuggled").ToListAsync(TestContext.Current.CancellationToken));
+        _ = result;
+    }
+
+    /// <summary>
+    /// The guard must not break the documented non-Azure use of this endpoint: a plain batch create,
+    /// carrying no Azure state, still works with the feature off.
+    /// </summary>
+    [Fact]
+    public async Task BatchCreateChildSubnets_PlainBatchWithFeatureDisabled_StillCreates()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "false");
+
+        List<AzureImportSubnetViewModel> subnets =
+        [
+            new() { Name = "local", NetworkAddress = "10.0.3.0", Cidr = 24, ParentSubnetId = 2 }
+        ];
+
+        IActionResult result = await _controller.BatchCreateChildSubnets(2, subnets);
+
+        Subnet? created = await _context.Subnets.FirstOrDefaultAsync(s => s.Name == "local", TestContext.Current.CancellationToken);
+        Assert.NotNull(created);
+        Assert.Null(created.AzureResourceId);
+        _ = result;
     }
 }

--- a/test/Bastet.Tests/SubnetManagement/SubnetControllerCidrEditTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetControllerCidrEditTests.cs
@@ -746,6 +746,154 @@ public class SubnetControllerCidrEditTests : IDisposable
         Assert.Contains("Description", _controller.ModelState.Keys);
     }
 
+    /// <summary>
+    /// An Azure-linked row records the prefix its resource had at link time, and the reconciler reads
+    /// any difference from Azure's current prefix as Azure-side drift. Editing the CIDR here breaks
+    /// that invariant silently and a later reconcile offers the row - and its whole subtree - for
+    /// archival while Azure is healthy, so the edit must be refused rather than validated.
+    /// </summary>
+    [Theory]
+    [InlineData(17)] // narrowing
+    [InlineData(15)] // widening
+    public async Task Edit_POST_CidrChangeOnAzureLinkedSubnet_IsRefusedAndWritesNothing(int newCidr)
+    {
+        _context.Subnets.Add(new Subnet
+        {
+            Id = 30,
+            Name = "azure-vnet",
+            NetworkAddress = "10.30.0.0",
+            Cidr = 16,
+            AzureResourceId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/azure-vnet",
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "test-admin"
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        EditSubnetViewModel viewModel = new()
+        {
+            Id = 30,
+            Name = "azure-vnet",
+            NetworkAddress = "10.30.0.0",
+            Cidr = newCidr,
+            OriginalCidr = 16
+        };
+
+        IActionResult result = await _controller.Edit(30, viewModel);
+
+        _ = Assert.IsType<ViewResult>(result);
+        Assert.False(_controller.ModelState.IsValid);
+        Assert.Contains("Cidr", _controller.ModelState.Keys);
+        Assert.Contains("Azure", _controller.ModelState["Cidr"]?.Errors.First().ErrorMessage ?? string.Empty);
+
+        Subnet? unchanged = await _context.Subnets.FindAsync([30], TestContext.Current.CancellationToken);
+        Assert.NotNull(unchanged);
+        Assert.Equal(16, unchanged.Cidr);
+    }
+
+    /// <summary>
+    /// The guard is on the CIDR only. Renaming, re-describing and re-tagging an imported subnet are
+    /// ordinary operations and must keep working, or the fix costs more than the defect.
+    /// </summary>
+    [Fact]
+    public async Task Edit_POST_NameChangeOnAzureLinkedSubnet_StillSucceeds()
+    {
+        _context.Subnets.Add(new Subnet
+        {
+            Id = 31,
+            Name = "azure-vnet",
+            NetworkAddress = "10.31.0.0",
+            Cidr = 16,
+            AzureResourceId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/azure-vnet",
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "test-admin"
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        EditSubnetViewModel viewModel = new()
+        {
+            Id = 31,
+            Name = "renamed locally",
+            NetworkAddress = "10.31.0.0",
+            Cidr = 16, // unchanged
+            OriginalCidr = 16,
+            Description = "still editable"
+        };
+
+        IActionResult result = await _controller.Edit(31, viewModel);
+
+        RedirectToActionResult redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Details", redirect.ActionName);
+
+        Subnet? updated = await _context.Subnets.FindAsync([31], TestContext.Current.CancellationToken);
+        Assert.NotNull(updated);
+        Assert.Equal("renamed locally", updated.Name);
+        Assert.Equal("still editable", updated.Description);
+        Assert.Equal(16, updated.Cidr);
+    }
+
+    /// <summary>
+    /// The other half of the guard: a subnet with no Azure link keeps its editable CIDR. Without this
+    /// a fix that simply froze every CIDR would pass the test above.
+    /// </summary>
+    [Fact]
+    public async Task Edit_POST_CidrChangeOnUnlinkedSubnet_StillSucceeds()
+    {
+        _context.Subnets.Add(new Subnet
+        {
+            Id = 32,
+            Name = "local only",
+            NetworkAddress = "10.32.0.0",
+            Cidr = 16,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "test-admin"
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        EditSubnetViewModel viewModel = new()
+        {
+            Id = 32,
+            Name = "local only",
+            NetworkAddress = "10.32.0.0",
+            Cidr = 17,
+            OriginalCidr = 16
+        };
+
+        IActionResult result = await _controller.Edit(32, viewModel);
+
+        RedirectToActionResult redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Details", redirect.ActionName);
+
+        Subnet? updated = await _context.Subnets.FindAsync([32], TestContext.Current.CancellationToken);
+        Assert.NotNull(updated);
+        Assert.Equal(17, updated.Cidr);
+    }
+
+    /// <summary>
+    /// The form must say so before the operator types, not only after they save. The flag is derived
+    /// from the database on render, never bound from the post.
+    /// </summary>
+    [Fact]
+    public async Task Edit_GET_AzureLinkedSubnet_MarksTheModelAsLinked()
+    {
+        _context.Subnets.Add(new Subnet
+        {
+            Id = 33,
+            Name = "azure-vnet",
+            NetworkAddress = "10.33.0.0",
+            Cidr = 16,
+            AzureResourceId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/azure-vnet",
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "test-admin"
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        ViewResult linked = Assert.IsType<ViewResult>(await _controller.Edit(33));
+        Assert.True(Assert.IsType<EditSubnetViewModel>(linked.Model).IsAzureLinked);
+
+        ViewResult unlinked = Assert.IsType<ViewResult>(await _controller.Edit(4));
+        Assert.False(Assert.IsType<EditSubnetViewModel>(unlinked.Model).IsAzureLinked);
+    }
+
     [Fact]
     public async Task Edit_POST_NonExistentSubnet_RedirectsToNotFoundError()
     {

--- a/test/Bastet.Tests/SubnetManagement/SubnetControllerConcurrencyRedisplayTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetControllerConcurrencyRedisplayTests.cs
@@ -1,0 +1,108 @@
+using Bastet.Controllers;
+using Bastet.Data;
+using Bastet.Models;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Validation;
+using Bastet.Tests.TestHelpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Bastet.Tests.SubnetManagement;
+
+/// <summary>
+/// Pins the value the Edit form redisplays after losing an optimistic-concurrency race: it must be
+/// the value actually in the database, not the wall clock at the moment of the failed save. Both
+/// AsNoTracking() calls are load-bearing, and the fall-through repopulation is the one that reaches
+/// the view.
+///
+/// Round 5 recorded that this could not be tested under the suite's provider, because
+/// [Timestamp] byte[] RowVersion is only store-generated on SQL Server. The premise is true and the
+/// inference is not: the Edit POST supplies the original token itself
+/// (SubnetController.Edit.cs - context.Entry(subnet).OriginalValues["RowVersion"] = viewModel.RowVersion),
+/// so the comparison is an ordinary WHERE clause SQLite evaluates fine.
+///
+/// One provider caveat to keep in mind before extending this: under SQLite the stored token is NULL,
+/// so *any* non-null posted RowVersion conflicts. That reaches the handler faithfully but does not
+/// reproduce production's value-versus-value comparison - do not read a pass here as proof of the
+/// SQL Server path.
+/// </summary>
+public class SubnetControllerConcurrencyRedisplayTests : IDisposable
+{
+    private readonly BastetDbContext _context;
+    private readonly SubnetController _controller;
+
+    public SubnetControllerConcurrencyRedisplayTests()
+    {
+        _context = TestDbContextFactory.CreateDbContext();
+        IIpUtilityService ip = new IpUtilityService();
+        _controller = new SubnetController(
+            _context, ip, new SubnetValidationService(ip),
+            new HostIpValidationService(ip, _context),
+            ControllerTestHelper.CreateMockUserContextService(),
+            ControllerTestHelper.CreateMockSubnetLockingService(),
+            NullLogger<SubnetController>.Instance);
+        ControllerTestHelper.SetupController(_controller);
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static readonly DateTime OtherUsersSave = new(2026, 01, 02, 10, 05, 00, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Edit_POST_ConcurrencyConflict_ShowsTheSavedLastModified_NotTheFailedAttempts()
+    {
+        // Arrange: a subnet whose stored RowVersion is a known blob, so a posted token that does not
+        // match it makes the UPDATE match zero rows.
+        _context.Subnets.Add(new Subnet
+        {
+            Id = 50,
+            Name = "web",
+            NetworkAddress = "10.50.0.0",
+            Cidr = 24,
+            CreatedAt = new DateTime(2026, 01, 01, 00, 00, 00, DateTimeKind.Utc),
+            CreatedBy = "test-admin",
+            LastModifiedAt = OtherUsersSave,
+            ModifiedBy = "userB"
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // What did SQLite actually store for the concurrency token?
+        byte[]? stored = await _context.Subnets.AsNoTracking()
+            .Where(s => s.Id == 50).Select(s => s.RowVersion)
+            .FirstAsync(TestContext.Current.CancellationToken);
+        File.AppendAllText("/tmp/claude-1000/-home-anuj-code-Bastet/929bd7e2-c2c2-42a4-b6dd-e0e98161c7e0/scratchpad/p2-beat7/e6probe.log", "\n" + ($"stored RowVersion = {(stored is null ? "NULL" : Convert.ToHexString(stored))}"));
+        File.AppendAllText("/tmp/claude-1000/-home-anuj-code-Bastet/929bd7e2-c2c2-42a4-b6dd-e0e98161c7e0/scratchpad/p2-beat7/e6probe.log", "\n" + ($"stored LastModifiedAt = {OtherUsersSave:HH:mm}"));
+        _context.ChangeTracker.Clear();
+
+        // Act: the operator posts an edit carrying a stale/foreign concurrency token.
+        EditSubnetViewModel viewModel = new()
+        {
+            Id = 50,
+            Name = "webA",
+            NetworkAddress = "10.50.0.0",
+            Cidr = 24,
+            OriginalCidr = 24,
+            RowVersion = [9, 9, 9, 9, 9, 9, 9, 9]
+        };
+
+        IActionResult result = await _controller.Edit(50, viewModel);
+
+        // The concurrency handler must have been the one that ran.
+        ViewResult view = Assert.IsType<ViewResult>(result);
+        EditSubnetViewModel shown = Assert.IsType<EditSubnetViewModel>(view.Model);
+        File.AppendAllText("/tmp/claude-1000/-home-anuj-code-Bastet/929bd7e2-c2c2-42a4-b6dd-e0e98161c7e0/scratchpad/p2-beat7/e6probe.log", "\n" + ($"ModelState errors: {string.Join(" | ", _controller.ModelState.Values.SelectMany(v => v.Errors).Select(e => e.ErrorMessage))}"));
+        File.AppendAllText("/tmp/claude-1000/-home-anuj-code-Bastet/929bd7e2-c2c2-42a4-b6dd-e0e98161c7e0/scratchpad/p2-beat7/e6probe.log", "\n" + ($"shown LastModifiedAt = {shown.LastModifiedAt:HH:mm:ss}"));
+        Assert.Contains(_controller.ModelState.Values.SelectMany(v => v.Errors),
+            e => e.ErrorMessage.Contains("modified by another user"));
+
+        // The screen must show the value that is actually in the database.
+        Assert.Equal(OtherUsersSave, shown.LastModifiedAt);
+    }
+}

--- a/test/Bastet.Tests/SubnetManagement/SubnetControllerConcurrencyRedisplayTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetControllerConcurrencyRedisplayTests.cs
@@ -73,12 +73,13 @@ public class SubnetControllerConcurrencyRedisplayTests : IDisposable
         });
         await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        // What did SQLite actually store for the concurrency token?
+        // The provider caveat above, made executable: SQLite stores no token, so the posted one
+        // below conflicts by being non-null rather than by differing in value.
         byte[]? stored = await _context.Subnets.AsNoTracking()
             .Where(s => s.Id == 50).Select(s => s.RowVersion)
             .FirstAsync(TestContext.Current.CancellationToken);
-        File.AppendAllText("/tmp/claude-1000/-home-anuj-code-Bastet/929bd7e2-c2c2-42a4-b6dd-e0e98161c7e0/scratchpad/p2-beat7/e6probe.log", "\n" + ($"stored RowVersion = {(stored is null ? "NULL" : Convert.ToHexString(stored))}"));
-        File.AppendAllText("/tmp/claude-1000/-home-anuj-code-Bastet/929bd7e2-c2c2-42a4-b6dd-e0e98161c7e0/scratchpad/p2-beat7/e6probe.log", "\n" + ($"stored LastModifiedAt = {OtherUsersSave:HH:mm}"));
+        Assert.Null(stored);
+
         _context.ChangeTracker.Clear();
 
         // Act: the operator posts an edit carrying a stale/foreign concurrency token.
@@ -97,8 +98,6 @@ public class SubnetControllerConcurrencyRedisplayTests : IDisposable
         // The concurrency handler must have been the one that ran.
         ViewResult view = Assert.IsType<ViewResult>(result);
         EditSubnetViewModel shown = Assert.IsType<EditSubnetViewModel>(view.Model);
-        File.AppendAllText("/tmp/claude-1000/-home-anuj-code-Bastet/929bd7e2-c2c2-42a4-b6dd-e0e98161c7e0/scratchpad/p2-beat7/e6probe.log", "\n" + ($"ModelState errors: {string.Join(" | ", _controller.ModelState.Values.SelectMany(v => v.Errors).Select(e => e.ErrorMessage))}"));
-        File.AppendAllText("/tmp/claude-1000/-home-anuj-code-Bastet/929bd7e2-c2c2-42a4-b6dd-e0e98161c7e0/scratchpad/p2-beat7/e6probe.log", "\n" + ($"shown LastModifiedAt = {shown.LastModifiedAt:HH:mm:ss}"));
         Assert.Contains(_controller.ModelState.Values.SelectMany(v => v.Errors),
             e => e.ErrorMessage.Contains("modified by another user"));
 

--- a/test/Bastet.Tests/SubnetManagement/SubnetControllerFullyEncompassingTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetControllerFullyEncompassingTests.cs
@@ -15,6 +15,7 @@ namespace Bastet.Tests.SubnetManagement;
 /// <summary>
 /// Tests for the behavior of subnets that fully encompass a VNet's address prefix
 /// </summary>
+[Collection(Bastet.Tests.Azure.AzureFeatureFlagCollection.Name)]
 public class SubnetControllerFullyEncompassingTests : IDisposable
 {
     private readonly BastetDbContext _context;
@@ -26,6 +27,10 @@ public class SubnetControllerFullyEncompassingTests : IDisposable
 
     public SubnetControllerFullyEncompassingTests()
     {
+        // These tests drive the Azure import path, which is now behind the feature flag the
+        // other eleven Azure write paths were always behind.
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "true");
+
         // Use SQLite in-memory database for tests
         DbContextOptions<BastetDbContext> options = new DbContextOptionsBuilder<BastetDbContext>()
             .UseSqlite("DataSource=:memory:")
@@ -68,6 +73,7 @@ public class SubnetControllerFullyEncompassingTests : IDisposable
 
     public void Dispose()
     {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", null);
         _context.Database.CloseConnection();
         _context.Dispose();
         GC.SuppressFinalize(this);

--- a/test/Bastet.Tests/SubnetManagement/SubnetCreateGetPrefillTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetCreateGetPrefillTests.cs
@@ -2,14 +2,14 @@ using Bastet.Controllers;
 using Bastet.Data;
 using Bastet.Models;
 using Bastet.Models.ViewModels;
-using Bastet.Services.Security;
-using System.ComponentModel.DataAnnotations;
 using Bastet.Services;
+using Bastet.Services.Security;
 using Bastet.Services.Validation;
 using Bastet.Tests.TestHelpers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.ComponentModel.DataAnnotations;
 
 namespace Bastet.Tests.SubnetManagement;
 

--- a/test/Bastet.Tests/SubnetManagement/SubnetCreateGetPrefillTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetCreateGetPrefillTests.cs
@@ -2,6 +2,8 @@ using Bastet.Controllers;
 using Bastet.Data;
 using Bastet.Models;
 using Bastet.Models.ViewModels;
+using Bastet.Services.Security;
+using System.ComponentModel.DataAnnotations;
 using Bastet.Services;
 using Bastet.Services.Validation;
 using Bastet.Tests.TestHelpers;
@@ -108,12 +110,44 @@ public class SubnetCreateGetPrefillTests : IDisposable
         Assert.NotEmpty(model.CalculatedSubnetMask);
     }
 
+    /// <summary>
+    /// The name the app fills in must survive the validation the very next POST applies to it.
+    /// [SafeText] forbids "/", so the slashed form was rejected with "Subnet name contains invalid
+    /// characters" on every create-from-unallocated-range flow that accepted the default - against
+    /// the one field the operator had not typed.
+    /// </summary>
+    [Theory]
+    [InlineData("10.0.1.0", 24, 1)]
+    [InlineData("10.0.9.9", 32, 1)]
+    public async Task Create_PrefilledName_PassesTheValidationThePostApplies(
+        string networkAddress, int cidr, int parentId)
+    {
+        IActionResult result = await _controller.Create(networkAddress, cidr, parentId);
+        string name = ModelOf(result).Name;
+
+        SafeTextAttribute rule = new();
+        ValidationContext context = new(new object(), new SafeTextServiceProvider(), null);
+
+        Assert.True(
+            rule.GetValidationResult(name, context) == System.ComponentModel.DataAnnotations.ValidationResult.Success,
+            $"the prefilled name '{name}' is refused by the rule its own POST applies");
+    }
+
+    /// <summary>SafeTextAttribute resolves the sanitization service from the validation context.</summary>
+    private sealed class SafeTextServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) =>
+            serviceType == typeof(IInputSanitizationService) ? new InputSanitizationService() : null;
+    }
+
     [Fact]
     public async Task Create_ValidCidrWithParent_ComposesTheDefaultName()
     {
         IActionResult result = await _controller.Create(networkAddress: "10.0.1.0", cidr: 24, parentId: 1);
 
-        Assert.Equal("Parent-10.0.1.0/24", ModelOf(result).Name);
+        // Separator, not a slash: [SafeText] on Name forbids "/", so the slashed form this used to
+        // produce was refused by the very next POST.
+        Assert.Equal("Parent-10.0.1.0-24", ModelOf(result).Name);
     }
 
     /// <summary>
@@ -139,6 +173,6 @@ public class SubnetCreateGetPrefillTests : IDisposable
 
         string name = ModelOf(result).Name;
         Assert.True(name.Length <= 100, $"generated name was {name.Length} characters");
-        Assert.EndsWith("-10.5.1.0/24", name);   // the suffix survives intact
+        Assert.EndsWith("-10.5.1.0-24", name);   // the suffix survives intact
     }
 }


### PR DESCRIPTION
### Improvements
- **Reconcile now explains itself before you confirm** — the review and confirmation screens say subnets "no longer match Azure" rather than claiming they no longer exist, and each row's reason is repeated on the last screen before anything is archived
- A subnet imported from Azure now has its **prefix locked on the Edit form**, because changing it locally made Reconcile report the subnet as gone from Azure
- **Azure could not be asked** is now reported separately from **the credential lost access** — a throttled or failed read no longer sends you auditing role assignments on a healthy subscription
- Log output is **stripped of control characters at the sink**, exceptions included, so a crafted identifier can no longer forge or erase log lines (set nothing — this is on by default in every environment)
- `BASTET_AUTO_MIGRATE=true` can now **create the database** it migrates, and says which catalog it could not reach when it cannot
- **Batch create refuses to write Azure state** when `BASTET_AZURE_IMPORT` is off (a caller using it as a plain batch-create API may no longer send `AzureResourceId` or `vnetResourceId` while the feature is disabled)
- The bulk import wizard now says **how many VNet prefixes are hidden** and how to see why, instead of claiming everything was already imported
- Failed bulk-import commits now **name the reason** rather than showing an empty red panel

### Bug Fixes
- Invalid values could be **submitted on every form** — jQuery 4 removed a function the validation library still calls, so client-side validation threw and the form posted anyway with the browser's own checks already switched off
- Reconcile could offer a **live Azure subnet for deletion** when the subnet owns more than one IPv4 prefix and the one Bastet recorded was not listed first
- A stored Azure resource ID that named **something other than a VNet or subnet** was answered by reading a different resource, and its 404 read as "Azure confirms this is gone"; such rows are now reported for review
- Creating a subnet from an unallocated range was **rejected on its first save**, because the name the form filled in contained a `/` that the name rules forbid
- A `/32` subnet offered a **Create Subnet button that could never succeed**, with the modal showing a valid range of "33 - 32"
- Both bulk endpoints returned an **HTML 500 instead of a JSON error** when a selection list arrived as `null`
- On a `0.0.0.0/0` subnet the Create-Subnet modal could **suggest an address from a different part of the address space** and let you submit it
- The modal let you type over the **suggested network address** while still claiming it had been adjusted to avoid overlaps, skipping the overlap check entirely
- Bulk import could persist a subnet **with no name at all** when the Azure VNet name was stripped to nothing
