### PR TITLE
Audit 8 Cleanup

### DIFF
--- a/docs/AUDIT-FINDINGS-8.md
+++ b/docs/AUDIT-FINDINGS-8.md
@@ -103,113 +103,52 @@ None.
 
 ## H1 [x2] — Azure reconcile archives descendants the same scan proved live, or explicitly withheld from deletion
 
-**Citation.** `src/Bastet/Controllers/SubnetController.AzureReconcile.cs:144` — the unconstrained
-subtree archive. Co-site: `src/Bastet/Services/Azure/AzureReconciler.cs:145-213`
-(`ApplyConfirmations` withholds rows from deletion without making the withholding transitive).
+_H1 is fixed and committed. `AzureReconciler` now withholds any target whose subtree contains a
+subnet the same scan says must not be destroyed, in **both** places that knowledge exists and nowhere
+else. In `BuildPlan`, every linked row that evaluated to live — the ones that become neither an item
+nor a review item, and so are invisible downstream — is collected into a `liveLinked` set, and any
+item whose `DescendantSubnetIds` meets it is dropped with a warning naming it. In
+`ApplyConfirmations`, the same is done for `notVisible ∪ unknown ∪ stillLive ∪ plan.ReviewItems`.
+`ReviewItems` is in that set for the reason the finding gives: the confirmation loop walks
+`plan.Items` only, so a `FullyAllocatingSubnetDeleted` descendant — which ordinary imports produce —
+appears in none of the lists built there._
 
-**Confidence.** Confirmed.
+_The two removals are one private helper, `WithholdTargetsWhoseCascadeIsBlocked`, rather than the two
+inline copies the finding sketched. They differ only in which ids are protected and in the clause
+explaining why, so a single implementation is what stops the live-descendant guard and the withheld
+guard drifting apart — the same failure mode that produced this finding, where `ApplyConfirmations`
+knew about withholding and the cascade did not._
 
-**Scenario.** Two ordinary bulk imports nest `rig-verc1-inner` (10.78.128.0/17) under
-`rig-verc1-outer` (10.78.0.0/16), each linked to its own live Azure VNet, with
-`rig-snet-verc1-inner-a` (10.78.130.0/24) beneath. Only `rig-verc1-outer` is deleted in Azure.
-
-`POST /Azure/ReconcileScan` returns exactly one item — `subnetId 1`, `VNetDeleted`,
-`descendantSubnetIds [2,3]` — and **`warnings: []`**, because the scan read rows 2 and 3 from the
-same subscription listing and found them **live**. The very next request,
-`POST /Subnet/BulkDeleteStaleAzureSubnets {"subnetIds":[1],"confirmation":"approved"}`, answers
-`{"success":true,"targetsDeleted":1,"subnetsArchived":3,"hostIpsArchived":0}` — all three rows
-archived, including the two whose Azure resources are still `Succeeded`.
-
-The gate at `:77-92` is keyed on `request.SubnetIds` only. No descendant is ever compared against
-`plan.Items`, `plan.ReviewItems`, or the per-resource confirmation verdicts.
-
-The RBAC variant is sharper. With rows 5 and 6 linked into a resource group the current credential
-cannot see, the scan's own body says:
-
-> *"2 Azure-linked subnet(s) were missing from the subscription listing, and Azure denied access when
-> asked about them directly … **They have been withheld from deletion**: 'rig-verc1-hidden',
-> 'rig-snet-verc1-hidden-a'."*
-
-and the next request archives exactly those two rows plus a host IP. `DeletedSubnets` has no
-`AzureResourceId` column (`Models/DeletedSubnet.cs:11-43`) and there is no restore path anywhere in
-the app, so the Azure link is destroyed unrecoverably. In the RBAC variant the operator cannot even
-re-import: the credential that would have to do it is the one ARM refuses.
-
-**Reproduction.** Live rig, port 5400, catalog `bastet_audit_200`, real ARM, SP_A and SP_B, fixtures
-created through the shipped wizards (no hand-seeded rows).
+_Verified at both levels. Six tests were written first and five of them failed against the unfixed
+code with `Collection was not empty` — the target surviving in `plan.Items` — covering the live
+descendant, all three withholding verdicts (`NotVisible`, `Unknown`, `Live`) and a review-item
+descendant. The sixth is the control that must **not** move: a VNet deleted together with its own
+imported children stays committable, and it passed before and after. Then end to end on the live rig,
+real ARM and SQL Server 2022, driving the shipped endpoints: `rig-h1-inner` (10.78.128.0/17, live,
+carrying `rig-h1-inner-a`) nested under `rig-h1-outer` (10.78.0.0/16) by two ordinary bulk imports,
+then only the outer VNet deleted in Azure._
 
 ```
-POST /Azure/ReconcileScan  subscriptionId=f0e8d6db-e9c4-4215-81a5-17762ea56be8
-scanSucceeded True  canCommit True
-items: [{subnetId:1, name:'rig-verc1-outer', statusName:'VNetDeleted',
-         descendantCount:2, hostIpCount:0, descendantSubnetIds:[2,3]}]
-reviewItems: []
-warnings:    []          <-- EMPTY: the scan read 2 and 3 and found them live
-
-POST /Subnet/BulkDeleteStaleAzureSubnets {"subnetIds":[1],"confirmation":"approved"}
-{"success":true,"redirectUrl":"/Subnet","targetsDeleted":1,"subnetsArchived":3,"hostIpsArchived":0}
-
-Subnets        -> (no rows)
-DeletedSubnets -> 1|rig-verc1-outer  2|rig-verc1-inner  3|rig-snet-verc1-inner-a
-az network vnet subnet list --vnet-name rig-verc1-inner
-               -> rig-snet-verc1-inner-a  10.78.130.0/24  Succeeded    <-- still live
+                       unfixed (ff285cf)                       fixed
+scan                   canCommit True, warnings []             canCommit False, warning names 'rig-h1-outer'
+approve subnetIds:[1]  200 {"subnetsArchived":2}               409 "no longer reported as deleted in Azure"
+Subnets after          (no rows)                               1 rig-h1-outer, 2 rig-h1-inner
+DeletedSubnets after   2                                       0
+rig-h1-inner-a in ARM  10.78.130.0/24 Succeeded                10.78.130.0/24 Succeeded
 ```
 
-Also driven end to end in real Chromium through the shipped three-step wizard (zero page errors, zero
-console errors). Step 3, the last screen before the archive, reads verbatim: *"You are about to
-delete 1 subnet(s) that no longer match Azure… This also archives 2 child subnet(s) and 0 host IP
-assignment(s) that live beneath them."* Both review screens state the cascade and its **count**; what
-neither ever says is that the collateral is linked to Azure resources this same scan verified are
-still live, or explicitly withheld. Step 2's banner actively misleads on the point, framing the
-collateral as *"including any you created by hand"*. `_StepConfirm.cshtml` has **no warnings block at
-all** — `#rec-scan-warnings` exists only in `_StepReview.cshtml:23` — so in the RBAC variant the
-withheld sentence never reaches the screen that performs the archive.
+_The finding's step 3 — that nothing further is needed server-side, because the existing
+`noLongerStale` gate answers 409 and already carries `plan.Warnings` — is correct and was confirmed
+rather than assumed: the 409 body above carries the withholding sentence verbatim, so the operator is
+told why without any new plumbing._
 
-This is **not** the accepted C20 window. In both reproductions the archived subtree matched
-`stillStale[id].DescendantSubnetIds` **exactly**, so the closure C20 documents at `:109-110` would not
-catch either case. Everything here is deterministic, single-request, single-threaded.
+_Two things in the finding were deliberately **not** done, both out of scope for the defect.
+Interim **(C)**, the display-only descendant count, is moot now that a blocked target is never offered:
+there is nothing to warn about on a screen that cannot be reached. Adding a warnings block to
+`_StepConfirm.cshtml` is a real gap and stays on the watch list, but it is a separate change to a view
+this fix does not touch, and with the cascade guard in place no withheld row can reach that screen._
 
-**Fix.** *The finder's fix was corrected as incomplete: its part 2 was placed in a method with no
-access to `linkedSubnets`, and its cheap interim missed `plan.ReviewItems` entirely.*
-
-In `AzureReconciler`, so it stays pure and testable:
-
-1. In `ApplyConfirmations`, after `plan.Items = keep` (`:187`), build
-   `HashSet<int> blocked = [.. notVisible.Concat(unknown).Concat(stillLive).Select(i => i.SubnetId),
-   .. plan.ReviewItems.Select(i => i.SubnetId)]`, then
-   `plan.Items.RemoveAll(i => i.DescendantSubnetIds.Any(blocked.Contains))`, naming the removed
-   targets in a new warning. **`plan.ReviewItems` must be in that set**: `ApplyConfirmations` iterates
-   `plan.Items` only (`:145`) and never reads `ReviewItems`, so an `UnrecognisedResourceId` or
-   `FullyAllocatingSubnetDeleted` descendant is in no set built there — and
-   `FullyAllocatingSubnetDeleted` is produced by ordinary imports (`AzureReconciler.cs:261-267`).
-2. In `BuildPlan`, collect into `HashSet<int> liveLinked` the ids of `linkedSubnets` entries that
-   evaluated to `null` — verified live in Azure — at `:99-102`, and after the loop remove from
-   `plan.Items` any item whose `DescendantSubnetIds` intersects it, with its own warning naming those
-   descendants. This is the half that closes the no-RBAC variant, the likeliest in the field.
-   `BuildPlan` is the right home: both callers hold `linked` (`AzureController.cs:342`,
-   `SubnetController.AzureReconcile.cs:56`).
-3. Nothing further is needed server-side: with (1) and (2) in place the existing `noLongerStale` gate
-   at `:78-92` already answers **409** for a dropped target and already carries `plan.Warnings`
-   (`:90`), so the operator gets the real reason for free.
-
-This does not over-withhold the ordinary case: when a VNet is deleted its own imported subnets vanish
-with it, confirm as `Deleted`, and land in `keep`. Dropping items degrades safely — `CanCommit` is
-`ScanSucceeded && GlobalErrors.Count == 0 && Items.Count > 0`
-(`AzureReconcileViewModels.cs:192`) and the wizard's `nothingToReport` check
-(`_ReconcileScripts.cshtml:258`) already handles warnings-without-items.
-`AzureReconcileItem.DescendantSubnetIds` is the **full transitive** descendant set
-(`AzureSubnetSnapshotService.GetDescendants`, BFS with a visited set), and
-`BulkDeleteStaleAzureSubnets` rebuilds the plan server-side at `:57`, so the guard runs on fresh data.
-
-**Cheaper interims, ranked by harm removed per line.**
-**(A)** step 1 alone — about five lines, closes the withheld and review-item variants.
-**(B)** step 2 alone — about ten lines, closes the live-descendant variant.
-**(C)** display-only, closes nothing but ends the surprise: have `BuildPlan` count, per item, the
-descendants that are Azure-linked and became neither an item nor a review item, carry it on
-`AzureReconcileItem`, and render it in `cascadeNote()` (`_ReconcileScripts.cshtml:194-203`) **and** in
-the step-3 confirm list (`:352`) — *"also archives 2 subnet(s) still linked to live Azure resources"*.
-Worth doing regardless: `_StepConfirm.cshtml` should repeat `plan.warnings`, because today the
-withheld sentence never reaches the screen that archives.
+_Test count 677 → 683 (+6). `dotnet build --no-incremental` 0 warnings, 0 errors._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-8.md
+++ b/docs/AUDIT-FINDINGS-8.md
@@ -308,145 +308,60 @@ _Test count 683 → 690 (+7). `dotnet build --no-incremental` 0 warnings, 0 erro
 
 ## H5 [x1] — Migration bootstrap misreads SQL 4060: a database that exists but cannot be opened is treated as missing, so startup aborts with two successively wrong diagnostics
 
-**Citation.** `src/Bastet/Program.cs:305` (block `:305-326`); the consequence lands at `:371`
-(`dbContext.Database.Migrate()`).
+_H5 is fixed and committed. After the `master` bootstrap connection opens, `Program.cs` now probes
+`SELECT HAS_DBACCESS(@catalog)` on it, and when the answer is **0** — the catalog exists but cannot be
+opened — it disposes the connection and aborts startup with a message that names the database, both
+possible causes, and what not to do. `NULL` (genuinely absent) and `1` (healthy) keep today's
+behaviour, and a probe that cannot run at all is swallowed so the fix fails open rather than refusing
+to start._
 
-**Confidence.** Confirmed. The one step the finder inferred — that the `:305` branch is what puts the
-lock connection on `master` — was measured directly, twice and by two different methods.
+_It aborts rather than logging, which the finding is right to call a constraint: EF Core's
+`SqlServerDatabaseCreator.Exists()` misreads 4060 identically, so anything that merely warns is
+overruled by `Migrate()` a few lines later. The message names **both** causes because `HAS_DBACCESS`
+is also 0 for an offline database, even for `sa` — wording that asserted "this login has no user
+inside it" would be confidently wrong in exactly the case measured as run D below._
 
-**Scenario.** SQL Server raises error 4060 with **byte-identical text** for three different
-conditions: the catalog does not exist, the login has no user inside an existing catalog, and the
-catalog is offline. `Program.cs:305` treats 4060 as the bootstrap path unconditionally, contradicting
-its own comment at `:307-309` (*"the catalog is not there yet, so this is the bootstrap path"*).
+_**The finder's `SELECT DB_ID(@catalog)` probe was rejected, as the verifiers found.** It answers only
+because `VIEW ANY DATABASE` is granted to `public` by default; deny that — ordinary hardening — and it
+returns NULL for a database that plainly exists, so the fix silently no-ops and both wrong messages
+come back. That is run C below, and it is why `HAS_DBACCESS` is used instead. `DB_ID` also returns
+`smallint`, so the natural `is int` test never matches._
 
-With `BASTET_AUTO_MIGRATE=true`, the lock connection falls back to `master` — which **always succeeds
-on a stock SQL Server**, because `guest` holds `CONNECT` there — so the crafted
-`InvalidOperationException` at `:319-324` never fires, and `Migrate()` at `:371` issues
-`CREATE DATABASE [<catalog>]` against a database that already holds the operator's data. Startup
-aborts (exit 134) with `SqlException 262 "CREATE DATABASE permission denied in database 'master'"`.
-Acting on that message's own advice (`ALTER SERVER ROLE dbcreator ADD MEMBER`) produces
-`SqlException 1801 "Database '<catalog>' already exists. Choose a different database name."` — whose
-literal advice would abandon the production catalog. Neither message names the cause. The **same
-deployment with `BASTET_AUTO_MIGRATE=false` reports it accurately**, which is what makes this
-Bastet's wrong output rather than SQL Server's.
-
-**Reproduction.** Rig SQL Server 2022, unmodified shipped binary (byte-copy of the reference publish),
-`ASPNETCORE_ENVIRONMENT=Production`. Reached from three independent starting states:
-
-*Run A — orphaned database user after a restore or failover*, on a deployment that was serving
-`10.44.0.0/16` a minute earlier (README "Database Setup" done correctly, then the login recreated
-without `WITH SID`, which is `sp_change_users_login`'s entire reason to exist):
+_Verified on the rig SQL Server 2022 against the shipped binary in `ASPNETCORE_ENVIRONMENT=Production`,
+from six starting states, on both builds. The deployment was first migrated and given a row of real
+data, then its database user was orphaned the way `sp_change_users_login` exists to repair — the login
+dropped and recreated without `WITH SID`._
 
 ```
-PROCESS EXITED rc=134 after 11.06s
-fail: Microsoft.EntityFrameworkCore.Database.Command[20102]
-      CREATE DATABASE [bastet_audit_606];
-Unhandled exception. Microsoft.Data.SqlClient.SqlException: CREATE DATABASE permission denied in database 'master'.
-   at Program.<Main>$(String[] args) in /home/anuj/code/Bastet/src/Bastet/Program.cs:line 371
-Error Number:262,State:1,Class:14
+                                          unfixed (ff285cf)                fixed
+A orphaned user, auto-migrate on          CREATE DATABASE [bastet_h5];     no CREATE DATABASE
+                                          Error Number:262 "CREATE         Error Number:4060
+                                          DATABASE permission denied       "The configured database
+                                          in database 'master'."           'bastet_h5' exists on this
+                                                                           server but could not be opened"
+B same deployment, auto-migrate off       starts, accurate 4060 message    unchanged
+C DENY VIEW ANY DATABASE TO public        Error Number:262, as above       same correct message
+  (where the rejected DB_ID probe blinds)                                  (this is the case DB_ID fails)
+D database OFFLINE, connecting as sa      Error Number:1801 "Database      same correct message
+                                          'bastet_h5' already exists."
+E genuine bootstrap, catalog absent, sa   starts                           starts; database created,
+                                                                           6 tables - no over-fire
+F orphaned user repaired, nothing else    starts                           starts
+damage sweep                              Bastet tables in master 0, Subnets rows 1, migrations 6
 ```
 
-Not one line names the login, the user, or the fact that the database exists and holds the operator's
-subnets. *Run B* — follow that advice: `Error Number:1801 … Database 'bastet_audit_606' already
-exists.` *Run C — nothing misconfigured at all*, login `sa`, database `SET OFFLINE` for a maintenance
-window: same 4060 at login, same `CREATE DATABASE`, same 1801.
+_Runs B, E and F are identical on both builds, which is the point: the probe fires on exactly the
+condition it names and on nothing else. (`GET /Subnet` answers 500 in every started run on both
+builds — this rig runs Production with no OIDC authority configured. Pre-existing and environmental,
+not a regression; the signal in this table is started-versus-aborted.)_
 
-*Counterfactual*: identical broken deployment with `BASTET_AUTO_MIGRATE=false` →
-`GET /Subnet` 500 with the **accurate** message *"Cannot open database … Login failed for user
-'bastet_c7r_app'."* *Control*: `ALTER USER [bastet_c7r_app] WITH LOGIN = [bastet_c7r_app];` and
-nothing else → *"Application started"*, `GET /Subnet` 200. The only fault was the missing database
-user, which is exactly what neither message named.
+_Test count unchanged at 690. `Program.cs` is top-level startup code with no seam the suite can
+reach — the six-state rig above is the verification, and the watch list already records that this
+repo has no integration host. `dotnet build --no-incremental` 0 warnings, 0 errors._
 
-*Direct proof the `:305` branch fires* — 30 ms DMV sampling during Run A:
-
-```
-APPLOCK 52  master  0:[Bastet:Migration]:(4afee137) X GRANT
-SESSION 52  master  login=bastet_c7r_app  prog=Core Microsoft SqlClient Data Provider
-```
-
-`Configured()` returns the connection string verbatim, so the only path that yields a `master` lock
-connection is `:305 -> :312`. Corroborated by an external hold on `sp_getapplock 'Bastet:Migration'`:
-startup took 11.13 s unblocked, **27.83 s** with the lock held **in master**, and 11.14 s with the
-same resource held in another catalog.
-
-Damage sweep afterwards: `Bastet tables in master: 0`, no stray database, `Subnets` intact,
-`__EFMigrationsHistory: 6`, `APPLICATION locks on the server: 0`. `CREATE DATABASE` on this path can
-only end as 262 or 1801 — there is no data-loss path, which is why this is **low**. It is not info:
-the code takes an action the operator never asked for against a live catalog, throws away a correct
-diagnostic the same deployment produces with auto-migrate off, and its literal advice makes the
-operator grant the application account a server-level `dbcreator` right that does not help.
-
-**Fix.** *The finder's fix — `SELECT DB_ID(@catalog)`, treating non-NULL as "exists" — was corrected:
-it does not work as written, for two reasons both verifiers measured independently. `DB_ID` only
-answers because `VIEW ANY DATABASE` is granted to `public` by default; deny it to the application
-login (ordinary hardening) and the probe returns NULL for a database that plainly exists, so the fix
-silently no-ops and both wrong messages come back — demonstrated end to end with a build carrying the
-`DB_ID` probe. And `DB_ID` returns `smallint`, so the natural `probeResult is int` test never matches.* `HAS_DBACCESS` returns
-`int`, keeps answering under `DENY VIEW ANY DATABASE`, and separates the states correctly in every
-condition measured (0 = exists but unusable, including offline and including for `sa`; NULL = absent;
-1 = healthy, so it does not over-fire).
-
-```csharp
-SqlConnection bootstrapConnection;
-try
-{
-    bootstrapConnection = Open(MigrationLockConnectionString.MasterBootstrap(connectionString));
-}
-catch (SqlException bootstrapException)
-{
-    throw new InvalidOperationException(/* the existing :319-324 message, unchanged */, bootstrapException);
-}
-
-// 4060 is also what a login gets when the catalog EXISTS but cannot be opened - byte-identical text.
-// HAS_DBACCESS answers 0 (exists, not usable) / NULL (no such database) and, unlike DB_ID or
-// sys.databases, keeps answering when VIEW ANY DATABASE has been revoked from public. It returns
-// int, where DB_ID returns smallint. Fail open: if the probe cannot run, keep today's bootstrap path.
-string configuredCatalog = new SqlConnectionStringBuilder(connectionString).InitialCatalog;
-int? catalogAccess = null;
-try
-{
-    using SqlCommand probe = new("SELECT HAS_DBACCESS(@catalog)", bootstrapConnection);
-    probe.Parameters.AddWithValue("@catalog", configuredCatalog);
-    catalogAccess = probe.ExecuteScalar() is int access ? access : null;
-}
-catch (SqlException) { /* probe unavailable - behave exactly as before */ }
-
-if (catalogAccess == 0)
-{
-    bootstrapConnection.Dispose();
-    throw new InvalidOperationException(
-        $"The configured database '{configuredCatalog}' exists on this server but could not be opened, "
-        + "which SQL Server reports as error 4060 using the same text it uses for a database that does "
-        + "not exist. Either the login in BASTET_CONNECTION_STRING has no user inside that database "
-        + $"(CREATE USER inside '{configuredCatalog}', then db_owner for BASTET_AUTO_MIGRATE=true - if "
-        + "the database was restored or failed over, the user may be orphaned: ALTER USER ... WITH "
-        + "LOGIN), or the database is offline or recovering. Do not grant the login permission to "
-        + "create databases; it does not need it.");
-}
-
-return bootstrapConnection;
-```
-
-The message must name **both** causes: `HAS_DBACCESS` is also 0 for an offline database, even for
-`sa`, so wording that asserts "this login has no user inside it" would be confidently wrong in Run C.
-
-This form was built in a private worktree, published and run: correct message on the default server,
-**same** correct message under `DENY VIEW ANY DATABASE` (where `DB_ID` fails), genuine bootstrap
-(`sa`, catalog absent) still creates the database and serves `GET /Subnet` 200, and a genuinely absent
-catalog with a login that cannot create databases still gets the original 262 — the probe does not
-over-fire. `dotnet build` 0 warnings / 0 errors, `dotnet test` 677 passed.
-
-**Constraint on any fix:** EF Core's `SqlServerDatabaseCreator.Exists()` makes the *same* 4060
-misreading independently — that is why `Migrate()` issues `CREATE DATABASE` at all — so a fix at
-`:305` must **abort startup**. One that merely logs and continues is overruled by EF three lines
-later.
-
-**Cheaper interim:** remember that the `master` fallback fired and wrap `dbContext.Database.Migrate()`
-at `:371` so any failure on that path adds *"the configured database '<name>' could not be opened; if
-it already exists this login is not a user inside it, or the database is offline — grant access or
-bring it online rather than creating the database."* A few lines, no extra round trip, robust to
-metadata-visibility settings because it probes nothing. Strictly weaker — it fires only *after* the
-pointless `CREATE DATABASE` — but it removes the misdirection toward `dbcreator`.
+_Not taken: the cheaper interim that wraps `Migrate()` and appends advice after the fact. It is
+strictly weaker — it fires only after the pointless `CREATE DATABASE` — and the real fix costs one
+round trip on a path that already opened a connection._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-8.md
+++ b/docs/AUDIT-FINDINGS-8.md
@@ -1,0 +1,995 @@
+# Bastet — Round-8 Audit Findings
+
+| | |
+|---|---|
+| Round | **8** (finding letter **H**) |
+| Target branch | `audit/round-8` |
+| Baseline HEAD | `ff285cf` — *"Audit 7 Cleanup (#150)"*, identical to `main` |
+| Build at baseline | `dotnet build --no-incremental` → 0 warnings, 0 errors |
+| Tests at baseline | `dotnet test` → **677 passed, 0 failed, 0 skipped** |
+| Working tree | clean at start and at finish |
+| Date | 2026-07-28 |
+
+Every line number below was re-derived against the working tree at `ff285cf` while writing this file.
+
+---
+
+## Verdict
+
+**Seven findings: one high, two medium, three low, one info.** All seven were reproduced against the
+live rig — real SQL Server 2022, real ARM, real headless Chromium — not argued from source. One
+candidate was refuted.
+
+Read **H1** first. Azure reconcile's confirm cascade archives every descendant of a stale target
+without checking that descendant's own Azure verdict, so a single approved delete destroys Bastet
+rows that the *same scan* proved are still live in Azure, or that the same response explicitly said
+had been *withheld from deletion*. It reproduces with no concurrency, no crafted request and no RBAC
+trickery, on the ordinary operator path, and `DeletedSubnets` does not archive `AzureResourceId`, so
+the link is destroyed with no in-app restore.
+
+Then **H2** and **H3**, which are the same class as each other: both Azure import wizards fire
+overlapping AJAX requests with no ordering guard, and in both the browser ends up committing
+something the screen was not showing. H2 writes a child `AzureResourceId` belonging to a VNet the
+parent is not linked to — silently, and unrepairable by every route checked. H3 commits a plan the
+operator never reviewed.
+
+**H4** and **H5** are operator-facing: an unbounded "Purge All" that ignores the count its own
+confirmation ceremony states, and a startup bootstrap that misreads SQL error 4060 and then tells the
+operator two successively wrong things about a database full of their data. **H6** is a false
+"overlap" message on the Details Create-Subnet modal, introduced by round 7's G11 reorder. **H7** is a
+completion banner that cannot distinguish "I linked a subnet" from "I did nothing".
+
+Round 7's fix set is where round 8's defects were expected to be, and one is: **H6 is residue of
+G11**. The other six are older code that no previous round drove hard enough in a browser or against
+a real SQL Server.
+
+---
+
+## How this audit ran
+
+**The beats.** Twenty finder agents were spread over the surface: Azure integration (import wizards,
+bulk planner, reconciler, ARM boundary), UI and client-side JavaScript, logic and data integrity,
+locking and lifecycle, security and sanitization, regression correctness against the round-7 fix set,
+and a deep sweep over everything else.
+
+**Two passes plus a deep sweep.** Each beat was worked by two independent finder passes that did not
+see each other's output, plus a sweep pass over the whole tree. That is what `[x2]` and `[x1]` mean:
+
+- **`[x2]`** — two independent passes found it. Independent agreement is strong evidence that the
+  defect is visible from more than one angle.
+- **`[x1]`** — one pass found it and the other did not. Absence is weak evidence, so every `[x1]`
+  candidate was given a **second verifier working a reachability-and-consequence lens** —
+  can a real user get here from a realistic starting state, and what is actually damaged? — precisely
+  because "the other pass missed it" and "the other pass was right" look identical from the outside.
+  Two of the four `[x1]` candidates came back materially changed (H4 reframed, H5 strengthened), and
+  one came back dead (the `BatchCreateChildSubnets` candidate, in the refuted table below — this round
+  raised no finding numbered outside H1-H7).
+
+**The verification scheme.** Every candidate got at least one verifier on a **refutation lens**: is
+the citation real, is the path reachable, are the inputs acceptable, does the consequence follow, is
+it already fixed, is it a duplicate of something accepted or previously refuted. Verifiers ran on
+their own port, their own SQL catalog and their own publish, and reproduced independently rather than
+re-reading the finder's transcript. **Where a verifier corrected a finder, the correction is what is
+written below.**
+
+**The funnel.**
+
+| | |
+|---|---|
+| Finder agents | 20 |
+| Raw findings reported | 18 |
+| Candidates after dedup/merge | 8 — **4 `[x2]`, 4 `[x1]`** |
+| Verifier agents | 12 |
+| Judged | 8 |
+| **Survived** | **7** |
+| Refuted | 1 |
+| Reproduced against the live rig | **7 of 7** |
+| Not runnable | 0 |
+
+**Corrections applied by verifiers.** Severity: H1 critical → high, H4 medium → low, H7 low → info.
+Proposed fixes: H1, H2, H3 and H5 corrected as incomplete; H4's corrected as **unsound** (it was
+built, run, and measured to make one currently-correct ordering wrong). H4's *mechanism* was also
+refuted and the finding reframed around what actually reproduces.
+
+---
+
+# Critical
+
+None.
+
+---
+
+# High
+
+## H1 [x2] — Azure reconcile archives descendants the same scan proved live, or explicitly withheld from deletion
+
+**Citation.** `src/Bastet/Controllers/SubnetController.AzureReconcile.cs:144` — the unconstrained
+subtree archive. Co-site: `src/Bastet/Services/Azure/AzureReconciler.cs:145-213`
+(`ApplyConfirmations` withholds rows from deletion without making the withholding transitive).
+
+**Confidence.** Confirmed.
+
+**Scenario.** Two ordinary bulk imports nest `rig-verc1-inner` (10.78.128.0/17) under
+`rig-verc1-outer` (10.78.0.0/16), each linked to its own live Azure VNet, with
+`rig-snet-verc1-inner-a` (10.78.130.0/24) beneath. Only `rig-verc1-outer` is deleted in Azure.
+
+`POST /Azure/ReconcileScan` returns exactly one item — `subnetId 1`, `VNetDeleted`,
+`descendantSubnetIds [2,3]` — and **`warnings: []`**, because the scan read rows 2 and 3 from the
+same subscription listing and found them **live**. The very next request,
+`POST /Subnet/BulkDeleteStaleAzureSubnets {"subnetIds":[1],"confirmation":"approved"}`, answers
+`{"success":true,"targetsDeleted":1,"subnetsArchived":3,"hostIpsArchived":0}` — all three rows
+archived, including the two whose Azure resources are still `Succeeded`.
+
+The gate at `:77-92` is keyed on `request.SubnetIds` only. No descendant is ever compared against
+`plan.Items`, `plan.ReviewItems`, or the per-resource confirmation verdicts.
+
+The RBAC variant is sharper. With rows 5 and 6 linked into a resource group the current credential
+cannot see, the scan's own body says:
+
+> *"2 Azure-linked subnet(s) were missing from the subscription listing, and Azure denied access when
+> asked about them directly … **They have been withheld from deletion**: 'rig-verc1-hidden',
+> 'rig-snet-verc1-hidden-a'."*
+
+and the next request archives exactly those two rows plus a host IP. `DeletedSubnets` has no
+`AzureResourceId` column (`Models/DeletedSubnet.cs:11-43`) and there is no restore path anywhere in
+the app, so the Azure link is destroyed unrecoverably. In the RBAC variant the operator cannot even
+re-import: the credential that would have to do it is the one ARM refuses.
+
+**Reproduction.** Live rig, port 5400, catalog `bastet_audit_200`, real ARM, SP_A and SP_B, fixtures
+created through the shipped wizards (no hand-seeded rows).
+
+```
+POST /Azure/ReconcileScan  subscriptionId=f0e8d6db-e9c4-4215-81a5-17762ea56be8
+scanSucceeded True  canCommit True
+items: [{subnetId:1, name:'rig-verc1-outer', statusName:'VNetDeleted',
+         descendantCount:2, hostIpCount:0, descendantSubnetIds:[2,3]}]
+reviewItems: []
+warnings:    []          <-- EMPTY: the scan read 2 and 3 and found them live
+
+POST /Subnet/BulkDeleteStaleAzureSubnets {"subnetIds":[1],"confirmation":"approved"}
+{"success":true,"redirectUrl":"/Subnet","targetsDeleted":1,"subnetsArchived":3,"hostIpsArchived":0}
+
+Subnets        -> (no rows)
+DeletedSubnets -> 1|rig-verc1-outer  2|rig-verc1-inner  3|rig-snet-verc1-inner-a
+az network vnet subnet list --vnet-name rig-verc1-inner
+               -> rig-snet-verc1-inner-a  10.78.130.0/24  Succeeded    <-- still live
+```
+
+Also driven end to end in real Chromium through the shipped three-step wizard (zero page errors, zero
+console errors). Step 3, the last screen before the archive, reads verbatim: *"You are about to
+delete 1 subnet(s) that no longer match Azure… This also archives 2 child subnet(s) and 0 host IP
+assignment(s) that live beneath them."* Both review screens state the cascade and its **count**; what
+neither ever says is that the collateral is linked to Azure resources this same scan verified are
+still live, or explicitly withheld. Step 2's banner actively misleads on the point, framing the
+collateral as *"including any you created by hand"*. `_StepConfirm.cshtml` has **no warnings block at
+all** — `#rec-scan-warnings` exists only in `_StepReview.cshtml:23` — so in the RBAC variant the
+withheld sentence never reaches the screen that performs the archive.
+
+This is **not** the accepted C20 window. In both reproductions the archived subtree matched
+`stillStale[id].DescendantSubnetIds` **exactly**, so the closure C20 documents at `:109-110` would not
+catch either case. Everything here is deterministic, single-request, single-threaded.
+
+**Fix.** *The finder's fix was corrected as incomplete: its part 2 was placed in a method with no
+access to `linkedSubnets`, and its cheap interim missed `plan.ReviewItems` entirely.*
+
+In `AzureReconciler`, so it stays pure and testable:
+
+1. In `ApplyConfirmations`, after `plan.Items = keep` (`:187`), build
+   `HashSet<int> blocked = [.. notVisible.Concat(unknown).Concat(stillLive).Select(i => i.SubnetId),
+   .. plan.ReviewItems.Select(i => i.SubnetId)]`, then
+   `plan.Items.RemoveAll(i => i.DescendantSubnetIds.Any(blocked.Contains))`, naming the removed
+   targets in a new warning. **`plan.ReviewItems` must be in that set**: `ApplyConfirmations` iterates
+   `plan.Items` only (`:145`) and never reads `ReviewItems`, so an `UnrecognisedResourceId` or
+   `FullyAllocatingSubnetDeleted` descendant is in no set built there — and
+   `FullyAllocatingSubnetDeleted` is produced by ordinary imports (`AzureReconciler.cs:261-267`).
+2. In `BuildPlan`, collect into `HashSet<int> liveLinked` the ids of `linkedSubnets` entries that
+   evaluated to `null` — verified live in Azure — at `:99-102`, and after the loop remove from
+   `plan.Items` any item whose `DescendantSubnetIds` intersects it, with its own warning naming those
+   descendants. This is the half that closes the no-RBAC variant, the likeliest in the field.
+   `BuildPlan` is the right home: both callers hold `linked` (`AzureController.cs:342`,
+   `SubnetController.AzureReconcile.cs:56`).
+3. Nothing further is needed server-side: with (1) and (2) in place the existing `noLongerStale` gate
+   at `:78-92` already answers **409** for a dropped target and already carries `plan.Warnings`
+   (`:90`), so the operator gets the real reason for free.
+
+This does not over-withhold the ordinary case: when a VNet is deleted its own imported subnets vanish
+with it, confirm as `Deleted`, and land in `keep`. Dropping items degrades safely — `CanCommit` is
+`ScanSucceeded && GlobalErrors.Count == 0 && Items.Count > 0`
+(`AzureReconcileViewModels.cs:192`) and the wizard's `nothingToReport` check
+(`_ReconcileScripts.cshtml:258`) already handles warnings-without-items.
+`AzureReconcileItem.DescendantSubnetIds` is the **full transitive** descendant set
+(`AzureSubnetSnapshotService.GetDescendants`, BFS with a visited set), and
+`BulkDeleteStaleAzureSubnets` rebuilds the plan server-side at `:57`, so the guard runs on fresh data.
+
+**Cheaper interims, ranked by harm removed per line.**
+**(A)** step 1 alone — about five lines, closes the withheld and review-item variants.
+**(B)** step 2 alone — about ten lines, closes the live-descendant variant.
+**(C)** display-only, closes nothing but ends the surprise: have `BuildPlan` count, per item, the
+descendants that are Azure-linked and became neither an item nor a review item, carry it on
+`AzureReconcileItem`, and render it in `cascadeNote()` (`_ReconcileScripts.cshtml:194-203`) **and** in
+the step-3 confirm list (`:352`) — *"also archives 2 subnet(s) still linked to live Azure resources"*.
+Worth doing regardless: `_StepConfirm.cshtml` should repeat `plan.warnings`, because today the
+withheld sentence never reaches the screen that archives.
+
+---
+
+# Medium
+
+## H2 [x2] — Single-VNet import wizard has no staleness guard on `loadSubnets`, so an out-of-order response posts one VNet's subnets under another VNet's identity
+
+**Citation.** `src/Bastet/Views/Azure/Import/_ImportScripts.cshtml:250` (`loadSubnets`' `success`
+handler), against `:61-62` (identity written synchronously on click) and `:224` (`loadSubnets` keeps
+no token and no jqXHR).
+
+**Confidence.** Confirmed.
+
+**Scenario.** `#select-vnet-btn` writes the hidden `vnetName` / `vnetResourceId` fields synchronously
+at `:61-62` and then calls `loadSubnets(selectedVNetId)` at `:63`. The `success` handler at `:250`
+empties and rebuilds `#subnet-list` (`:254-255`) with **no** comparison against the currently selected
+VNet, and `/Azure/GetSubnets` does live per-VNet ARM reads, so latency varies.
+
+An admin on a Bastet subnet whose prefix is shared by two Azure VNets — a topology the source itself
+contemplates (*"Two VNets in one subscription may share a prefix"*,
+`SubnetController.Azure.cs:331-332`) — picks VNet A, goes back via the still-enabled step-2 pill,
+picks VNet B, and gets **A's subnet rows repainted over B's identity** when A's response lands last.
+`Views/Azure/Import/_SubnetList.cshtml` prints no VNet name on step 3, so nothing on screen
+contradicts it.
+
+Ticking a row and pressing Import posts children stamped with A's ARM ids alongside B's
+`vnetName`/`vnetResourceId`. The server accepts it — no site compares a child's `AzureResourceId`
+against `vnetResourceId`; the child stamp is a straight copy at `SubnetController.Azure.cs:409` — and
+reports success. The resulting row is unrepairable: the wizard refuses re-entry, G1 refuses a crafted
+relink, `Edit` cannot bind the column, and `DeletedSubnets` does not archive it. If the wrongly
+stamped VNet is later deleted in Azure, reconcile archives the parent **and its whole subtree**,
+including children that are alive in the other VNet.
+
+**Reproduction.** Live app on 127.0.0.1:5403, catalog `bastet_audit_203`, headless Chromium, real ARM,
+**no proxy and no injected delay** — the superseded response landed last on natural latency alone:
+
+```
+trial 2: resp-order=[(1.431,'rig-uip2-twin',200),(1.512,'rig-vnet-alpha',200)]
+         rows=['rig-snet-alpha-web','-app','-data','-import-only'] hidden vnetName='rig-uip2-twin' STALE=True
+...
+DELAY=0.0  trials=8  stale-repaints=5
+```
+
+Carried through to the write (again unmanipulated). Captured `POST /Subnet/BatchCreateChildSubnets`,
+URL-decoded:
+
+```
+parentId=1  vnetName=rig-uip2-twin  isAzureImport=true
+vnetResourceId=.../virtualNetworks/rig-uip2-twin
+subnets[0].Name=rig-snet-alpha-web  subnets[0].NetworkAddress=10.20.1.0  subnets[0].Cidr=24
+subnets[0].Description=Imported from Azure VNet: rig-uip2-twin
+subnets[0].AzureResourceId=.../virtualNetworks/rig-vnet-alpha/subnets/rig-snet-alpha-web
+-> 302 /Subnet/Details/1
+   "Successfully renamed parent subnet to 'rig-uip2-twin' and imported 1 child subnets."
+```
+
+Database (`bastet_audit_203`):
+
+```
+1 | rig-uip2-twin      | 10.20.0.0/16 | parent=- | arm=.../virtualNetworks/rig-uip2-twin
+2 | rig-snet-alpha-web | 10.20.1.0/24 | parent=1 | arm=.../virtualNetworks/rig-vnet-alpha/subnets/rig-snet-alpha-web
+```
+
+All three candidate correctors checked and silent: `POST /Azure/ReconcileScan` on the corrupted tree
+returned `items:[] reviewItems:[] warnings:[] canCommit:false` (both ARM ids exist, so the app's own
+consistency checker says nothing); `GET /Azure/Import/1` now 302s away with *"Subnet must not have any
+child subnets or host IP assignments"*; a crafted relink POST was refused by G1
+(`SubnetController.Azure.cs:338-350`).
+
+Window width, measured to bound severity: with a 1.5 s human-paced pause between the two clicks,
+**0 hits in 6** — `GetSubnets` answers in ~200 ms here, so the window is roughly the latency
+difference. `AzureService.GetCompatibleSubnets` still issues `vnetResource.Get()` **plus** a full
+`GetSubnets()` enumeration per VNet (the shape G3 deliberately left), so a VNet with hundreds of
+subnets, or a 429 with SDK retry backoff, puts it in multi-second territory.
+
+**Fix.** *The finder's fix was corrected as incomplete: it guarded `success` only.* The `error`
+handler (`:323-326`) and `complete` (`:327-329`) stay unguarded, so a superseded request that fails at
+the transport paints *"Error connecting to server: …"* over the current VNet's correctly rendered
+rows, and its `complete` hides `#subnet-loading` while the current request is still in flight.
+
+```js
+let subnetSeq = 0;
+function loadSubnets(vnetResourceId, vnetName) {
+    const seq = ++subnetSeq;
+    $.ajax({
+        url: '@Url.Action("GetSubnets", "Azure")',
+        type: "GET",
+        data: { vnetResourceId: vnetResourceId, subnetId: @Model.SubnetId },
+        dataType: "json",
+        beforeSend: function () { /* unchanged, incl. G10's reset */ },
+        success: function (result) {
+            if (seq !== subnetSeq) { return; }          // superseded - drop it
+            $("#vnet-name").val(vnetName);              // identity comes from the response
+            $("#vnet-resource-id").val(vnetResourceId); // that populated the rows
+            /* ...existing body... */
+        },
+        error: function (xhr, status, error) { if (seq !== subnetSeq) { return; } /* ...existing... */ },
+        complete: function () { if (seq !== subnetSeq) { return; } $("#subnet-loading").hide(); }
+    });
+}
+```
+
+with `:63` becoming `loadSubnets(selectedVNetId, selectedVNetName)`. `:61-62` may stay — `beforeSend`
+hides `#subnet-selection`, so the form is unreachable between the click and the accepted response;
+what fixes the defect is the **accepted response** writing the identity fields.
+
+**Cheaper interim:** retain the jqXHR and `.abort()` the previous one **at the very top of
+`loadSubnets`, before the new `$.ajax` call**. Verified against the pinned jQuery 4.0.0: the aborted
+request's handlers are dispatched synchronously inside `.abort()`
+(`['--about to call abort()--','error(abort)','complete','--abort() returned--']`), so the new
+request's `beforeSend` undoes them in the same task and nothing is painted. Placing the abort inside
+`beforeSend` instead reverses the order and leaves the red banner up — the interim is only correct as
+written, or with `if (status === "abort") { return; }` as the first line of `error`.
+
+**Optional defence-in-depth (not the finder's, and not the round-6 F1 check that was declined):** when
+`vnetResourceId` is supplied, require every child `AzureResourceId` to start with
+`vnetResourceId + "/subnets/"` (`OrdinalIgnoreCase`) and reject otherwise. Pure string test, no ARM
+round trip. It must be conditional on `vnetResourceId` being non-empty, because the documented plain
+JSON caller may post `AzureResourceId` without one.
+
+---
+
+## H3 [x1] — Bulk Azure import commits a plan the operator never saw: the preview pane renders the last response to arrive, Confirm posts the last selection clicked
+
+**Citation.** `src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:447` (`renderPlan(result.plan)`
+in `loadPreview`'s success handler), with `:387` (`lastSelection = selection`, set synchronously on
+the click) and `:543` (`$("#bulk-go-commit-btn").prop("disabled", !plan.canCommit)`).
+
+**Confidence.** Confirmed. `grep -n "abort\|seq"` over the whole 632-line file returns nothing: no
+sequence token, no retained jqXHR, no `.abort()`. `git log` on the file shows no guard was ever
+removed.
+
+**Scenario.** An admin ticks VNet prefix `10.40.0.0/16` (`rig-vnet-gamma`) and presses *Next:
+Preview*. The preview is slow. Rather than wait they click the **step-2 pill** — which stays enabled
+during a load (`activateTab` never re-disables a visited pill, and `#bulk-back-to-selection-btn` sits
+*inside* `#bulk-preview-content`, which is `d-none` while the spinner runs, so the pill is the only
+route back) — untick gamma, tick `10.31.0.0/16` (`rig-vnet-beta`) with both its subnets and the
+"rename matched" switch, and press *Next: Preview* again.
+
+The second response renders first. The first response then lands and repaints the pane with the gamma
+plan, re-enabling *Continue to Commit* from **gamma's** `canCommit`. The operator approves that
+screen. Confirm Import posts `lastSelection`, which is **beta**.
+`SubnetController.BulkAzure.cs:60-75` re-plans the *posted* selection, finds it internally consistent,
+and commits it. It never sees the rendered plan, so it cannot detect the divergence. Step 4 shows no
+recap.
+
+**Wrong output.** Banner: *"Created 0 VNet target(s), 2 child subnet(s), renamed 1 target(s)"*. In
+`bastet_audit_204` the operator's hand-made `Prod Core 10.31.0.0/16` was **renamed** to
+`rig-vnet-beta` (description still "Hand made by the operator"), **permanently stamped** with
+`AzureResourceId`, and two children created under it. `10.40.0.0/16` — the plan actually on screen —
+was never created.
+
+**Reproduction.** Real Chromium against the live app on 127.0.0.1:5404. The **only** thing forced is
+arrival order: `page.route` on `**/Azure/BulkImportPreview` does `resp = await route.fetch()` (the
+live app answers with its own bytes), sleeps 6 s for request #1 only, then
+`route.fulfill(response=resp)`. Request #2 passes straight through. No source patched, no body
+altered.
+
+```
+[t+ 1.53s] CLICK 1: ticked rig-vnet-gamma 10.40.0.0/16, pressing 'Next: Preview'
+[t+ 2.62s] clicked the step-2 pill; step2 pane visible = True     (request still in flight)
+[t+ 2.79s] CLICK 2: gamma unticked; ticked rig-vnet-beta 10.31.0.0/16 + 2 subnets + rename switch
+[t+ 3.08s] SCREEN after response #2: rig-vnet-beta / Exact match "Prod Core" -> rename
+[t+ 7.59s] preview RESPONSE #1 delivered (plan for rig-vnet-gamma)
+[t+10.64s] SCREEN: "New top-level create rig-vnet-gamma (10.40.0.0/16) / No child subnets selected."
+              commit button disabled? False
+[t+10.95s] COMMIT. POST body vNetPrefixes = [rig-vnet-beta 10.31.0.0/16 + mgmt + svc]
+
+1 | rig-vnet-beta      | 10.31.0.0/16 | arm=.../virtualNetworks/rig-vnet-beta | desc=Hand made by the operator
+2 | rig-snet-beta-mgmt | 10.31.1.0/24 | parent=1
+3 | rig-snet-beta-svc  | 10.31.2.0/24 | parent=1
+```
+
+The ordering premise was then measured **with nothing forced at all**. `/Azure/BulkImportPreview` is
+`GetExistingSubnetsAsync()` plus several O(existing) passes per selected prefix, so latency scales
+with `existing x selected` — 39 ms at 20 000 subnets / 1 prefix, **7 247 ms** at 200 000 / 600. Two
+ordinary requests, heavy preview first, light preview `GAP` seconds later:
+
+```
+gap=1.0s -> light finished t+1.24s ; heavy finished t+5.15s   INVERTED=True
+gap=2.0s -> light finished t+2.24s ; heavy finished t+6.69s   INVERTED=True
+gap=3.0s -> light finished t+3.23s ; heavy finished t+5.92s   INVERTED=True
+```
+
+That is literally the "select all, too much, go back and pick one" flow. Separately, 310 concurrent
+preview pairs on a warm small deployment completed **102 out of order**: the application imposes no
+ordering whatsoever. On a small tree the precondition is a transient stall on request #1 — pool wait
+(G5 measured 15 s pool timeouts in this app), a cold load-balanced replica, a DB failover — which is
+exactly what makes an operator abandon the spinner, so the two conditions are correlated.
+
+Contrast, which is what makes this a defect rather than house style: the reconcile wizard sets
+`lastPlan = plan` **inside** `renderPlan` (`_ReconcileScripts.cshtml:205-206`), so its screen and its
+payload always come from one response.
+
+**Fix.** *The finder's fix was corrected as incomplete (it guarded `success` only) and its interim was
+corrected as placement-dependent.* A stale `error` is reachable today and paints *"Error connecting to
+server:"* over a current, valid plan — measured: `after response #2 rendered a valid plan:
+content=True errorPanel=False` then `after stale request #1 FAILED: content=True errorPanel=True`. A
+stale `complete` hides the spinner of a request still in flight (jQuery always runs `complete`).
+
+```js
+let previewSeq = 0;
+function loadPreview(selection) {
+    const seq = ++previewSeq;
+    $.ajax({
+        /* ... unchanged ... */
+        success:  function (result) { if (seq !== previewSeq) { return; } /* unchanged */ },
+        error:    function (xhr, status, error) { if (seq !== previewSeq) { return; } /* unchanged */ },
+        complete: function ()       { if (seq !== previewSeq) { return; }
+                                      $("#bulk-preview-loading").addClass("d-none"); }
+    });
+}
+```
+
+**Cheaper interim:** retain the jqXHR and `.abort()` it **at the top of `loadPreview`, before the new
+`$.ajax` call**, plus `if (status === "abort") { return; }` as the first line of `error`. The abort
+alone is only correct at that exact placement — measured with the abort reached after the new
+`beforeSend`, jQuery 4.0.0 fired `error(status=abort)` then `complete` and left
+`errorText='Error connecting to server: abort'` on screen. The `status === "abort"` line makes the
+interim placement-independent and costs one line.
+
+---
+
+# Low
+
+## H4 [x1] — "Purge All" ignores the scope its own confirmation page states: the POST round-trips nothing and deletes whatever exists at execution time
+
+**Citation.** `src/Bastet/Controllers/SubnetController.Delete.cs:299` (`ExecuteDeleteAsync`), with the
+GET at `:275-284` and the view text at `Views/Subnet/PurgeAllDeletedSubnets.cshtml:17`. Twin:
+`src/Bastet/Controllers/HostIpController.cs:617`, GET at `:593-602`.
+
+**Confidence.** Confirmed — for the reframed defect. *The finding as filed blamed the missing global
+subnet lock; that mechanism is refuted (see the fix, and the reproduction below with zero
+concurrency). The defect does not depend on it.*
+
+**Scenario.** The POST's whole signature is `PurgeAllDeletedSubnetsConfirmed(string confirmation)`.
+Nothing from the GET is round-tripped, so the delete is unbounded, while the page the operator typed
+`approved` into says *"You are about to permanently delete **1** archived subnet record(s). After
+purging, these records will be gone forever — there is no recovery."*
+
+**One admin, one session, two tabs, zero concurrency.** Tab 1 opens
+`/Subnet/PurgeAllDeletedSubnets`, which renders `permanently delete <strong>1</strong> archived subnet
+record(s)`. In tab 2 the same admin (or a Delete-role colleague) deletes `10.50.0.0/16` and its 10
+children, archiving 11 more rows. **Five seconds later** tab 1 submits the form it already had open:
+12 archive records destroyed, banner *"Permanently purged 12 deleted subnet record(s)"*, and the
+deleting tab's own success banner promised an archive that no longer exists.
+
+**Reproduction.** HEAD build, SQL Server 2022, catalogs `bastet_audit_207` / `bastet_audit_607`.
+Sequential, no overlap at all:
+
+```
+BEFORE:                Subnets=11 DeletedSubnets=1
+tab-1 page said:       permanently delete <strong>1</strong> archived subnet record(s)
+tab-2 delete HTTP=302  Subnets=0  DeletedSubnets=12
+(sleep 5)
+tab-1 purge  HTTP=302  banner: Permanently purged 12 deleted subnet record(s)
+FINAL:                 Subnets=0  DeletedSubnets=0
+```
+
+At 900 children the page said `1` and 902 rows were destroyed. Host-IP twin, same shape: page said
+`permanently delete 1 archived host IP record(s)`, another tab archived 4, five seconds later the
+stale form reported *"Permanently purged 5 deleted host IP record(s)"*.
+
+Second, concrete consequence: `HostIpController.cs:522` loads `DeletedSubnets` so
+`/HostIp/AllDeletedHostIps` can name the subnet each archived IP belonged to. Purging the subnet
+archive blinds the host-IP archive:
+
+```
+before purge:  3 rows render "net-b (deleted)"  10.61.0.0  /24
+after purge:   3 rows render "Unknown"          "Unknown"  cidr 0
+```
+
+No live data is touched, no corruption occurs (`DeletedSubnets` after each of eight runs was only ever
+0, 901 or 902 — never partial), and both sides are admin-gated; hence **low**. It is not info, because
+data really is destroyed unrecoverably (there is no restore path anywhere in the app, so the archive
+is the only record that a subnet existed, who deleted it and when) and the app itself already gates
+the same operation on the same count one HTTP request earlier — `GET` with an empty archive 302s away
+with *"There are no deleted subnet records to purge."*
+
+**Fix.** *The finder's fix — wrapping both POSTs in `ExecuteWithSubnetLockAsync` — was built, run and
+measured **unsound**, independently by both verifiers. Do not add the lock.* It prevents nothing (the
+loss above needs no concurrency) and it converts the one ordering HEAD handles **correctly** into
+total loss:
+
+```
+(HEAD,         purge at +109ms)  waited   12ms -> DeletedSubnets=901  B: "purged 1"
+(PATCHED-LOCK, purge at +108ms)  waited 1185ms -> DeletedSubnets=0    B: "purged 902"
+```
+
+A purge issued before the archive inserts finishes first and takes exactly the records the page
+promised; the lock parks it behind the entire delete.
+
+Bound the delete to the set the operator was shown — the finder's own cheaper interim, promoted to the
+fix:
+
+- `Models/ViewModels/PurgeAllViewModels.cs`: add `public int MaxId { get; set; }` to both view models.
+- GET: `int maxId = await context.DeletedSubnets.MaxAsync(d => (int?)d.Id) ?? 0;` into the model.
+- View: `<input type="hidden" name="confirmedMaxId" value="@Model.MaxId" />`.
+- POST: `PurgeAllDeletedSubnetsConfirmed(string confirmation, int? confirmedMaxId)` →
+  `context.DeletedSubnets.Where(d => d.Id <= confirmedMaxId).ExecuteDeleteAsync()`. Same for
+  `DeletedHostIpAssignments`.
+- Bind it as `int?` and re-render the confirmation when it is null or `<= 0` — otherwise a POST
+  without the field silently reports *"Permanently purged 0 deleted subnet record(s)"* and does
+  nothing. (One verifier hit this by accident.)
+
+Soundness of the bound: production is SQL Server only (`Program.cs:72` and `:79` are both
+`UseSqlServer`), `Id` is `IDENTITY`, and `DELETE` — unlike `TRUNCATE` — never reseeds it, so any row
+archived after the GET necessarily has `Id > MaxId`. Measured on the patched build:
+
+```
+purge at +108ms  confirmedMaxId=10825  waited 22ms -> DeletedSubnets=901  B: "purged 1"
+purge at +458ms  confirmedMaxId=11727  waited 13ms -> DeletedSubnets=901  B: "purged 1"
+sequential       confirmedMaxId=12629             -> DeletedSubnets=901  B: "purged 1"
+```
+
+Free side effect visible in those timings: the bounded `DELETE` is a clustered-index seek that never
+touches the uncommitted tail rows, so the purge stops blocking (13-22 ms versus 285-696 ms).
+
+**Cheaper interim, no schema or view-model change, and it keeps "Purge All" meaning all:** post the
+rendered `Count` back as a hidden field and refuse when
+`await context.DeletedSubnets.CountAsync() != confirmedCount`, redirecting to the GET with *"the
+archive changed since this page was rendered — review and confirm again."* Rows are only ever **added**
+to these two tables outside the purge itself, so count equality is a reliable optimistic check.
+
+`grep -rn "PurgeAll" test/` returns 0 hits, so there is no test fallout. **Caveat for whoever writes
+the regression test:** the suite is SQLite, where a plain `INTEGER PRIMARY KEY` reuses the highest
+rowid after the max row is deleted, so a SQLite test must not assume monotonicity across a purge —
+assert on rows inserted while the archive is non-empty.
+
+---
+
+## H5 [x1] — Migration bootstrap misreads SQL 4060: a database that exists but cannot be opened is treated as missing, so startup aborts with two successively wrong diagnostics
+
+**Citation.** `src/Bastet/Program.cs:305` (block `:305-326`); the consequence lands at `:371`
+(`dbContext.Database.Migrate()`).
+
+**Confidence.** Confirmed. The one step the finder inferred — that the `:305` branch is what puts the
+lock connection on `master` — was measured directly, twice and by two different methods.
+
+**Scenario.** SQL Server raises error 4060 with **byte-identical text** for three different
+conditions: the catalog does not exist, the login has no user inside an existing catalog, and the
+catalog is offline. `Program.cs:305` treats 4060 as the bootstrap path unconditionally, contradicting
+its own comment at `:307-309` (*"the catalog is not there yet, so this is the bootstrap path"*).
+
+With `BASTET_AUTO_MIGRATE=true`, the lock connection falls back to `master` — which **always succeeds
+on a stock SQL Server**, because `guest` holds `CONNECT` there — so the crafted
+`InvalidOperationException` at `:319-324` never fires, and `Migrate()` at `:371` issues
+`CREATE DATABASE [<catalog>]` against a database that already holds the operator's data. Startup
+aborts (exit 134) with `SqlException 262 "CREATE DATABASE permission denied in database 'master'"`.
+Acting on that message's own advice (`ALTER SERVER ROLE dbcreator ADD MEMBER`) produces
+`SqlException 1801 "Database '<catalog>' already exists. Choose a different database name."` — whose
+literal advice would abandon the production catalog. Neither message names the cause. The **same
+deployment with `BASTET_AUTO_MIGRATE=false` reports it accurately**, which is what makes this
+Bastet's wrong output rather than SQL Server's.
+
+**Reproduction.** Rig SQL Server 2022, unmodified shipped binary (byte-copy of the reference publish),
+`ASPNETCORE_ENVIRONMENT=Production`. Reached from three independent starting states:
+
+*Run A — orphaned database user after a restore or failover*, on a deployment that was serving
+`10.44.0.0/16` a minute earlier (README "Database Setup" done correctly, then the login recreated
+without `WITH SID`, which is `sp_change_users_login`'s entire reason to exist):
+
+```
+PROCESS EXITED rc=134 after 11.06s
+fail: Microsoft.EntityFrameworkCore.Database.Command[20102]
+      CREATE DATABASE [bastet_audit_606];
+Unhandled exception. Microsoft.Data.SqlClient.SqlException: CREATE DATABASE permission denied in database 'master'.
+   at Program.<Main>$(String[] args) in /home/anuj/code/Bastet/src/Bastet/Program.cs:line 371
+Error Number:262,State:1,Class:14
+```
+
+Not one line names the login, the user, or the fact that the database exists and holds the operator's
+subnets. *Run B* — follow that advice: `Error Number:1801 … Database 'bastet_audit_606' already
+exists.` *Run C — nothing misconfigured at all*, login `sa`, database `SET OFFLINE` for a maintenance
+window: same 4060 at login, same `CREATE DATABASE`, same 1801.
+
+*Counterfactual*: identical broken deployment with `BASTET_AUTO_MIGRATE=false` →
+`GET /Subnet` 500 with the **accurate** message *"Cannot open database … Login failed for user
+'bastet_c7r_app'."* *Control*: `ALTER USER [bastet_c7r_app] WITH LOGIN = [bastet_c7r_app];` and
+nothing else → *"Application started"*, `GET /Subnet` 200. The only fault was the missing database
+user, which is exactly what neither message named.
+
+*Direct proof the `:305` branch fires* — 30 ms DMV sampling during Run A:
+
+```
+APPLOCK 52  master  0:[Bastet:Migration]:(4afee137) X GRANT
+SESSION 52  master  login=bastet_c7r_app  prog=Core Microsoft SqlClient Data Provider
+```
+
+`Configured()` returns the connection string verbatim, so the only path that yields a `master` lock
+connection is `:305 -> :312`. Corroborated by an external hold on `sp_getapplock 'Bastet:Migration'`:
+startup took 11.13 s unblocked, **27.83 s** with the lock held **in master**, and 11.14 s with the
+same resource held in another catalog.
+
+Damage sweep afterwards: `Bastet tables in master: 0`, no stray database, `Subnets` intact,
+`__EFMigrationsHistory: 6`, `APPLICATION locks on the server: 0`. `CREATE DATABASE` on this path can
+only end as 262 or 1801 — there is no data-loss path, which is why this is **low**. It is not info:
+the code takes an action the operator never asked for against a live catalog, throws away a correct
+diagnostic the same deployment produces with auto-migrate off, and its literal advice makes the
+operator grant the application account a server-level `dbcreator` right that does not help.
+
+**Fix.** *The finder's fix — `SELECT DB_ID(@catalog)`, treating non-NULL as "exists" — was corrected:
+it does not work as written, for two reasons both verifiers measured independently. `DB_ID` only
+answers because `VIEW ANY DATABASE` is granted to `public` by default; deny it to the application
+login (ordinary hardening) and the probe returns NULL for a database that plainly exists, so the fix
+silently no-ops and both wrong messages come back — demonstrated end to end with a build carrying the
+`DB_ID` probe. And `DB_ID` returns `smallint`, so the natural `probeResult is int` test never matches.* `HAS_DBACCESS` returns
+`int`, keeps answering under `DENY VIEW ANY DATABASE`, and separates the states correctly in every
+condition measured (0 = exists but unusable, including offline and including for `sa`; NULL = absent;
+1 = healthy, so it does not over-fire).
+
+```csharp
+SqlConnection bootstrapConnection;
+try
+{
+    bootstrapConnection = Open(MigrationLockConnectionString.MasterBootstrap(connectionString));
+}
+catch (SqlException bootstrapException)
+{
+    throw new InvalidOperationException(/* the existing :319-324 message, unchanged */, bootstrapException);
+}
+
+// 4060 is also what a login gets when the catalog EXISTS but cannot be opened - byte-identical text.
+// HAS_DBACCESS answers 0 (exists, not usable) / NULL (no such database) and, unlike DB_ID or
+// sys.databases, keeps answering when VIEW ANY DATABASE has been revoked from public. It returns
+// int, where DB_ID returns smallint. Fail open: if the probe cannot run, keep today's bootstrap path.
+string configuredCatalog = new SqlConnectionStringBuilder(connectionString).InitialCatalog;
+int? catalogAccess = null;
+try
+{
+    using SqlCommand probe = new("SELECT HAS_DBACCESS(@catalog)", bootstrapConnection);
+    probe.Parameters.AddWithValue("@catalog", configuredCatalog);
+    catalogAccess = probe.ExecuteScalar() is int access ? access : null;
+}
+catch (SqlException) { /* probe unavailable - behave exactly as before */ }
+
+if (catalogAccess == 0)
+{
+    bootstrapConnection.Dispose();
+    throw new InvalidOperationException(
+        $"The configured database '{configuredCatalog}' exists on this server but could not be opened, "
+        + "which SQL Server reports as error 4060 using the same text it uses for a database that does "
+        + "not exist. Either the login in BASTET_CONNECTION_STRING has no user inside that database "
+        + $"(CREATE USER inside '{configuredCatalog}', then db_owner for BASTET_AUTO_MIGRATE=true - if "
+        + "the database was restored or failed over, the user may be orphaned: ALTER USER ... WITH "
+        + "LOGIN), or the database is offline or recovering. Do not grant the login permission to "
+        + "create databases; it does not need it.");
+}
+
+return bootstrapConnection;
+```
+
+The message must name **both** causes: `HAS_DBACCESS` is also 0 for an offline database, even for
+`sa`, so wording that asserts "this login has no user inside it" would be confidently wrong in Run C.
+
+This form was built in a private worktree, published and run: correct message on the default server,
+**same** correct message under `DENY VIEW ANY DATABASE` (where `DB_ID` fails), genuine bootstrap
+(`sa`, catalog absent) still creates the database and serves `GET /Subnet` 200, and a genuinely absent
+catalog with a login that cannot create databases still gets the original 262 — the probe does not
+over-fire. `dotnet build` 0 warnings / 0 errors, `dotnet test` 677 passed.
+
+**Constraint on any fix:** EF Core's `SqlServerDatabaseCreator.Exists()` makes the *same* 4060
+misreading independently — that is why `Migrate()` issues `CREATE DATABASE` at all — so a fix at
+`:305` must **abort startup**. One that merely logs and continues is overruled by EF three lines
+later.
+
+**Cheaper interim:** remember that the `master` fallback fired and wrap `dbContext.Database.Migrate()`
+at `:371` so any failure on that path adds *"the configured database '<name>' could not be opened; if
+it already exists this login is not a user inside it, or the database is offline — grant access or
+bring it online rather than creating the database."* A few lines, no extra round trip, robust to
+metadata-visibility settings because it probes nothing. Strictly weaker — it fires only *after* the
+pointless `CREATE DATABASE` — but it removes the misdirection toward `dbcreator`.
+
+---
+
+## H6 [x2] — G11's branch reorder makes a cleared CIDR field in the Details Create-Subnet modal report a non-existent overlap
+
+**Citation.** `src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml:142` (the range arm
+that fails to catch `NaN`). The wrong text is written at `:154-155`; the comment that states the
+opposite of what the code does is at `:145-146`.
+
+**Confidence.** Confirmed.
+
+**Scenario.** Open `/Subnet/Details/1` for a parent `10.0.0.0/16` with one child `10.0.0.0/18`, click
+the Unallocated Ranges "Create Subnet" button (network `10.0.64.0`, prefilled CIDR 18), then **clear
+the CIDR box** — or type any non-numeric text into it. `#cidrInput` is `<input type="number">`, so the
+element value is `''` and `parseInt('')` is `NaN`. `NaN < minCidr` and `NaN > maxCidr` are both false,
+so the range arm at `:142` is skipped and control falls to the `else` at `:151`, which since `ff285cf`
+is the **overlap** arm.
+
+Actual wrong output, observed: `#cidrValidationFeedback` = *"This CIDR would create a subnet that
+overlaps with existing subnets."* with computed `display: block` (visible, not merely in the DOM), and
+`#subnetSizeDisplay` = *"Invalid - Would overlap"* — while the page's own `wouldOverlap` is false. The
+same output appears on `/Subnet/Details/2`, a subnet with **no children at all**: the page asserts an
+overlap with a set that is empty.
+
+Before `ff285cf` the same input produced *"Please enter a valid CIDR value within the allowed range."*
+/ *"Invalid"*. G11's reorder moved the false sentence off the out-of-range input, which it correctly
+fixed, and onto the empty field.
+
+**Reproduction.** Playwright/Chromium driving the published `ff285cf` build on 127.0.0.1:5402 against
+SQL Server catalog `bastet_audit_202`, fixtures created through the app's own Create form. Real
+keystrokes (`click`, `Control+a`, `Delete`) on the shipped button:
+
+```
+== A. modal just opened ==   rawValue "18"  classes "form-control"  sizeDisplay "16,382"  btn enabled
+== B. field CLEARED ==       rawValue ""    parseInt "NaN"
+                             classes  "form-control is-invalid"
+                             feedback "This CIDR would create a subnet that overlaps with existing subnets."
+                             feedbackDisplay "block"   feedbackVisible true
+                             sizeDisplay "Invalid - Would overlap"   createBtnDisabled true
+== C. typed 5 (minCidr 17) == feedback "Please enter a valid CIDR value within the allowed range."
+== D. typed 18 ==             classes "form-control is-valid"  sizeDisplay "16,382"  btn enabled
+page errors: []
+```
+
+The same scripts against a `6a1fe75` worktree published separately: `== B. field CLEARED ==` gave
+*"Please enter a valid CIDR value within the allowed range." / "Invalid"*, and `== C. typed 5 ==` gave
+the overlap sentence. The builds swap exactly. That run also settles the one value not directly
+readable at HEAD: on `6a1fe75` the cleared field does **not** take `else if (wouldOverlap)`, proving
+`wouldOverlap === false` for the `NaN` input — so the overlap claim at HEAD contradicts the page's own
+overlap computation.
+
+A 46-input census (`''`, `0..40`, `abc`, `-4`, `1e2`, `18.5`) across three topologies (1 child, 0
+children, 3 children fragmented) shows the overlap arm is now reached by **exactly two inputs on every
+topology** — `''` and `abc` (an `<input type="number">` reports `value === ''` for non-numeric text, so
+typing letters is a second trigger) — and by no numeric input at all:
+
+```
+Details/1  OVERLAP-ARM 2 inputs: '' and 'abc'   RANGE-ARM 27   SUCCESS-ARM 17
+Details/2  OVERLAP-ARM 2 inputs: '' and 'abc'   RANGE-ARM 30   SUCCESS-ARM 14
+Details/3  OVERLAP-ARM 2 inputs: '' and 'abc'   RANGE-ARM 27   SUCCESS-ARM 17
+```
+
+Nothing is written and `#createSubnetBtn` is correctly disabled in both arms, hence **low**. It is not
+info: it is a false factual assertion, visible, on the main path an operator uses to carve a child out
+of an unallocated range — the identical class of defect G11 itself was accepted for in round 7.
+
+**Fix.** Verified **sound** as filed, applied and measured in a worktree:
+
+```diff
+-            } else if (cidrValue < minCidr || cidrValue > maxCidr) {
++            } else if (isNaN(cidrValue) || cidrValue < minCidr || cidrValue > maxCidr) {
+                 // Range before overlap: a CIDR that is both out of range and overlapping was
+                 // reported as an overlap, which is not the objection the operator can act on.
+-                // A cleared field still lands here - parseInt gives NaN, every comparison is
+-                // false - and still gets the generic message, as before.
++                // isNaN is tested explicitly because a cleared field parses to NaN and every
++                // NaN comparison is false, so the range test alone would drop it through to the
++                // overlap arm below - claiming a collision with a sibling that need not exist.
+```
+
+Measured on the fixed build: cleared field on `/Subnet/Details/1` and `/2` gives *"Please enter a valid
+CIDR value within the allowed range." / "Invalid"*, button disabled. Census, arm by arm:
+`SUCCESS-ARM 17/14/17` (identical to HEAD), `RANGE-ARM 29/32/29` (HEAD 27/30/27, `+2` = exactly the two
+`NaN` inputs), `OVERLAP-ARM 0` (HEAD 2). **No numeric path moves**, as it must not, since `isNaN(x)` is
+false for every value `parseInt` can return other than `NaN`. `dotnet build --no-incremental` 0
+warnings / 0 errors; `dotnet test` 677 passed.
+
+The comment rewrite is required, and is not quite what the finder proposed: after the fix the
+comment's *conclusion* ("a cleared field lands here") becomes true, but its stated *mechanism* ("every
+comparison is false", offered as the reason it lands here) remains exactly backwards — that is why it
+did **not** land here. Reword as above rather than deleting.
+
+**No cheaper interim exists** — this one-token change is already the floor. Note for whoever applies
+it: `:151-155` is already unreachable for every numeric input at HEAD, so the fix removes the arm's
+only visitor. **Do not "tidy" the arm away**; it is defence-in-depth for a case `findOptimalCidr`
+currently makes impossible.
+
+---
+
+# Info
+
+## H7 [x2] — Bulk import's commit-success banner never reads `linkedTargets`, so a link-only import reports every count as zero
+
+**Citation.** `src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:588`.
+
+**Confidence.** Confirmed.
+
+**Scenario.** Bastet holds a hand-made subnet `Prod Core 10.20.0.0/16`, no `AzureResourceId`, no
+children. An admin ticks only the VNet prefix `10.20.0.0/16` in the bulk wizard (badge *"Will update
+existing"*), selects no child subnets, leaves rename off, and commits. The server stamps the VNet's
+ARM id onto `Prod Core` and answers
+`{"createdTargets":0,"createdChildSubnets":0,"renamedTargets":0,"linkedTargets":1,"fullyAllocatedTargets":0}`.
+
+`:588` renders *"Bulk import completed. Created 0 VNet target(s), 0 child subnet(s), renamed 0
+target(s), marked 0 target(s) as fully allocated."* — four counters, `linkedTargets` absent.
+`grep -rn "linkedTargets" src/Bastet/Views src/Bastet/wwwroot test/` returns **no hits**. G1 added the
+counter to the JSON response and to the TempData banner, but `:588` is original wizard code
+(`73fc76f2`) that G1 never touched.
+
+**The sharpest form of the wrong output:** re-committing the identical selection now writes nothing
+and returns `linkedTargets: 0` — and `:588` renders **byte-identical text**. The completion screen
+cannot distinguish *"I just stamped an ARM id onto Prod Core"* from *"I did absolutely nothing"*.
+
+**Reproduction.** Headless Chromium against the live app, port 5401, catalog `bastet_audit_201`. Built
+by clicking, not by crafting a post:
+
+```
+TICKING: bulk-prefix-3-0  10.20.0.0/16  "Will update existing"
+CHECKED SUBNET BOXES AFTER TICKING PREFIX: []
+STEP 3 PREVIEW: Exact match Bastet subnet "Prod Core" (10.20.0.0/16) / No child subnets selected.
+COMMIT BUTTON DISABLED: False
+COMMIT BANNER (t+0.11s):
+ ' Bulk import completed. Created 0 VNet target(s), 0 child subnet(s), renamed 0 target(s), marked 0 target(s) as fully allocated.'
+COMMIT RESPONSE: {"success":true,...,"createdTargets":0,"createdChildSubnets":0,"renamedTargets":0,"linkedTargets":1,"fullyAllocatedTargets":0}
+CONSOLE: (empty)
+```
+
+The write landed — `sqlcmd` shows `Prod Core` carrying
+`azid=.../virtualNetworks/rig-regressp2-dup`. Re-posting the same selection returned all counters zero
+and produced identical banner text.
+
+**Why info and not low:** `:592-594` schedules an **unconditional** `window.location.href =
+result.redirectUrl` on a 2000 ms timer, and `TempData["SuccessMessage"]`
+(`SubnetController.BulkAzure.cs:324-329`) carries the complete sentence. Measured: banner at t+0.11 s,
+correct sentence on `/Subnet` at t+2.17 s:
+
+```
+POST-REDIRECT alert-success: "Bulk import succeeded: created 0 VNet target subnet(s), created 0 Azure
+child subnet(s), renamed 0 target(s), linked 1 existing target(s) to Azure, and marked 0 target(s) as
+fully allocated."
+```
+
+The only plausible reaction to the wrong banner ("it did nothing, do it again") is a tested no-op: 200,
+all counters zero, no second write, no G1 conflict.
+
+**Fix.** One line, rendering verified in the pinned Chromium:
+
+```js
+` Created ${result.createdTargets} VNet target(s), ${result.createdChildSubnets} child subnet(s), renamed ${result.renamedTargets} target(s), linked ${result.linkedTargets} existing target(s) to Azure, marked ${result.fullyAllocatedTargets} target(s) as fully allocated.`
+```
+
+Counter order then matches `TempData["SuccessMessage"]` exactly, so the two summaries of one commit
+agree. `linkedTargets` is always present on the success path
+(`SubnetController.BulkAzure.cs:338`). No cheaper interim exists — one line is already the floor. It
+touches an inline template literal only, so plain-HTTP and air-gapped hosting are unaffected.
+
+**Do not bundle** the finder's optional extra (naming the pending link in the preview's `ExactMatch`
+branch): step 2 already says *"Will import into existing Bastet subnet 'Prod Core'."* under a "Will
+update existing" badge, so the decision point is not uninformed. Separate call.
+
+---
+
+# Refuted
+
+| Candidate | What it claimed | Why it was killed |
+|---|---|---|
+| **`BatchCreateChildSubnets` renames and Azure-links a target subnet that already has child subnets** — `src/Bastet/Controllers/SubnetController.Azure.cs:329`, filed low, `[x1]` | That the "target must have no children" precondition is enforced by the wizard entry gate (`AzureController.cs:41-46`) and by the bulk planner (`AzureBulkImportPlanner.cs:199`, `:382`) but not by the write, making it an asymmetry rather than a policy choice; and that the operator's chosen name is destroyed with no undo. | **Not reproduced as a defect — the mechanism reproduces byte for byte but the resulting state is harmless, and the load-bearing premise is factually false.** Both verifiers killed it independently, one by curl and one by driving the shipped wizard in real Chromium. **(1)** The end state is one Bastet reaches through fully sanctioned operations in a different order: importing into an *empty* subnet and then creating the manual child afterwards was offered and accepted at every step and produces rows structurally identical in every column. `ValidateSubnetCreation` (`SubnetController.Helpers.cs:114-285`) does not test `AzureResourceId`, nor does `SubnetDetailsViewModel.CanAddChildSubnet` (`Models/ViewModels/SubnetViewModels.cs:114`) — a manual child under an Azure-linked parent is a supported operation, created live. There is no invariant to restore. **(2)** Both corroborating signals fire on *every* successful import: `GET /Azure/Import/{id}` on a legitimately imported subnet answers the identical *"Subnet must not have any child subnets or host IP assignments"*, and `BulkGetVNets` annotates it `Blocked` with the identical *"…already has child subnets. Already imported?"* — wording that describes a completed import. These are entry gates, not row invariants. The rename harm is likewise not caused by the missing check: it is the endpoint's documented purpose (`SubnetController.Azure.cs:104-110`) and cost the sanctioned import its name identically. **(3)** The "asymmetry" premise is **false**: with the other legitimate wizard shape — a `FullyEncompassesVNetPrefix` entry — a fully-allocated parent, which `GET /Azure/Import/{id}` refuses, **is** renamed and Azure-linked. The write path enforces *none* of the three entry preconditions; two merely coincide with `ValidateSubnetCreation`'s universal child-creation rules under one of the two batch shapes. Additionally, the one parent write that would produce a genuinely contradictory row (`IsFullyAllocated=true` beside children) is already guarded at `:314`, and a colliding batch rolls back completely, so the realistic stale-form race fails closed. **Fix also unsound:** the proposed blanket `AnyAsync(s => s.ParentSubnetId == parentId)` refusal sits *before* the `isAzureImport` branch, so it would break the plain non-Azure JSON batch-create API documented at `:104-110`, whose ordinary case is adding children to a parent that already has some. This lands squarely in the shape that has died five rounds running: the wrong output exists only if a render-time affordance is read as a row invariant, and the state produced is otherwise permitted. One pass reported it; the pass that did not find it was right. |
+
+---
+
+# Watch list
+
+Not findings. Known, accepted or deferred. Knowing these stops a later round filing something already
+understood — and several are the *reason* a nearby defect is worth more than it looks.
+
+## Accepted and still open — never re-raised, at any severity
+
+1. **ForwardedHeaders trust-all with `AllowedHosts: "*"`** (`Program.cs:260-267`).
+2. **The Development-only `DevAuthHandler` bypass** (`Program.cs:177-189`).
+3. **`GlobalSanitizationFilter` skipping nested `System.*` collections.**
+4. **`CollectDescendants` lacking a cycle guard** (`SubnetController.Helpers.cs:92`).
+5. **The unreachable IP-change branch in `ValidateHostIpUpdate`.**
+6. **The blind `catch {}` around the DataProtectionKeys probe** (`Program.cs:105-109`).
+7. **C20 — the Azure reconcile check/act window**, documented in-file at
+   `SubnetController.AzureReconcile.cs:98-110`. H1 is **not** this: in both H1 reproductions the
+   archived subtree matched `DescendantSubnetIds` exactly, so C20's own stated closure would not catch
+   it.
+
+## Carried forward from rounds 4-7
+
+- **The unreachable IP-change branch in `ValidateHostIpUpdate` is the one place applying the
+  network/broadcast reservations without the `cidr < 31` guard** the other two sites carry. A trap for
+  whoever makes that field editable.
+- **`GlobalSanitizationFilter` runs after model binding and validation.** Any new `[Sanitize*]`
+  attribute needs a matching validator.
+- **`MockAzureService.DefaultConfirmation` is `Deleted`.** Any test touching the confirmation path must
+  set the verdict explicitly.
+- **Still no `WebApplicationFactory`, no integration host, no JS test harness.** Most of this round's
+  findings are in that category. **"There is no test for this" is not a finding** — that shape has been
+  refuted in four consecutive rounds.
+- **Migration `.Designer.cs` snapshots contain old column widths on purpose.** Correct and frozen.
+- **A real Azure tenant ID is committed** at `Properties/launchSettings.json:41`. Not a credential.
+- **The equality-vs-membership prefix check on the VNet-resource-id stamp in
+  `SubnetController.Azure.cs`** — deliberately not implemented in round 6 (it needs an ARM read inside
+  a transactional write). H2's optional server-side hardening is a *string* test, not this.
+- **The bulk import reads only a multi-prefix Azure subnet's first prefix.** Closing it means creating
+  several Bastet subnets from one Azure subnet — a feature change. The prefix list is already carried
+  on the inventory view model.
+- **`findOptimalCidr`'s loop bound**, the `site.js` consolidation of the CIDR→mask copies, and the
+  per-prefix "already imported" sentence — all deliberately left.
+- **`AnnotatePrefix` cannot return `AlreadyImported`** — established over 4,046 brute-forced planner
+  outcomes.
+- **The usable-IP calculation's three copies agree at every CIDR 0-32.** The drift is in the CIDR→mask
+  copies: six across four files, two fixed by F16.
+- **Three cheap test gaps, each with a free fix**: a `SubnetDeleted` case for `IsAbsenceStatus`; E4's
+  five call-site orderings; E9's `Count > 1` boundary. **Watch-list items, not findings.**
+- **`DeletedSubnets` does not archive `AzureResourceId` or `IsFullyAllocated`**, the deleted-subnets
+  table renders neither `Tags` nor `OriginalParentId`, and there is **no restore path anywhere in the
+  app**. Confirmed again this round from the live schema. **H1, H2, H3 and H4 all depend on this** — it
+  is what makes each of them unrecoverable.
+- **`AZURE_TOKEN_CREDENTIALS=dev`, which the launch profiles set, excludes `EnvironmentCredential`.**
+- **`success` is not uniform across the Azure AJAX endpoints.** `/Azure/BulkGetVNets` reports an Azure
+  read failure as `success:false`; `/Azure/ReconcileScan` reports the same failure as `success:true`
+  with the reason inside the plan. Both conventions coexist deliberately.
+- **`pkill -f "Bastet.dll"` kills every instance on the box.** Match on `ASPNETCORE_URLS` or a PID.
+- **Headless Chromium never ticks `requestAnimationFrame`**, so jQuery's fx queue never drains and
+  every animation assertion is a false pass unless `window.requestAnimationFrame` is deleted first.
+- **Three CodeQL log-forging alerts are open on `main` and are expected to stay open.** True positives
+  resolved by a mechanism CodeQL cannot see (the sanitizing console formatter).
+- **F15 / the migration lock.** The lock opens the configured catalog first and falls back to `master`
+  only on SQL 4060. **Do not propose re-applying an unconditional `master` scope.** The documented
+  mid-bootstrap mixed-scope window is accepted. H5 narrows the *fallback*, it does not widen the scope.
+- **ARM ids are path-based and survive delete-and-recreate.** Measured twice; the "but recreate breaks
+  it" objection to G1's fix is empirically false.
+- **`GetVNetInventory` was 1+N by construction** — G3 removed the per-VNet call.
+  `GetCompatibleSubnets` still has the 1-call shape by design, and H2 records what that costs in
+  latency.
+- **The queued-writer connection-pool amplification (G5) is closed by the gate, but `Max Pool Size` is
+  still unset anywhere in the repo, README or appsettings.**
+- **`Logging__LogLevel__*` outranks every `BASTET_LOG_LEVEL_*` knob.** Measured; the README says so.
+- **`SaveTokens = true` has no scope gate.** Why G7 needed `OnTicketReceived` and not just the scope
+  deletion.
+- **The DataProtection key ring is persisted unencrypted in the application database** (accepted;
+  `Program.cs:115-120`, confirmed by the startup warning *"No XML encryptor configured"*).
+- **`HostIpController.DeletedHostIps(int subnetId)` does exist**, on route
+  `HostIp/DeletedHostIps/{subnetId}`; without an id it binds `subnetId = 0` and returns `NotFound()`.
+  Round 7's note to the contrary was wrong, and correcting it is documentation, not a finding.
+- **Round-7 line-number citations have already moved**, and round-8's will move again. Re-derive every
+  line before citing it.
+- **Still open, deliberately (carried from round 7's sweep):** eleven controller sites `RedirectToAction`
+  to `/Error/{code}` rather than answering the status at the requested URL, so the original URL is
+  replaced and the client pays a round trip. Answering in place would touch five controllers. Not
+  filed this round either.
+
+## New in round 8
+
+- **Entry gates are not row invariants.** A `Blocked` bulk-planner row, a refused
+  `GET /Azure/Import/{id}` (*"Subnet must not have any child subnets or host IP assignments"*), and a
+  hidden Import-from-Azure button are all **expected** on any correctly imported subnet, because every
+  single-VNet import creates children under its target. Do not read any of them as evidence of
+  corruption. This is what killed the one refuted candidate.
+- **The single-VNet import write path enforces none of the three wizard-entry preconditions directly.**
+  Not just "already has children": a **fully allocated** target is also renamed and Azure-linked when
+  the batch carries a `FullyEncompassesVNetPrefix` entry, reproduced live. The host-IP and
+  fully-allocated refusals for an *ordinary* batch come from `ValidateSubnetCreation` acting on the
+  children being created, not from any test of the target. Any future round re-deriving an "asymmetry"
+  here should stop at this bullet.
+- **EF Core's `SqlServerDatabaseCreator.Exists()` misreads SQL 4060 the same way `Program.cs:305`
+  does.** Any fix at `:305` must abort startup; one that logs and continues is overruled at `:371`.
+- **`Program.cs:319-324`'s crafted `InvalidOperationException` is effectively unreachable on SQL
+  Server**, because `guest` holds `CONNECT` in `master` and cannot be disabled there. It fires only for
+  an Azure SQL contained user with no login in `master` — where its advice is at least right.
+- **The purge POST does not require the confirmation page at all.** Antiforgery tokens are per-session,
+  so a token harvested from `/Subnet/Create` drives `/Subnet/PurgeAllDeletedSubnets` to completion. The
+  ceremony is neither scoping nor gating. (H4 fixes the scoping half; the rest is by design.)
+- **Round 6's clean bill already recorded the purge lock gap** (*"the only unguarded writes are archive
+  table purges"*) **and left it — correctly.** Adding `ExecuteWithSubnetLockAsync` there was built and
+  measured to make one currently-correct ordering wrong. Do not re-file the lock gap.
+- **jQuery 4.0.0 dispatches an aborted request's `error` and `complete` handlers synchronously inside
+  `.abort()`.** Measured on the live pages. Any `.abort()`-based staleness interim in this codebase is
+  therefore **placement-sensitive**: called before the new `$.ajax`, the new `beforeSend` undoes the
+  paint and nothing shows; called from inside `beforeSend`, it leaves *"Error connecting to server:
+  abort"* on screen. Add `if (status === "abort") { return; }` to be placement-independent.
+- **The same click-time-versus-response-time split exists in `loadVNets`** —
+  `_BulkScripts.cshtml:104-105` (set on the click) versus `:137` (set from the response). Not filed:
+  the rendered tree and the `vnets` array come from the same response, so only the subscription
+  **label** can disagree, and the planner merely copies `SubscriptionId` onto the plan view model.
+- **`/Azure/BulkImportPreview` latency scales with `existing x selected`**, measured at roughly
+  0.06 ms per (selected prefix x 1 000 existing subnets): 39 ms at 20 000 subnets / 1 prefix,
+  **7 247 ms** at 200 000 / 600. Relevant to H3, and to anyone sizing a large deployment.
+- **`_StepConfirm.cshtml` has no warnings block.** `#rec-scan-warnings` exists only in
+  `_StepReview.cshtml:23`, so any scan warning — including *"withheld from deletion"* — never reaches
+  the screen that performs the archive. Worth fixing alongside H1 regardless of which H1 interim is
+  taken.
+- **After H6's fix, `_SubnetCalculationScripts.cshtml:151-155` has no remaining visitor**, because no
+  numeric input reaches it (46-input census across three topologies). It is defence-in-depth for a case
+  `findOptimalCidr` currently makes impossible — **do not tidy it away**.
+- **Rig hazard, not a product defect:** three VNets in `bastet-visible` now share the prefix
+  `10.20.0.0/16` (`rig-vnet-alpha`, `rig-uip2-twin`, `rig-regressp2-dup`) because sibling agents
+  created fixtures. Convenient for H2, but a later round reading `10.20.0.0/16` in a transcript should
+  not assume it means `rig-vnet-alpha`.

--- a/docs/AUDIT-FINDINGS-8.md
+++ b/docs/AUDIT-FINDINGS-8.md
@@ -156,118 +156,50 @@ _Test count 677 → 683 (+6). `dotnet build --no-incremental` 0 warnings, 0 erro
 
 ## H2 [x2] — Single-VNet import wizard has no staleness guard on `loadSubnets`, so an out-of-order response posts one VNet's subnets under another VNet's identity
 
-**Citation.** `src/Bastet/Views/Azure/Import/_ImportScripts.cshtml:250` (`loadSubnets`' `success`
-handler), against `:61-62` (identity written synchronously on click) and `:224` (`loadSubnets` keeps
-no token and no jqXHR).
+_H2 is fixed and committed. `loadSubnets` now takes a sequence number from a module-level
+`subnetSeq`, and **all three** jQuery callbacks return early when they are not the newest request:
+`success` so a superseded response cannot repaint rows under the current VNet's identity, `error` so a
+superseded transport failure cannot paint "Error connecting to server:" over a valid list, and
+`complete` so it cannot hide the spinner of a request still in flight. The accepted `success` also
+writes `#vnet-name` and `#vnet-resource-id` from its own arguments, so the identity always comes from
+the response that populated the rows rather than from the click that started it. `:61-62` were left in
+place, as the finding allows — `beforeSend` hides `#subnet-selection`, so the form is unreachable
+between the click and the accepted response, and what actually fixes the defect is the accepted
+response writing the identity._
 
-**Confidence.** Confirmed.
+_The finder's fix was taken with the verifier's correction, which was right: guarding `success` alone
+leaves both other legs reachable, and the `error` leak is not theoretical — it reproduced here on the
+first attempt. The `.abort()` interim was **not** taken. It is placement-sensitive against the pinned
+jQuery 4.0.0 (the aborted request's handlers run synchronously inside `.abort()`), so it is correct
+only at one exact call site or with an extra `status === "abort"` line; the sequence guard is the same
+size, needs no such caveat, and is what the reconcile wizard already does. The optional server-side
+prefix check was also not taken: it is a different finding's territory, sits on the watch list as a
+deliberate round-6 decision, and would need a conditional for the documented plain-JSON caller._
 
-**Scenario.** `#select-vnet-btn` writes the hidden `vnetName` / `vnetResourceId` fields synchronously
-at `:61-62` and then calls `loadSubnets(selectedVNetId)` at `:63`. The `success` handler at `:250`
-empties and rebuilds `#subnet-list` (`:254-255`) with **no** comparison against the currently selected
-VNet, and `/Azure/GetSubnets` does live per-VNet ARM reads, so latency varies.
-
-An admin on a Bastet subnet whose prefix is shared by two Azure VNets — a topology the source itself
-contemplates (*"Two VNets in one subscription may share a prefix"*,
-`SubnetController.Azure.cs:331-332`) — picks VNet A, goes back via the still-enabled step-2 pill,
-picks VNet B, and gets **A's subnet rows repainted over B's identity** when A's response lands last.
-`Views/Azure/Import/_SubnetList.cshtml` prints no VNet name on step 3, so nothing on screen
-contradicts it.
-
-Ticking a row and pressing Import posts children stamped with A's ARM ids alongside B's
-`vnetName`/`vnetResourceId`. The server accepts it — no site compares a child's `AzureResourceId`
-against `vnetResourceId`; the child stamp is a straight copy at `SubnetController.Azure.cs:409` — and
-reports success. The resulting row is unrepairable: the wizard refuses re-entry, G1 refuses a crafted
-relink, `Edit` cannot bind the column, and `DeletedSubnets` does not archive it. If the wrongly
-stamped VNet is later deleted in Azure, reconcile archives the parent **and its whole subtree**,
-including children that are alive in the other VNet.
-
-**Reproduction.** Live app on 127.0.0.1:5403, catalog `bastet_audit_203`, headless Chromium, real ARM,
-**no proxy and no injected delay** — the superseded response landed last on natural latency alone:
+_Verified in real Chromium against the live app on 127.0.0.1:5812, SQL Server 2022, real ARM, with two
+Azure VNets deliberately sharing `10.20.0.0/16` (`rig-h2-alpha` with three subnets, `rig-h2-twin` with
+one) and a hand-made Bastet subnet on the same prefix. Only the **arrival order** is manipulated —
+`page.route` fetches the live app's own bytes for request #1, holds them 5 s, then fulfils; request #2
+passes straight through. Async, so both are genuinely in flight._
 
 ```
-trial 2: resp-order=[(1.431,'rig-uip2-twin',200),(1.512,'rig-vnet-alpha',200)]
-         rows=['rig-snet-alpha-web','-app','-data','-import-only'] hidden vnetName='rig-uip2-twin' STALE=True
-...
-DELAY=0.0  trials=8  stale-repaints=5
+                              unfixed (ff285cf)                          fixed
+A superseded response last    rows alpha-web/app/data, identity          rows twin-only, identity
+                              'rig-h2-twin'   STALE_REPAINT=True         'rig-h2-twin'   False
+B superseded request fails    errorPanel True, "Error connecting         errorPanel False
+                              to server: " over valid twin rows
+C control, one pick           3 alpha rows, identity 'rig-h2-alpha'      identical
+page errors                   []                                        []
 ```
 
-Carried through to the write (again unmanipulated). Captured `POST /Subnet/BatchCreateChildSubnets`,
-URL-decoded:
+_The description each imported child carries still reads `selectedVNetName`, the click-time closure
+variable. Checked rather than assumed: `loadSubnets` is called from exactly one place, so under the
+guard the newest request is always the newest click and the two agree. Left alone to keep the change
+to the defect._
 
-```
-parentId=1  vnetName=rig-uip2-twin  isAzureImport=true
-vnetResourceId=.../virtualNetworks/rig-uip2-twin
-subnets[0].Name=rig-snet-alpha-web  subnets[0].NetworkAddress=10.20.1.0  subnets[0].Cidr=24
-subnets[0].Description=Imported from Azure VNet: rig-uip2-twin
-subnets[0].AzureResourceId=.../virtualNetworks/rig-vnet-alpha/subnets/rig-snet-alpha-web
--> 302 /Subnet/Details/1
-   "Successfully renamed parent subnet to 'rig-uip2-twin' and imported 1 child subnets."
-```
-
-Database (`bastet_audit_203`):
-
-```
-1 | rig-uip2-twin      | 10.20.0.0/16 | parent=- | arm=.../virtualNetworks/rig-uip2-twin
-2 | rig-snet-alpha-web | 10.20.1.0/24 | parent=1 | arm=.../virtualNetworks/rig-vnet-alpha/subnets/rig-snet-alpha-web
-```
-
-All three candidate correctors checked and silent: `POST /Azure/ReconcileScan` on the corrupted tree
-returned `items:[] reviewItems:[] warnings:[] canCommit:false` (both ARM ids exist, so the app's own
-consistency checker says nothing); `GET /Azure/Import/1` now 302s away with *"Subnet must not have any
-child subnets or host IP assignments"*; a crafted relink POST was refused by G1
-(`SubnetController.Azure.cs:338-350`).
-
-Window width, measured to bound severity: with a 1.5 s human-paced pause between the two clicks,
-**0 hits in 6** — `GetSubnets` answers in ~200 ms here, so the window is roughly the latency
-difference. `AzureService.GetCompatibleSubnets` still issues `vnetResource.Get()` **plus** a full
-`GetSubnets()` enumeration per VNet (the shape G3 deliberately left), so a VNet with hundreds of
-subnets, or a 429 with SDK retry backoff, puts it in multi-second territory.
-
-**Fix.** *The finder's fix was corrected as incomplete: it guarded `success` only.* The `error`
-handler (`:323-326`) and `complete` (`:327-329`) stay unguarded, so a superseded request that fails at
-the transport paints *"Error connecting to server: …"* over the current VNet's correctly rendered
-rows, and its `complete` hides `#subnet-loading` while the current request is still in flight.
-
-```js
-let subnetSeq = 0;
-function loadSubnets(vnetResourceId, vnetName) {
-    const seq = ++subnetSeq;
-    $.ajax({
-        url: '@Url.Action("GetSubnets", "Azure")',
-        type: "GET",
-        data: { vnetResourceId: vnetResourceId, subnetId: @Model.SubnetId },
-        dataType: "json",
-        beforeSend: function () { /* unchanged, incl. G10's reset */ },
-        success: function (result) {
-            if (seq !== subnetSeq) { return; }          // superseded - drop it
-            $("#vnet-name").val(vnetName);              // identity comes from the response
-            $("#vnet-resource-id").val(vnetResourceId); // that populated the rows
-            /* ...existing body... */
-        },
-        error: function (xhr, status, error) { if (seq !== subnetSeq) { return; } /* ...existing... */ },
-        complete: function () { if (seq !== subnetSeq) { return; } $("#subnet-loading").hide(); }
-    });
-}
-```
-
-with `:63` becoming `loadSubnets(selectedVNetId, selectedVNetName)`. `:61-62` may stay — `beforeSend`
-hides `#subnet-selection`, so the form is unreachable between the click and the accepted response;
-what fixes the defect is the **accepted response** writing the identity fields.
-
-**Cheaper interim:** retain the jqXHR and `.abort()` the previous one **at the very top of
-`loadSubnets`, before the new `$.ajax` call**. Verified against the pinned jQuery 4.0.0: the aborted
-request's handlers are dispatched synchronously inside `.abort()`
-(`['--about to call abort()--','error(abort)','complete','--abort() returned--']`), so the new
-request's `beforeSend` undoes them in the same task and nothing is painted. Placing the abort inside
-`beforeSend` instead reverses the order and leaves the red banner up — the interim is only correct as
-written, or with `if (status === "abort") { return; }` as the first line of `error`.
-
-**Optional defence-in-depth (not the finder's, and not the round-6 F1 check that was declined):** when
-`vnetResourceId` is supplied, require every child `AzureResourceId` to start with
-`vnetResourceId + "/subnets/"` (`OrdinalIgnoreCase`) and reject otherwise. Pure string test, no ARM
-round trip. It must be conditional on `vnetResourceId` being non-empty, because the documented plain
-JSON caller may post `AzureResourceId` without one.
+_Test count unchanged at 683 — there is no JS test harness in this repo, which the watch list already
+records, so the verification is the browser run above. `dotnet build --no-incremental` 0 warnings,
+0 errors._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-8.md
+++ b/docs/AUDIT-FINDINGS-8.md
@@ -1,16 +1,56 @@
 # Bastet — Round-8 Audit Findings
 
-| | |
-|---|---|
-| Round | **8** (finding letter **H**) |
-| Target branch | `audit/round-8` |
-| Baseline HEAD | `ff285cf` — *"Audit 7 Cleanup (#150)"*, identical to `main` |
-| Build at baseline | `dotnet build --no-incremental` → 0 warnings, 0 errors |
-| Tests at baseline | `dotnet test` → **677 passed, 0 failed, 0 skipped** |
-| Working tree | clean at start and at finish |
-| Date | 2026-07-28 |
+| | Audit | After reconciliation |
+|---|---|---|
+| Round | **8** (finding letter **H**) | |
+| Branch | `audit/round-8` | one commit per finding |
+| HEAD | `ff285cf` — *"Audit 7 Cleanup (#150)"*, identical to `main` | |
+| Build | 0 warnings, 0 errors | **0 warnings, 0 errors** (clean rebuild, `bin`/`obj` deleted) |
+| Tests | 677 passed, 0 failed, 0 skipped | **690 passed, 0 failed, 0 skipped** (+13) |
+| Working tree | clean at start and at finish | clean |
+| Date | 2026-07-28 | 2026-07-29 |
 
 Every line number below was re-derived against the working tree at `ff285cf` while writing this file.
+
+**All seven findings were fixed — none was refuted on re-verification.** Each was reproduced against
+the unfixed build before being fixed and re-measured after, one commit per finding, each carrying its
+own struck entry. Two proposed fixes were rejected on evidence and replaced: H4's global subnet lock
+(measured to make a currently-correct ordering wrong) and H5's `DB_ID` probe (blind under
+`DENY VIEW ANY DATABASE`, and the wrong SQL type). Four more were extended from the finder's version
+after the verifiers found them incomplete.
+
+## Final verification sweep
+
+| | |
+|---|---|
+| Clean rebuild | `bin`/`obj` deleted, `dotnet build --no-incremental` → **0 warnings, 0 errors** |
+| Suite | **690 passed**, 0 failed, 0 skipped (677 baseline + 13) |
+| Live app | 28 assertions over subnet list, details, create, edit, delete, host IPs, all-host-IPs, deleted subnets, all-deleted-host-IPs, both purge pages, all three Azure wizards, 404 and 500 — **content asserted, not just status** |
+| Security headers | `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy` present on a normal response **and** on `/Error/500` |
+| Azure end to end | 10 assertions against live ARM: subscriptions → discovery → single-VNet import → bulk preview and commit with a child subnet → reconcile scan → delete commit |
+| Reconciler discriminates | a resource the credential **cannot see** is withheld with a warning naming it; a **genuinely deleted** resource is still offered and deletable. Both checked — testing only the first would let an over-blocking regression pass |
+| Logs | **zero `fail:` lines.** Warnings all accounted for: the accepted unencrypted DataProtection key ring; EF's `QuerySplittingBehavior` and MARS-savepoint notices (both pre-existing); and `AzureService` logging a 403 on the withheld resource, which is the withholding path working by design |
+
+Two sweep observations that are **not** defects, recorded so a later round does not re-derive them:
+`GET /Azure/Import/{id}` 302s away for a subnet carrying host IPs — the documented entry gate — and a
+`WebRootPath was not found` warning appears only when the published app is launched with its working
+directory set elsewhere; run from its own publish directory the warning is absent and `/css/site.css`
+and `/js/site.js` serve 200.
+
+## Deliberately not done
+
+- **The global subnet lock on the two purge POSTs** (H4's originally proposed fix). Built, run and
+  measured unsound by both verifiers and again here; round 6 had already left it deliberately.
+- **A warnings block in `_StepConfirm.cshtml`** (H1). A real gap, still on the watch list, but a
+  separate change to a view H1 does not touch — and with the cascade guard no withheld row reaches
+  that screen.
+- **The server-side VNet-prefix check on child `AzureResourceId`s** (H2's optional hardening) and
+  **naming the pending link in the bulk preview's `ExactMatch` branch** (H7's optional extra). Both
+  are separate calls; the second is explicitly deferred by the finding itself.
+- **Tidying away `_SubnetCalculationScripts.cshtml`'s overlap arm**, which H6's fix leaves with no
+  reachable input. It is defence-in-depth for a case `findOptimalCidr` currently makes impossible.
+- **The purge POST not requiring its confirmation page at all.** Antiforgery tokens are per-session;
+  the watch list records this as by design, and it is a different question from scoping.
 
 ---
 

--- a/docs/AUDIT-FINDINGS-8.md
+++ b/docs/AUDIT-FINDINGS-8.md
@@ -255,107 +255,54 @@ the verification. `dotnet build --no-incremental` 0 warnings, 0 errors._
 
 ## H4 [x1] — "Purge All" ignores the scope its own confirmation page states: the POST round-trips nothing and deletes whatever exists at execution time
 
-**Citation.** `src/Bastet/Controllers/SubnetController.Delete.cs:299` (`ExecuteDeleteAsync`), with the
-GET at `:275-284` and the view text at `Views/Subnet/PurgeAllDeletedSubnets.cshtml:17`. Twin:
-`src/Bastet/Controllers/HostIpController.cs:617`, GET at `:593-602`.
+_H4 is fixed and committed by bounding the purge to the set the confirmation page counted, which is
+the finding's own promoted interim. Both view models carry a `MaxId`, both GETs read
+`MaxAsync(d => (int?)d.Id) ?? 0` into it, both views post it back as a hidden `confirmedMaxId`, and
+both POSTs delete `Where(d => d.Id <= confirmedMaxId)`. The parameter binds as `int?` and a missing or
+non-positive value is **refused** with an error and a redirect to the confirmation page, rather than
+binding 0 and reporting a cheerful "Permanently purged 0 record(s)" — the trap one verifier fell into
+by accident. Both twins were changed together; they had already drifted once._
 
-**Confidence.** Confirmed — for the reframed defect. *The finding as filed blamed the missing global
-subnet lock; that mechanism is refuted (see the fix, and the reproduction below with zero
-concurrency). The defect does not depend on it.*
+_**The finding's originally proposed fix was not applied, and must not be.** Wrapping the two POSTs in
+`ExecuteWithSubnetLockAsync` was built, run and measured unsound by both verifiers: it prevents
+nothing, because the loss needs no concurrency at all, and it converts the one ordering HEAD already
+handles correctly into total loss by parking a purge behind an entire delete. Round 6's clean bill had
+already noticed the same unguarded purge and left it deliberately. The watch list carries this;
+nothing here should be read as re-opening it._
 
-**Scenario.** The POST's whole signature is `PurgeAllDeletedSubnetsConfirmed(string confirmation)`.
-Nothing from the GET is round-tripped, so the delete is unbounded, while the page the operator typed
-`approved` into says *"You are about to permanently delete **1** archived subnet record(s). After
-purging, these records will be gone forever — there is no recovery."*
+_The alternative interim — posting the rendered `Count` back and refusing on any change — was also not
+taken. It refuses work the operator can legitimately do, where the bound simply does the right amount
+of it, and the bounded `DELETE` is a clustered-index seek that never touches the uncommitted tail._
 
-**One admin, one session, two tabs, zero concurrency.** Tab 1 opens
-`/Subnet/PurgeAllDeletedSubnets`, which renders `permanently delete <strong>1</strong> archived subnet
-record(s)`. In tab 2 the same admin (or a Delete-role colleague) deletes `10.50.0.0/16` and its 10
-children, archiving 11 more rows. **Five seconds later** tab 1 submits the form it already had open:
-12 archive records destroyed, banner *"Permanently purged 12 deleted subnet record(s)"*, and the
-deleting tab's own success banner promised an archive that no longer exists.
+_Soundness of the bound, unchanged from the finding and re-checked: production is SQL Server only
+(`Program.cs` uses `UseSqlServer` on both paths), `Id` is `IDENTITY`, and `DELETE` — unlike
+`TRUNCATE` — never reseeds it, so any row archived after the GET necessarily has a higher `Id`._
 
-**Reproduction.** HEAD build, SQL Server 2022, catalogs `bastet_audit_207` / `bastet_audit_607`.
-Sequential, no overlap at all:
-
-```
-BEFORE:                Subnets=11 DeletedSubnets=1
-tab-1 page said:       permanently delete <strong>1</strong> archived subnet record(s)
-tab-2 delete HTTP=302  Subnets=0  DeletedSubnets=12
-(sleep 5)
-tab-1 purge  HTTP=302  banner: Permanently purged 12 deleted subnet record(s)
-FINAL:                 Subnets=0  DeletedSubnets=0
-```
-
-At 900 children the page said `1` and 902 rows were destroyed. Host-IP twin, same shape: page said
-`permanently delete 1 archived host IP record(s)`, another tab archived 4, five seconds later the
-stale form reported *"Permanently purged 5 deleted host IP record(s)"*.
-
-Second, concrete consequence: `HostIpController.cs:522` loads `DeletedSubnets` so
-`/HostIp/AllDeletedHostIps` can name the subnet each archived IP belonged to. Purging the subnet
-archive blinds the host-IP archive:
+_Verified live first, on the unfixed build, with the finding's own sequence — one admin, two tabs,
+zero concurrency, five seconds apart — then again on the fixed build:_
 
 ```
-before purge:  3 rows render "net-b (deleted)"  10.61.0.0  /24
-after purge:   3 rows render "Unknown"          "Unknown"  cidr 0
+                              unfixed (ff285cf)            fixed
+page promised                 1                            1
+hidden confirmedMaxId         absent - unbounded           1
+tab 2 archives 11 more        DeletedSubnets=12            DeletedSubnets=12
+tab 1 submits its open form   "Permanently purged 12"      "Permanently purged 1"
+DeletedSubnets remaining      0                            11
 ```
 
-No live data is touched, no corruption occurs (`DeletedSubnets` after each of eight runs was only ever
-0, 901 or 902 — never partial), and both sides are admin-gated; hence **low**. It is not info, because
-data really is destroyed unrecoverably (there is no restore path anywhere in the app, so the archive
-is the only record that a subnet existed, who deleted it and when) and the app itself already gates
-the same operation on the same count one HTTP request earlier — `GET` with an empty archive 302s away
-with *"There are no deleted subnet records to purge."*
+_Seven tests were added (`PurgeAllScopeTests`), covering both archives: the bounded purge leaves
+later-archived rows alone, a scope-less POST refuses and destroys nothing (`null`, `0`, `-1`), and the
+ordinary unchanged case still purges everything. They are load-bearing, proved the way the skill
+prescribes — in a scratch copy with **only** the `Where` bound reverted and the parameter kept, the two
+scope tests fail and the rest pass. The suite runs on SQLite, where a plain `INTEGER PRIMARY KEY`
+reuses the top rowid after a delete, so every assertion is about rows inserted while the archive is
+non-empty and never about IDs surviving a purge — the caveat the finding raised._
 
-**Fix.** *The finder's fix — wrapping both POSTs in `ExecuteWithSubnetLockAsync` — was built, run and
-measured **unsound**, independently by both verifiers. Do not add the lock.* It prevents nothing (the
-loss above needs no concurrency) and it converts the one ordering HEAD handles **correctly** into
-total loss:
+_Not addressed, and deliberately: that the purge POST does not require the confirmation page at all,
+since antiforgery tokens are per-session. That is on the watch list as by design, and it is a
+different question from scoping._
 
-```
-(HEAD,         purge at +109ms)  waited   12ms -> DeletedSubnets=901  B: "purged 1"
-(PATCHED-LOCK, purge at +108ms)  waited 1185ms -> DeletedSubnets=0    B: "purged 902"
-```
-
-A purge issued before the archive inserts finishes first and takes exactly the records the page
-promised; the lock parks it behind the entire delete.
-
-Bound the delete to the set the operator was shown — the finder's own cheaper interim, promoted to the
-fix:
-
-- `Models/ViewModels/PurgeAllViewModels.cs`: add `public int MaxId { get; set; }` to both view models.
-- GET: `int maxId = await context.DeletedSubnets.MaxAsync(d => (int?)d.Id) ?? 0;` into the model.
-- View: `<input type="hidden" name="confirmedMaxId" value="@Model.MaxId" />`.
-- POST: `PurgeAllDeletedSubnetsConfirmed(string confirmation, int? confirmedMaxId)` →
-  `context.DeletedSubnets.Where(d => d.Id <= confirmedMaxId).ExecuteDeleteAsync()`. Same for
-  `DeletedHostIpAssignments`.
-- Bind it as `int?` and re-render the confirmation when it is null or `<= 0` — otherwise a POST
-  without the field silently reports *"Permanently purged 0 deleted subnet record(s)"* and does
-  nothing. (One verifier hit this by accident.)
-
-Soundness of the bound: production is SQL Server only (`Program.cs:72` and `:79` are both
-`UseSqlServer`), `Id` is `IDENTITY`, and `DELETE` — unlike `TRUNCATE` — never reseeds it, so any row
-archived after the GET necessarily has `Id > MaxId`. Measured on the patched build:
-
-```
-purge at +108ms  confirmedMaxId=10825  waited 22ms -> DeletedSubnets=901  B: "purged 1"
-purge at +458ms  confirmedMaxId=11727  waited 13ms -> DeletedSubnets=901  B: "purged 1"
-sequential       confirmedMaxId=12629             -> DeletedSubnets=901  B: "purged 1"
-```
-
-Free side effect visible in those timings: the bounded `DELETE` is a clustered-index seek that never
-touches the uncommitted tail rows, so the purge stops blocking (13-22 ms versus 285-696 ms).
-
-**Cheaper interim, no schema or view-model change, and it keeps "Purge All" meaning all:** post the
-rendered `Count` back as a hidden field and refuse when
-`await context.DeletedSubnets.CountAsync() != confirmedCount`, redirecting to the GET with *"the
-archive changed since this page was rendered — review and confirm again."* Rows are only ever **added**
-to these two tables outside the purge itself, so count equality is a reliable optimistic check.
-
-`grep -rn "PurgeAll" test/` returns 0 hits, so there is no test fallout. **Caveat for whoever writes
-the regression test:** the suite is SQLite, where a plain `INTEGER PRIMARY KEY` reuses the highest
-rowid after the max row is deleted, so a SQLite test must not assume monotonicity across a purge —
-assert on rows inserted while the archive is non-empty.
+_Test count 683 → 690 (+7). `dotnet build --no-incremental` 0 warnings, 0 errors._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-8.md
+++ b/docs/AUDIT-FINDINGS-8.md
@@ -367,97 +367,52 @@ round trip on a path that already opened a connection._
 
 ## H6 [x2] — G11's branch reorder makes a cleared CIDR field in the Details Create-Subnet modal report a non-existent overlap
 
-**Citation.** `src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml:142` (the range arm
-that fails to catch `NaN`). The wrong text is written at `:154-155`; the comment that states the
-opposite of what the code does is at `:145-146`.
+_H6 is fixed and committed with the one-token change the finding proposes, verified sound:
+`isNaN(cidrValue) ||` added to the range arm at `_SubnetCalculationScripts.cshtml`, so a cleared or
+non-numeric CIDR box gets the objection the operator can act on instead of a claim that it collides
+with a sibling._
 
-**Confidence.** Confirmed.
+_The comment above the arm was rewritten rather than deleted, which the finding is right about and
+which is the only place the fix departs from a pure one-token diff: after the change the comment's
+**conclusion** ("a cleared field lands here") becomes true, but its stated **mechanism** — "every
+comparison is false", offered as the reason it lands here — remains exactly backwards, because that is
+precisely why it did **not** land here. The new wording says why `isNaN` has to be tested explicitly._
 
-**Scenario.** Open `/Subnet/Details/1` for a parent `10.0.0.0/16` with one child `10.0.0.0/18`, click
-the Unallocated Ranges "Create Subnet" button (network `10.0.64.0`, prefilled CIDR 18), then **clear
-the CIDR box** — or type any non-numeric text into it. `#cidrInput` is `<input type="number">`, so the
-element value is `''` and `parseInt('')` is `NaN`. `NaN < minCidr` and `NaN > maxCidr` are both false,
-so the range arm at `:142` is skipped and control falls to the `else` at `:151`, which since `ff285cf`
-is the **overlap** arm.
-
-Actual wrong output, observed: `#cidrValidationFeedback` = *"This CIDR would create a subnet that
-overlaps with existing subnets."* with computed `display: block` (visible, not merely in the DOM), and
-`#subnetSizeDisplay` = *"Invalid - Would overlap"* — while the page's own `wouldOverlap` is false. The
-same output appears on `/Subnet/Details/2`, a subnet with **no children at all**: the page asserts an
-overlap with a set that is empty.
-
-Before `ff285cf` the same input produced *"Please enter a valid CIDR value within the allowed range."*
-/ *"Invalid"*. G11's reorder moved the false sentence off the out-of-range input, which it correctly
-fixed, and onto the empty field.
-
-**Reproduction.** Playwright/Chromium driving the published `ff285cf` build on 127.0.0.1:5402 against
-SQL Server catalog `bastet_audit_202`, fixtures created through the app's own Create form. Real
-keystrokes (`click`, `Control+a`, `Delete`) on the shipped button:
+_Verified in Playwright/Chromium against the published build on 127.0.0.1:5816, SQL Server 2022,
+fixtures created through the app's own Create form, real keystrokes (`click`, `Control+a`, `Delete`)
+on the shipped button. Three topologies — one child, no children at all, two fragmented children — and
+a 46-input census per topology (`''`, `0..40`, `abc`, `-4`, `1e2`, `18.5`)._
 
 ```
-== A. modal just opened ==   rawValue "18"  classes "form-control"  sizeDisplay "16,382"  btn enabled
-== B. field CLEARED ==       rawValue ""    parseInt "NaN"
-                             classes  "form-control is-invalid"
-                             feedback "This CIDR would create a subnet that overlaps with existing subnets."
-                             feedbackDisplay "block"   feedbackVisible true
-                             sizeDisplay "Invalid - Would overlap"   createBtnDisabled true
-== C. typed 5 (minCidr 17) == feedback "Please enter a valid CIDR value within the allowed range."
-== D. typed 18 ==             classes "form-control is-valid"  sizeDisplay "16,382"  btn enabled
-page errors: []
+                          unfixed (ff285cf)                        fixed
+Details/1, field cleared  "This CIDR would create a subnet that    "Please enter a valid CIDR value
+                          overlaps with existing subnets."          within the allowed range."
+                          display block, "Invalid - Would overlap"  display block, "Invalid"
+                          button disabled                           button disabled
+
+census, overlap arm       Details/1  2 inputs: '' and 'abc'        0
+                          Details/2  2 inputs: '' and 'abc'        0
+                          Details/3  2 inputs: '' and 'abc'        0
+census, success arm       17 / 17 / 16                             17 / 17 / 16   <- unmoved
+census, range arm         27 / 27 / 28                             29 / 29 / 30   <- +2, the NaN inputs
+page errors               []                                       []
 ```
 
-The same scripts against a `6a1fe75` worktree published separately: `== B. field CLEARED ==` gave
-*"Please enter a valid CIDR value within the allowed range." / "Invalid"*, and `== C. typed 5 ==` gave
-the overlap sentence. The builds swap exactly. That run also settles the one value not directly
-readable at HEAD: on `6a1fe75` the cleared field does **not** take `else if (wouldOverlap)`, proving
-`wouldOverlap === false` for the `NaN` input — so the overlap claim at HEAD contradicts the page's own
-overlap computation.
+_`Details/2` is the sharpest form and it moved with the rest: that subnet has no children whatsoever,
+so the unfixed page was asserting an overlap against an empty set. No numeric path moves in either
+direction, as it must not — `isNaN(x)` is false for every value `parseInt` can return other than
+`NaN`, and the success arm's count is identical on all three topologies._
 
-A 46-input census (`''`, `0..40`, `abc`, `-4`, `1e2`, `18.5`) across three topologies (1 child, 0
-children, 3 children fragmented) shows the overlap arm is now reached by **exactly two inputs on every
-topology** — `''` and `abc` (an `<input type="number">` reports `value === ''` for non-numeric text, so
-typing letters is a second trigger) — and by no numeric input at all:
+_`abc` is the second trigger for the same reason as the empty string: `#cidrInput` is
+`<input type="number">`, which reports `value === ''` for non-numeric text._
 
-```
-Details/1  OVERLAP-ARM 2 inputs: '' and 'abc'   RANGE-ARM 27   SUCCESS-ARM 17
-Details/2  OVERLAP-ARM 2 inputs: '' and 'abc'   RANGE-ARM 30   SUCCESS-ARM 14
-Details/3  OVERLAP-ARM 2 inputs: '' and 'abc'   RANGE-ARM 27   SUCCESS-ARM 17
-```
+_**The overlap arm was left in place and must stay.** After this fix it has no remaining visitor, and
+the temptation is to tidy it away; it is defence-in-depth for a case `findOptimalCidr` currently makes
+impossible, and the watch list records this. Deleting it would be the exact class of refactor residue
+these audits keep finding._
 
-Nothing is written and `#createSubnetBtn` is correctly disabled in both arms, hence **low**. It is not
-info: it is a false factual assertion, visible, on the main path an operator uses to carve a child out
-of an unallocated range — the identical class of defect G11 itself was accepted for in round 7.
-
-**Fix.** Verified **sound** as filed, applied and measured in a worktree:
-
-```diff
--            } else if (cidrValue < minCidr || cidrValue > maxCidr) {
-+            } else if (isNaN(cidrValue) || cidrValue < minCidr || cidrValue > maxCidr) {
-                 // Range before overlap: a CIDR that is both out of range and overlapping was
-                 // reported as an overlap, which is not the objection the operator can act on.
--                // A cleared field still lands here - parseInt gives NaN, every comparison is
--                // false - and still gets the generic message, as before.
-+                // isNaN is tested explicitly because a cleared field parses to NaN and every
-+                // NaN comparison is false, so the range test alone would drop it through to the
-+                // overlap arm below - claiming a collision with a sibling that need not exist.
-```
-
-Measured on the fixed build: cleared field on `/Subnet/Details/1` and `/2` gives *"Please enter a valid
-CIDR value within the allowed range." / "Invalid"*, button disabled. Census, arm by arm:
-`SUCCESS-ARM 17/14/17` (identical to HEAD), `RANGE-ARM 29/32/29` (HEAD 27/30/27, `+2` = exactly the two
-`NaN` inputs), `OVERLAP-ARM 0` (HEAD 2). **No numeric path moves**, as it must not, since `isNaN(x)` is
-false for every value `parseInt` can return other than `NaN`. `dotnet build --no-incremental` 0
-warnings / 0 errors; `dotnet test` 677 passed.
-
-The comment rewrite is required, and is not quite what the finder proposed: after the fix the
-comment's *conclusion* ("a cleared field lands here") becomes true, but its stated *mechanism* ("every
-comparison is false", offered as the reason it lands here) remains exactly backwards — that is why it
-did **not** land here. Reword as above rather than deleting.
-
-**No cheaper interim exists** — this one-token change is already the floor. Note for whoever applies
-it: `:151-155` is already unreachable for every numeric input at HEAD, so the fix removes the arm's
-only visitor. **Do not "tidy" the arm away**; it is defence-in-depth for a case `findOptimalCidr`
-currently makes impossible.
+_Test count unchanged at 690 — no JS test harness exists, per the watch list; the census above is the
+verification. `dotnet build --no-incremental` 0 warnings, 0 errors._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-8.md
+++ b/docs/AUDIT-FINDINGS-8.md
@@ -420,72 +420,44 @@ verification. `dotnet build --no-incremental` 0 warnings, 0 errors._
 
 ## H7 [x2] — Bulk import's commit-success banner never reads `linkedTargets`, so a link-only import reports every count as zero
 
-**Citation.** `src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:588`.
+_H7 is fixed and committed with the one-line change the finding proposes: the commit-success banner in
+`_BulkScripts.cshtml` now renders `linked ${result.linkedTargets} existing target(s) to Azure`, in the
+position that makes its counter order match `TempData["SuccessMessage"]` exactly, so the two summaries
+of one commit agree word for word. `linkedTargets` is always present on the success path, so there is
+no undefined case to guard._
 
-**Confidence.** Confirmed.
-
-**Scenario.** Bastet holds a hand-made subnet `Prod Core 10.20.0.0/16`, no `AzureResourceId`, no
-children. An admin ticks only the VNet prefix `10.20.0.0/16` in the bulk wizard (badge *"Will update
-existing"*), selects no child subnets, leaves rename off, and commits. The server stamps the VNet's
-ARM id onto `Prod Core` and answers
-`{"createdTargets":0,"createdChildSubnets":0,"renamedTargets":0,"linkedTargets":1,"fullyAllocatedTargets":0}`.
-
-`:588` renders *"Bulk import completed. Created 0 VNet target(s), 0 child subnet(s), renamed 0
-target(s), marked 0 target(s) as fully allocated."* — four counters, `linkedTargets` absent.
-`grep -rn "linkedTargets" src/Bastet/Views src/Bastet/wwwroot test/` returns **no hits**. G1 added the
-counter to the JSON response and to the TempData banner, but `:588` is original wizard code
-(`73fc76f2`) that G1 never touched.
-
-**The sharpest form of the wrong output:** re-committing the identical selection now writes nothing
-and returns `linkedTargets: 0` — and `:588` renders **byte-identical text**. The completion screen
-cannot distinguish *"I just stamped an ARM id onto Prod Core"* from *"I did absolutely nothing"*.
-
-**Reproduction.** Headless Chromium against the live app, port 5401, catalog `bastet_audit_201`. Built
-by clicking, not by crafting a post:
+_Verified in headless Chromium against the live app on 127.0.0.1:5817, SQL Server 2022, real ARM,
+built by clicking rather than by crafting a post: a hand-made Bastet subnet `Prod Core` 10.70.0.0/16,
+the Azure VNet `rig-h7-match` on the same prefix, tick only the prefix (badge "Will update existing"),
+no child subnets selected, rename off, commit. Then commit the identical selection a second time,
+which writes nothing._
 
 ```
-TICKING: bulk-prefix-3-0  10.20.0.0/16  "Will update existing"
-CHECKED SUBNET BOXES AFTER TICKING PREFIX: []
-STEP 3 PREVIEW: Exact match Bastet subnet "Prod Core" (10.20.0.0/16) / No child subnets selected.
-COMMIT BUTTON DISABLED: False
-COMMIT BANNER (t+0.11s):
- ' Bulk import completed. Created 0 VNet target(s), 0 child subnet(s), renamed 0 target(s), marked 0 target(s) as fully allocated.'
-COMMIT RESPONSE: {"success":true,...,"createdTargets":0,"createdChildSubnets":0,"renamedTargets":0,"linkedTargets":1,"fullyAllocatedTargets":0}
-CONSOLE: (empty)
+                        unfixed (ff285cf)                        fixed
+link commit banner      "Created 0 VNet target(s), 0 child       "... renamed 0 target(s), linked 1
+                        subnet(s), renamed 0 target(s),           existing target(s) to Azure,
+                        marked 0 target(s) as fully allocated."   marked 0 ..."
+  its response          linkedTargets=1                          linkedTargets=1
+re-commit banner        byte-identical to the above              "... linked 0 existing target(s) ..."
+  its response          linkedTargets=0                          linkedTargets=0
+the two banners         IDENTICAL                                distinct
+after the 2 s redirect  correct sentence, both runs              unchanged
+page errors             []                                       []
 ```
 
-The write landed — `sqlcmd` shows `Prod Core` carrying
-`azid=.../virtualNetworks/rig-regressp2-dup`. Re-posting the same selection returned all counters zero
-and produced identical banner text.
+_The write landed in both runs, confirmed in `bastet_h7`: `Prod Core` carries
+`.../virtualNetworks/rig-h7-match`. That is what makes the unfixed banner wrong rather than merely
+terse — it cannot distinguish "I stamped an ARM id onto your subnet" from "I did nothing", and the
+only plausible reaction to the second reading is to run it again._
 
-**Why info and not low:** `:592-594` schedules an **unconditional** `window.location.href =
-result.redirectUrl` on a 2000 ms timer, and `TempData["SuccessMessage"]`
-(`SubnetController.BulkAzure.cs:324-329`) carries the complete sentence. Measured: banner at t+0.11 s,
-correct sentence on `/Subnet` at t+2.17 s:
+_**The finder's optional extra was deliberately not bundled**, as the finding itself directs: naming
+the pending link in the preview's `ExactMatch` branch is a separate call, and step 2 already says
+"Will import into existing Bastet subnet 'Prod Core'." under a "Will update existing" badge — visible
+in the run above — so the decision point is not uninformed._
 
-```
-POST-REDIRECT alert-success: "Bulk import succeeded: created 0 VNet target subnet(s), created 0 Azure
-child subnet(s), renamed 0 target(s), linked 1 existing target(s) to Azure, and marked 0 target(s) as
-fully allocated."
-```
-
-The only plausible reaction to the wrong banner ("it did nothing, do it again") is a tested no-op: 200,
-all counters zero, no second write, no G1 conflict.
-
-**Fix.** One line, rendering verified in the pinned Chromium:
-
-```js
-` Created ${result.createdTargets} VNet target(s), ${result.createdChildSubnets} child subnet(s), renamed ${result.renamedTargets} target(s), linked ${result.linkedTargets} existing target(s) to Azure, marked ${result.fullyAllocatedTargets} target(s) as fully allocated.`
-```
-
-Counter order then matches `TempData["SuccessMessage"]` exactly, so the two summaries of one commit
-agree. `linkedTargets` is always present on the success path
-(`SubnetController.BulkAzure.cs:338`). No cheaper interim exists — one line is already the floor. It
-touches an inline template literal only, so plain-HTTP and air-gapped hosting are unaffected.
-
-**Do not bundle** the finder's optional extra (naming the pending link in the preview's `ExactMatch`
-branch): step 2 already says *"Will import into existing Bastet subnet 'Prod Core'."* under a "Will
-update existing" badge, so the decision point is not uninformed. Separate call.
+_It touches an inline template literal only, so plain-HTTP and air-gapped hosting are unaffected. Test
+count unchanged at 690 — no JS test harness, per the watch list. `dotnet build --no-incremental`
+0 warnings, 0 errors._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-8.md
+++ b/docs/AUDIT-FINDINGS-8.md
@@ -205,102 +205,49 @@ records, so the verification is the browser run above. `dotnet build --no-increm
 
 ## H3 [x1] — Bulk Azure import commits a plan the operator never saw: the preview pane renders the last response to arrive, Confirm posts the last selection clicked
 
-**Citation.** `src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:447` (`renderPlan(result.plan)`
-in `loadPreview`'s success handler), with `:387` (`lastSelection = selection`, set synchronously on
-the click) and `:543` (`$("#bulk-go-commit-btn").prop("disabled", !plan.canCommit)`).
+_H3 is fixed and committed, the same way and for the same reason as H2: `loadPreview` takes a
+sequence number from a module-level `previewSeq`, and `success`, `error` and `complete` all return
+early when they are not the newest request. A superseded plan can no longer repaint the pane, so
+`#bulk-go-commit-btn` can no longer be re-enabled from a plan the operator is not looking at, and the
+screen and `lastSelection` cannot describe different selections. Nothing server-side changed:
+`BulkCreateFromAzurePlan` re-plans what it is posted and is right to, since it has no way to know what
+was rendered._
 
-**Confidence.** Confirmed. `grep -n "abort\|seq"` over the whole 632-line file returns nothing: no
-sequence token, no retained jqXHR, no `.abort()`. `git log` on the file shows no guard was ever
-removed.
+_Both corrections the verifier made to the finder's fix were taken. Guarding `success` alone leaves a
+stale `error` painting "Error connecting to server:" over a current valid plan, and a stale `complete`
+hiding the spinner of a request still in flight. The `.abort()` interim was rejected for the reason
+recorded under H2 — placement-sensitive against the pinned jQuery 4.0.0 — and the two wizards now
+carry the identical guard, which is the point: they were diverging, and the reconcile wizard's
+`renderPlan`-sets-`lastPlan` arrangement was already correct._
 
-**Scenario.** An admin ticks VNet prefix `10.40.0.0/16` (`rig-vnet-gamma`) and presses *Next:
-Preview*. The preview is slow. Rather than wait they click the **step-2 pill** — which stays enabled
-during a load (`activateTab` never re-disables a visited pill, and `#bulk-back-to-selection-btn` sits
-*inside* `#bulk-preview-content`, which is `d-none` while the spinner runs, so the pill is the only
-route back) — untick gamma, tick `10.31.0.0/16` (`rig-vnet-beta`) with both its subnets and the
-"rename matched" switch, and press *Next: Preview* again.
-
-The second response renders first. The first response then lands and repaints the pane with the gamma
-plan, re-enabling *Continue to Commit* from **gamma's** `canCommit`. The operator approves that
-screen. Confirm Import posts `lastSelection`, which is **beta**.
-`SubnetController.BulkAzure.cs:60-75` re-plans the *posted* selection, finds it internally consistent,
-and commits it. It never sees the rendered plan, so it cannot detect the divergence. Step 4 shows no
-recap.
-
-**Wrong output.** Banner: *"Created 0 VNet target(s), 2 child subnet(s), renamed 1 target(s)"*. In
-`bastet_audit_204` the operator's hand-made `Prod Core 10.31.0.0/16` was **renamed** to
-`rig-vnet-beta` (description still "Hand made by the operator"), **permanently stamped** with
-`AzureResourceId`, and two children created under it. `10.40.0.0/16` — the plan actually on screen —
-was never created.
-
-**Reproduction.** Real Chromium against the live app on 127.0.0.1:5404. The **only** thing forced is
-arrival order: `page.route` on `**/Azure/BulkImportPreview` does `resp = await route.fetch()` (the
-live app answers with its own bytes), sleeps 6 s for request #1 only, then
-`route.fulfill(response=resp)`. Request #2 passes straight through. No source patched, no body
-altered.
+_Verified in real Chromium against the live app on 127.0.0.1:5813, SQL Server 2022, real ARM.
+`rig-h3-gamma` (10.40.0.0/16, no subnets) and `rig-h3-beta` (10.31.0.0/16, two subnets) in Azure, and
+a hand-made Bastet subnet `Prod Core` 10.31.0.0/16. Tick gamma, press Next: Preview, jump back through
+the still-enabled step-2 pill while it loads, tick beta, preview again. Only arrival order is forced:
+`page.route` fetches the live app's own bytes for preview #1, holds them 6 s, then fulfils; preview #2
+passes straight through._
 
 ```
-[t+ 1.53s] CLICK 1: ticked rig-vnet-gamma 10.40.0.0/16, pressing 'Next: Preview'
-[t+ 2.62s] clicked the step-2 pill; step2 pane visible = True     (request still in flight)
-[t+ 2.79s] CLICK 2: gamma unticked; ticked rig-vnet-beta 10.31.0.0/16 + 2 subnets + rename switch
-[t+ 3.08s] SCREEN after response #2: rig-vnet-beta / Exact match "Prod Core" -> rename
-[t+ 7.59s] preview RESPONSE #1 delivered (plan for rig-vnet-gamma)
-[t+10.64s] SCREEN: "New top-level create rig-vnet-gamma (10.40.0.0/16) / No child subnets selected."
-              commit button disabled? False
-[t+10.95s] COMMIT. POST body vNetPrefixes = [rig-vnet-beta 10.31.0.0/16 + mgmt + svc]
-
-1 | rig-vnet-beta      | 10.31.0.0/16 | arm=.../virtualNetworks/rig-vnet-beta | desc=Hand made by the operator
-2 | rig-snet-beta-mgmt | 10.31.1.0/24 | parent=1
-3 | rig-snet-beta-svc  | 10.31.2.0/24 | parent=1
+                       unfixed (ff285cf)                          fixed
+after the stale plan   pane: 'New top-level create rig-h3-gamma   pane: 'VNet "rig-h3-beta" - prefix
+lands                   (10.40.0.0/16) No child subnets            10.31.0.0/16 Exact match Bastet
+                        selected.'                                 subnet "Prod Core"'
+commit button          enabled, from GAMMA's canCommit            enabled, from BETA's canCommit
+Confirm posts          vNetPrefixes=[rig-h3-beta ...]             vNetPrefixes=[rig-h3-beta ...]
+screen vs payload      DIVERGENT                                  agree
+row 1 after commit     Prod Core stamped with beta's ARM id       Prod Core stamped with beta's ARM id
+                       while gamma was on screen; 10.40.0.0/16    - the plan that was reviewed
+                       never created
+page errors            []                                         []
 ```
 
-The ordering premise was then measured **with nothing forced at all**. `/Azure/BulkImportPreview` is
-`GetExistingSubnetsAsync()` plus several O(existing) passes per selected prefix, so latency scales
-with `existing x selected` — 39 ms at 20 000 subnets / 1 prefix, **7 247 ms** at 200 000 / 600. Two
-ordinary requests, heavy preview first, light preview `GAP` seconds later:
+_The write is identical in both columns, which is the whole point: unfixed, that write is the one the
+operator did **not** approve. `Prod Core` carries an `AzureResourceId` permanently either way —
+`DeletedSubnets` does not archive the column and there is no restore path — so the difference between
+the two runs is whether the operator agreed to it._
 
-```
-gap=1.0s -> light finished t+1.24s ; heavy finished t+5.15s   INVERTED=True
-gap=2.0s -> light finished t+2.24s ; heavy finished t+6.69s   INVERTED=True
-gap=3.0s -> light finished t+3.23s ; heavy finished t+5.92s   INVERTED=True
-```
-
-That is literally the "select all, too much, go back and pick one" flow. Separately, 310 concurrent
-preview pairs on a warm small deployment completed **102 out of order**: the application imposes no
-ordering whatsoever. On a small tree the precondition is a transient stall on request #1 — pool wait
-(G5 measured 15 s pool timeouts in this app), a cold load-balanced replica, a DB failover — which is
-exactly what makes an operator abandon the spinner, so the two conditions are correlated.
-
-Contrast, which is what makes this a defect rather than house style: the reconcile wizard sets
-`lastPlan = plan` **inside** `renderPlan` (`_ReconcileScripts.cshtml:205-206`), so its screen and its
-payload always come from one response.
-
-**Fix.** *The finder's fix was corrected as incomplete (it guarded `success` only) and its interim was
-corrected as placement-dependent.* A stale `error` is reachable today and paints *"Error connecting to
-server:"* over a current, valid plan — measured: `after response #2 rendered a valid plan:
-content=True errorPanel=False` then `after stale request #1 FAILED: content=True errorPanel=True`. A
-stale `complete` hides the spinner of a request still in flight (jQuery always runs `complete`).
-
-```js
-let previewSeq = 0;
-function loadPreview(selection) {
-    const seq = ++previewSeq;
-    $.ajax({
-        /* ... unchanged ... */
-        success:  function (result) { if (seq !== previewSeq) { return; } /* unchanged */ },
-        error:    function (xhr, status, error) { if (seq !== previewSeq) { return; } /* unchanged */ },
-        complete: function ()       { if (seq !== previewSeq) { return; }
-                                      $("#bulk-preview-loading").addClass("d-none"); }
-    });
-}
-```
-
-**Cheaper interim:** retain the jqXHR and `.abort()` it **at the top of `loadPreview`, before the new
-`$.ajax` call**, plus `if (status === "abort") { return; }` as the first line of `error`. The abort
-alone is only correct at that exact placement — measured with the abort reached after the new
-`beforeSend`, jQuery 4.0.0 fired `error(status=abort)` then `complete` and left
-`errorText='Error connecting to server: abort'` on screen. The `status === "abort"` line makes the
-interim placement-independent and costs one line.
+_Test count unchanged at 683 — no JS test harness exists, per the watch list; the browser run above is
+the verification. `dotnet build --no-incremental` 0 warnings, 0 errors._
 
 ---
 

--- a/src/Bastet/Controllers/HostIpController.cs
+++ b/src/Bastet/Controllers/HostIpController.cs
@@ -599,14 +599,15 @@ public class HostIpController(
             return RedirectToAction(nameof(AllDeletedHostIps));
         }
 
-        return View(new PurgeAllDeletedHostIpsViewModel { Count = count });
+        int maxId = await context.DeletedHostIpAssignments.MaxAsync(d => (int?)d.Id) ?? 0;
+        return View(new PurgeAllDeletedHostIpsViewModel { Count = count, MaxId = maxId });
     }
 
     // POST: HostIp/PurgeAllDeletedHostIps
     [HttpPost, ActionName("PurgeAllDeletedHostIps")]
     [ValidateAntiForgeryToken]
     [Authorize(Policy = "RequireAdminRole")]
-    public async Task<IActionResult> PurgeAllDeletedHostIpsConfirmed(string confirmation)
+    public async Task<IActionResult> PurgeAllDeletedHostIpsConfirmed(string confirmation, int? confirmedMaxId)
     {
         if (confirmation != "approved")
         {
@@ -614,7 +615,18 @@ public class HostIpController(
             return RedirectToAction(nameof(PurgeAllDeletedHostIps));
         }
 
-        int removed = await context.DeletedHostIpAssignments.ExecuteDeleteAsync();
+        // Same bound as the subnet archive, for the same reason - see the comment there.
+        if (confirmedMaxId is null or <= 0)
+        {
+            TempData["ErrorMessage"] =
+                "The purge scope was missing from the form. Review the archive and confirm again.";
+            return RedirectToAction(nameof(PurgeAllDeletedHostIps));
+        }
+
+        int removed = await context.DeletedHostIpAssignments
+            .Where(d => d.Id <= confirmedMaxId)
+            .ExecuteDeleteAsync();
+
         TempData["SuccessMessage"] = $"Permanently purged {removed} deleted host IP record(s).";
         return RedirectToAction(nameof(AllDeletedHostIps));
     }

--- a/src/Bastet/Controllers/SubnetController.Delete.cs
+++ b/src/Bastet/Controllers/SubnetController.Delete.cs
@@ -281,14 +281,15 @@ public partial class SubnetController : Controller
             return RedirectToAction(nameof(DeletedSubnets));
         }
 
-        return View(new PurgeAllDeletedSubnetsViewModel { Count = count });
+        int maxId = await context.DeletedSubnets.MaxAsync(d => (int?)d.Id) ?? 0;
+        return View(new PurgeAllDeletedSubnetsViewModel { Count = count, MaxId = maxId });
     }
 
     // POST: Subnet/PurgeAllDeletedSubnets
     [HttpPost, ActionName("PurgeAllDeletedSubnets")]
     [ValidateAntiForgeryToken]
     [Authorize(Policy = "RequireAdminRole")]
-    public async Task<IActionResult> PurgeAllDeletedSubnetsConfirmed(string confirmation)
+    public async Task<IActionResult> PurgeAllDeletedSubnetsConfirmed(string confirmation, int? confirmedMaxId)
     {
         if (confirmation != "approved")
         {
@@ -296,7 +297,24 @@ public partial class SubnetController : Controller
             return RedirectToAction(nameof(PurgeAllDeletedSubnets));
         }
 
-        int removed = await context.DeletedSubnets.ExecuteDeleteAsync();
+        // The confirmation page states a count, and this is what makes that statement true: the
+        // purge is bounded to the records that existed when the operator read it. Without the bound
+        // the POST carries no scope at all and destroys whatever exists at execution time, which is
+        // a different set whenever anything was archived in between.
+        //
+        // Bound as int? and refuse a missing value rather than defaulting: a POST without the field
+        // would otherwise bind 0, delete nothing, and report "Permanently purged 0 record(s)".
+        if (confirmedMaxId is null or <= 0)
+        {
+            TempData["ErrorMessage"] =
+                "The purge scope was missing from the form. Review the archive and confirm again.";
+            return RedirectToAction(nameof(PurgeAllDeletedSubnets));
+        }
+
+        int removed = await context.DeletedSubnets
+            .Where(d => d.Id <= confirmedMaxId)
+            .ExecuteDeleteAsync();
+
         TempData["SuccessMessage"] = $"Permanently purged {removed} deleted subnet record(s).";
         return RedirectToAction(nameof(DeletedSubnets));
     }

--- a/src/Bastet/Models/ViewModels/PurgeAllViewModels.cs
+++ b/src/Bastet/Models/ViewModels/PurgeAllViewModels.cs
@@ -1,11 +1,26 @@
 namespace Bastet.Models.ViewModels;
 
+/// <summary>
+/// Confirmation model for purging the subnet archive. <see cref="MaxId"/> is posted back so the
+/// purge destroys exactly the records the operator was shown a count of, and not whatever happens
+/// to exist by the time they submit.
+/// </summary>
 public class PurgeAllDeletedSubnetsViewModel
 {
     public int Count { get; set; }
+
+    /// <summary>
+    /// Highest archived record ID at the moment this page was rendered, and the upper bound of the
+    /// purge. Rows archived after this point necessarily have a higher ID - production is SQL Server
+    /// only, the column is IDENTITY, and DELETE (unlike TRUNCATE) never reseeds it.
+    /// </summary>
+    public int MaxId { get; set; }
 }
 
+/// <summary>Confirmation model for purging the host IP archive. <see cref="MaxId"/> as above.</summary>
 public class PurgeAllDeletedHostIpsViewModel
 {
     public int Count { get; set; }
+
+    public int MaxId { get; set; }
 }

--- a/src/Bastet/Program.cs
+++ b/src/Bastet/Program.cs
@@ -304,12 +304,13 @@ if (autoMigrate)
         }
         catch (SqlException ex) when (ex.Number == 4060)
         {
-            // 4060 is "cannot open database" - the catalog is not there yet, so this is the
-            // bootstrap path. Every other failure, a bad credential included, is left to surface as
-            // itself rather than being reinterpreted as a missing database.
+            // 4060 is "cannot open database". Every other failure, a bad credential included, is
+            // left to surface as itself rather than being reinterpreted as a missing database.
+            SqlConnection bootstrapConnection;
+
             try
             {
-                return Open(MigrationLockConnectionString.MasterBootstrap(connectionString));
+                bootstrapConnection = Open(MigrationLockConnectionString.MasterBootstrap(connectionString));
             }
             catch (SqlException bootstrapException)
             {
@@ -323,6 +324,52 @@ if (autoMigrate)
                     + $"login access to '{MigrationLockConnectionString.BootstrapCatalog}'. "
                     + "See BASTET_CONNECTION_STRING and BASTET_AUTO_MIGRATE.", bootstrapException);
             }
+
+            // 4060 is byte-identical for three different conditions: the catalog is absent, the
+            // login has no user inside a catalog that exists, and the catalog is offline. Assuming
+            // the first sends a deployment whose database is present and full of data down the
+            // bootstrap path, where Migrate() issues CREATE DATABASE against it and startup dies
+            // with a diagnostic about master permissions that names nothing real.
+            //
+            // HAS_DBACCESS separates them: 0 = it exists but cannot be used, NULL = no such
+            // database, 1 = healthy. It is used rather than DB_ID or sys.databases because it keeps
+            // answering when VIEW ANY DATABASE has been revoked from public - ordinary hardening,
+            // under which DB_ID returns NULL for a database that plainly exists - and because it
+            // returns int where DB_ID returns smallint. Fail open: if the probe cannot run at all,
+            // behave exactly as before.
+            string configuredCatalog = new SqlConnectionStringBuilder(connectionString).InitialCatalog;
+            int? catalogAccess = null;
+
+            try
+            {
+                using SqlCommand probe = new("SELECT HAS_DBACCESS(@catalog)", bootstrapConnection);
+                probe.Parameters.AddWithValue("@catalog", configuredCatalog);
+                catalogAccess = probe.ExecuteScalar() is int access ? access : null;
+            }
+            catch (SqlException)
+            {
+                // Probe unavailable - keep today's behaviour rather than refusing to start.
+            }
+
+            if (catalogAccess == 0)
+            {
+                bootstrapConnection.Dispose();
+
+                // This must abort startup, not log and continue: EF Core's
+                // SqlServerDatabaseCreator.Exists() misreads 4060 the same way, so anything short of
+                // throwing is overruled by Migrate() a few lines below.
+                throw new InvalidOperationException(
+                    $"The configured database '{configuredCatalog}' exists on this server but could not be "
+                    + "opened, which SQL Server reports as error 4060 using the same text it uses for a "
+                    + "database that does not exist. Either the login in BASTET_CONNECTION_STRING has no "
+                    + $"user inside that database (CREATE USER inside '{configuredCatalog}', then db_owner "
+                    + "for BASTET_AUTO_MIGRATE=true - if the database was restored or failed over the user "
+                    + "may be orphaned: ALTER USER ... WITH LOGIN), or the database is offline or "
+                    + "recovering. Do not grant the login permission to create databases; it does not need "
+                    + "it.", ex);
+            }
+
+            return bootstrapConnection;
         }
 
         // Disposes on any failed open, so neither attempt above can leak a connection.

--- a/src/Bastet/Services/Azure/AzureReconciler.cs
+++ b/src/Bastet/Services/Azure/AzureReconciler.cs
@@ -45,6 +45,10 @@ namespace Bastet.Services.Azure
             Dictionary<string, BulkAzureVNetViewModel> liveVNets = new(StringComparer.OrdinalIgnoreCase);
             Dictionary<string, List<string>> liveSubnetPrefixes = new(StringComparer.OrdinalIgnoreCase);
 
+            // Subnets this scan positively verified are still present in Azure. Collected so a
+            // target sitting above one is never offered for deletion: see the cascade guard below.
+            HashSet<int> liveLinked = [];
+
             foreach (BulkAzureVNetViewModel vnet in inventory.VNets)
             {
                 if (!string.IsNullOrEmpty(vnet.ResourceId))
@@ -98,6 +102,11 @@ namespace Bastet.Services.Azure
 
                 if (item is null)
                 {
+                    // Evaluated against a successful read and found live: the VNet or Azure subnet
+                    // is there and still carries the recorded prefix. Nothing downstream ever sees
+                    // this row again - it becomes neither an item nor a review item - so the only
+                    // place it can protect an ancestor from the cascade is here.
+                    liveLinked.Add(snapshot.Id);
                     continue;
                 }
 
@@ -111,6 +120,10 @@ namespace Bastet.Services.Azure
                     plan.Items.Add(item);
                 }
             }
+
+            WithholdTargetsWhoseCascadeIsBlocked(
+                plan, liveLinked,
+                "archiving them would also archive Azure-linked subnet(s) beneath them that still exist in Azure");
 
             // An empty subscription and a subscription we failed to enumerate properly look the same
             // from here, and the consequence of being wrong is deleting everything.
@@ -210,6 +223,51 @@ namespace Bastet.Services.Azure
                     $"{stillLive.Count} Azure-linked subnet(s) were missing from the subscription listing but still exist " +
                     $"in Azure, so they have been withheld from deletion: {NameList(stillLive)}.");
             }
+
+            // Withholding a row means nothing while an ancestor that would archive it is still on
+            // offer: approving the ancestor takes the whole subtree, including everything protected
+            // above. ReviewItems belongs in the set as well - the loop above walks plan.Items only,
+            // so a FullyAllocatingSubnetDeleted or UnrecognisedResourceId descendant appears in none
+            // of the lists built from it, and ordinary imports produce the former.
+            HashSet<int> withheld =
+            [
+                .. notVisible.Select(i => i.SubnetId),
+                .. unknown.Select(i => i.SubnetId),
+                .. stillLive.Select(i => i.SubnetId),
+                .. plan.ReviewItems.Select(i => i.SubnetId)
+            ];
+
+            WithholdTargetsWhoseCascadeIsBlocked(
+                plan, withheld,
+                "archiving them would also archive subnet(s) beneath them that were withheld from deletion");
+        }
+
+        /// <summary>
+        /// Drops every remaining item whose subtree contains a protected subnet, because archiving a
+        /// target archives its whole subtree. <paramref name="protectedSubnetIds"/> holds the rows
+        /// that must not be destroyed; <paramref name="because"/> completes the warning sentence.
+        /// </summary>
+        private static void WithholdTargetsWhoseCascadeIsBlocked(
+            AzureReconcilePlanViewModel plan,
+            HashSet<int> protectedSubnetIds,
+            string because)
+        {
+            if (protectedSubnetIds.Count == 0 || plan.Items.Count == 0)
+            {
+                return;
+            }
+
+            List<AzureReconcileItem> blocked =
+                [.. plan.Items.Where(i => i.DescendantSubnetIds.Any(protectedSubnetIds.Contains))];
+
+            if (blocked.Count == 0)
+            {
+                return;
+            }
+
+            plan.Items.RemoveAll(blocked.Contains);
+            plan.Warnings.Add(
+                $"{blocked.Count} subnet(s) were withheld from deletion because {because}: {NameList(blocked)}.");
         }
 
         /// <summary>

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -9,6 +9,7 @@
         let selectedSubscriptionName = "";
         let vnets = []; // [{ resourceId, name, ipv4AddressPrefixes:[], subnets:[{name, addressPrefix}] }]
         let lastSelection = null; // last BulkImportSelectionDto submitted
+        let previewSeq = 0;       // bumped per preview so a superseded response can be told apart
 
         // ---------------------------------------------------------------
         // Step navigation helpers
@@ -427,6 +428,11 @@
         }
 
         function loadPreview(selection) {
+            // Preview latency scales with (existing subnets x selected prefixes), so two previews
+            // can answer out of order. Commit posts lastSelection, which is set on the click - if a
+            // superseded response were allowed to repaint, the screen would show one plan while the
+            // button posted another, and the server re-plans what it is sent and cannot tell.
+            const seq = ++previewSeq;
             $.ajax({
                 url: '@Url.Action("BulkImportPreview", "Azure")',
                 type: "POST",
@@ -439,6 +445,9 @@
                     $("#bulk-preview-error").addClass("d-none");
                 },
                 success: function (result) {
+                    if (seq !== previewSeq) {
+                        return;
+                    }
                     if (!result.success) {
                         $("#bulk-preview-error-message").text(result.error || "Failed to build plan");
                         $("#bulk-preview-error").removeClass("d-none");
@@ -448,10 +457,20 @@
                     $("#bulk-preview-content").removeClass("d-none");
                 },
                 error: function (xhr, status, error) {
+                    // Without this a superseded request that fails paints its error over a current,
+                    // valid plan.
+                    if (seq !== previewSeq) {
+                        return;
+                    }
                     $("#bulk-preview-error-message").text("Error connecting to server: " + error);
                     $("#bulk-preview-error").removeClass("d-none");
                 },
                 complete: function () {
+                    // jQuery always runs complete, so a superseded request would otherwise hide the
+                    // spinner of one still in flight.
+                    if (seq !== previewSeq) {
+                        return;
+                    }
                     $("#bulk-preview-loading").addClass("d-none");
                 }
             });

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -604,7 +604,12 @@
                 success: function (result) {
                     if (result && result.success) {
                         $("#bulk-commit-success-message").text(
-                            ` Created ${result.createdTargets} VNet target(s), ${result.createdChildSubnets} child subnet(s), renamed ${result.renamedTargets} target(s), marked ${result.fullyAllocatedTargets} target(s) as fully allocated.`
+                            // linkedTargets counts the existing Bastet subnets this commit stamped
+                            // with an ARM id. Without it a link-only import reports every counter as
+                            // zero, which is byte-identical to the banner for a commit that wrote
+                            // nothing at all. Counter order matches TempData["SuccessMessage"] so the
+                            // two summaries of one commit agree.
+                            ` Created ${result.createdTargets} VNet target(s), ${result.createdChildSubnets} child subnet(s), renamed ${result.renamedTargets} target(s), linked ${result.linkedTargets} existing target(s) to Azure, marked ${result.fullyAllocatedTargets} target(s) as fully allocated.`
                         );
                         $("#bulk-commit-success").removeClass("d-none");
                         $("#bulk-confirm-commit-btn").hide();

--- a/src/Bastet/Views/Azure/Import/_ImportScripts.cshtml
+++ b/src/Bastet/Views/Azure/Import/_ImportScripts.cshtml
@@ -7,6 +7,12 @@
         let selectedVNetId = "";
         let selectedVNetName = "";
 
+        // Bumped on every loadSubnets call so a response that has been superseded can be told from
+        // the current one. /Azure/GetSubnets reads Azure per VNet, so two picks in quick succession
+        // can answer out of order, and the rows painted last would then describe a different VNet
+        // from the one the hidden identity fields name.
+        let subnetSeq = 0;
+
         // Escape Azure-derived strings before putting them in HTML (matches the Bulk/Reconcile wizards).
         function escapeHtml(s) {
             if (s === null || s === undefined) {
@@ -57,10 +63,11 @@
                 $("#step2").removeClass("show active");
                 $("#step3").addClass("show active");
 
-                // Load subnets for the selected VNet
+                // Load subnets for the selected VNet. The identity is passed in and re-written from
+                // the response that actually populates the rows, so the two can never disagree.
                 $("#vnet-name").val(selectedVNetName);
                 $("#vnet-resource-id").val(selectedVNetId);
-                loadSubnets(selectedVNetId);
+                loadSubnets(selectedVNetId, selectedVNetName);
             }
         });
         
@@ -221,7 +228,8 @@
         }
         
         // Load Subnets for selected VNet
-        function loadSubnets(vnetResourceId) {
+        function loadSubnets(vnetResourceId, vnetName) {
+            const seq = ++subnetSeq;
             $.ajax({
                 url: '@Url.Action("GetSubnets", "Azure")',
                 type: "GET",
@@ -248,6 +256,18 @@
                     $("#import-subnets-btn").prop("disabled", true);
                 },
                 success: function(result) {
+                    // A superseded response must not paint: its rows belong to a VNet the operator
+                    // has already moved off, and they would be submitted under the current VNet's
+                    // identity.
+                    if (seq !== subnetSeq) {
+                        return;
+                    }
+
+                    // The identity comes from the response that populated the rows, not from the
+                    // click that started it.
+                    $("#vnet-name").val(vnetName);
+                    $("#vnet-resource-id").val(vnetResourceId);
+
                     if (result.success) {
                         if (result.subnets && result.subnets.length > 0) {
                             // Clear and populate subnet list
@@ -321,10 +341,20 @@
                     }
                 },
                 error: function(xhr, status, error) {
+                    // A superseded request failing at the transport would otherwise paint its error
+                    // over the current VNet's correctly rendered rows.
+                    if (seq !== subnetSeq) {
+                        return;
+                    }
                     $("#subnet-error-message").text("Error connecting to server: " + error);
                     $("#subnet-error").removeClass("d-none");
                 },
                 complete: function() {
+                    // jQuery always runs complete, so without this a superseded request hides the
+                    // spinner of one that is still in flight.
+                    if (seq !== subnetSeq) {
+                        return;
+                    }
                     $("#subnet-loading").hide();
                 }
             });

--- a/src/Bastet/Views/HostIp/PurgeAllDeletedHostIps.cshtml
+++ b/src/Bastet/Views/HostIp/PurgeAllDeletedHostIps.cshtml
@@ -22,6 +22,9 @@
 <form asp-action="PurgeAllDeletedHostIps" method="post">
     @Html.AntiForgeryToken()
 
+    @* Bounds the purge to the records this page counted - see the subnet twin. *@
+    <input type="hidden" name="confirmedMaxId" value="@Model.MaxId" />
+
     <div class="mb-4">
         <label for="confirmation" class="form-label fw-bold">Type "approved" to confirm purge:</label>
         <input type="text" class="form-control form-control-lg" id="confirmation" name="confirmation" required autocomplete="off" />

--- a/src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml
+++ b/src/Bastet/Views/Subnet/Details/_SubnetCalculationScripts.cshtml
@@ -139,11 +139,12 @@
                 $('#createSubnetBtn').prop('disabled', false);
                 $('#cidrValidationFeedback').text('Please enter a valid CIDR value within the allowed range.');
                 updateSubnetSize(cidrValue);
-            } else if (cidrValue < minCidr || cidrValue > maxCidr) {
+            } else if (isNaN(cidrValue) || cidrValue < minCidr || cidrValue > maxCidr) {
                 // Range before overlap: a CIDR that is both out of range and overlapping was
                 // reported as an overlap, which is not the objection the operator can act on.
-                // A cleared field still lands here - parseInt gives NaN, every comparison is
-                // false - and still gets the generic message, as before.
+                // isNaN is tested explicitly because a cleared field parses to NaN and every
+                // NaN comparison is false, so the range test alone would drop it through to the
+                // overlap arm below - claiming a collision with a sibling that need not exist.
                 $(this).removeClass('is-valid').addClass('is-invalid');
                 $('#createSubnetBtn').prop('disabled', true);
                 $('#cidrValidationFeedback').text('Please enter a valid CIDR value within the allowed range.');

--- a/src/Bastet/Views/Subnet/PurgeAllDeletedSubnets.cshtml
+++ b/src/Bastet/Views/Subnet/PurgeAllDeletedSubnets.cshtml
@@ -22,6 +22,10 @@
 <form asp-action="PurgeAllDeletedSubnets" method="post">
     @Html.AntiForgeryToken()
 
+    @* Bounds the purge to the records this page counted, so anything archived while the operator
+       was reading it survives rather than being swept up silently. *@
+    <input type="hidden" name="confirmedMaxId" value="@Model.MaxId" />
+
     <div class="mb-4">
         <label for="confirmation" class="form-label fw-bold">Type "approved" to confirm purge:</label>
         <input type="text" class="form-control form-control-lg" id="confirmation" name="confirmation" required autocomplete="off" />

--- a/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
@@ -791,4 +791,110 @@ public class AzureReconcilerTests
         Assert.True(plan.ScanSucceeded);
         Assert.Empty(plan.GlobalErrors);
     }
+
+    // -------------------------------------------------------------------------
+    // The cascade. Archiving a target takes its whole subtree, so a target is only deletable if
+    // every Azure-linked row beneath it is deletable too. A descendant this scan verified is live,
+    // or explicitly withheld from deletion, must take its ancestor out of the plan with it -
+    // otherwise approving the ancestor destroys exactly the rows the scan just protected.
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// The no-RBAC variant, and the likeliest in the field: an outer VNet is deleted in Azure while
+    /// an inner VNet imported beneath it is still live. The inner row never becomes an item at all
+    /// (it evaluated to live), so nothing downstream can notice it - the check has to happen here.
+    /// </summary>
+    [Fact]
+    public void BuildPlan_TargetWhoseDescendantIsStillLiveInAzure_IsWithheld()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("inner", ["10.78.128.0/17"])),                                  // outer is gone, inner is not
+            Linked(1, "outer", "10.78.0.0", 16, VNetId("outer"), descendants: 1, descendantIds: [2]),
+            Linked(2, "inner", "10.78.128.0", 17, VNetId("inner")));
+
+        Assert.True(plan.ScanSucceeded);
+        Assert.Empty(plan.Items);
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.Warnings, w => w.Contains("still exist in Azure") && w.Contains("'outer'"));
+    }
+
+    /// <summary>
+    /// The RBAC variant. The descendant is withheld by <see cref="AzureReconciler.ApplyConfirmations"/>
+    /// - Azure would not confirm it is gone - and the warning says so by name. Approving the ancestor
+    /// archived it anyway, including the case where the credential that would be needed to re-import
+    /// it is the one ARM is refusing.
+    /// </summary>
+    [Theory]
+    [InlineData(AzureResourceConfirmation.NotVisible)]
+    [InlineData(AzureResourceConfirmation.Unknown)]
+    [InlineData(AzureResourceConfirmation.Live)]
+    public void ApplyConfirmations_TargetWhoseDescendantWasWithheld_IsAlsoWithheld(
+        AzureResourceConfirmation verdict)
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),                                    // live VNet, no subnets
+            Linked(1, "outer", "10.78.0.0", 16, VNetId("outer"), descendants: 1, descendantIds: [2]),
+            Linked(2, "child", "10.0.1.0", 24, SubnetId("vnet-a", "snet-a")));
+
+        Assert.Equal(2, plan.Items.Count);
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [VNetId("outer")] = AzureResourceConfirmation.Deleted,
+            [SubnetId("vnet-a", "snet-a")] = verdict
+        });
+
+        Assert.Empty(plan.Items);
+        Assert.False(plan.CanCommit);
+        Assert.Contains(plan.Warnings, w => w.Contains("'outer'"));
+    }
+
+    /// <summary>
+    /// ApplyConfirmations iterates plan.Items and never reads plan.ReviewItems, so a review-item
+    /// descendant is in none of the sets built there. FullyAllocatingSubnetDeleted is produced by
+    /// ordinary imports, so this is not an exotic shape.
+    /// </summary>
+    [Fact]
+    public void ApplyConfirmations_TargetWhoseDescendantIsAReviewItem_IsAlsoWithheld()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("inner", ["10.78.128.0/17"])),                                  // live, but nothing covers the prefix
+            Linked(1, "outer", "10.78.0.0", 16, VNetId("outer"), descendants: 1, descendantIds: [2]),
+            Linked(2, "inner", "10.78.128.0", 17, VNetId("inner"), fullyAllocated: true));
+
+        _ = Assert.Single(plan.ReviewItems);
+        _ = Assert.Single(plan.Items);
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [VNetId("outer")] = AzureResourceConfirmation.Deleted
+        });
+
+        Assert.Empty(plan.Items);
+        Assert.Contains(plan.Warnings, w => w.Contains("'outer'"));
+    }
+
+    /// <summary>
+    /// The ordinary case must survive both guards: when a VNet is deleted its imported subnets go
+    /// with it, confirm as Deleted, and are still deletable. A guard that withheld this would make
+    /// the feature useless.
+    /// </summary>
+    [Fact]
+    public void ApplyConfirmations_TargetWhoseDescendantIsAlsoDeleted_IsStillCommittable()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-other", ["192.168.0.0/16"])),
+            Linked(1, "outer", "10.78.0.0", 16, VNetId("outer"), descendants: 1, descendantIds: [2]),
+            Linked(2, "child", "10.78.1.0", 24, SubnetId("outer", "snet-a")));
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [VNetId("outer")] = AzureResourceConfirmation.Deleted,
+            [SubnetId("outer", "snet-a")] = AzureResourceConfirmation.Deleted
+        });
+
+        Assert.Equal(2, plan.Items.Count);
+        Assert.True(plan.CanCommit);
+        Assert.Empty(plan.Warnings);
+    }
 }

--- a/test/Bastet.Tests/SubnetManagement/PurgeAllScopeTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/PurgeAllScopeTests.cs
@@ -1,0 +1,196 @@
+using Bastet.Controllers;
+using Bastet.Data;
+using Bastet.Models;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Validation;
+using Bastet.Tests.TestHelpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Bastet.Tests.SubnetManagement;
+
+/// <summary>
+/// "Purge All" states a count on its confirmation page and then destroys records that cannot be
+/// recovered - there is no restore path anywhere in the application. These tests pin the purge to
+/// the set the operator was actually shown, so anything archived while they were reading the page
+/// survives instead of being swept up silently.
+/// </summary>
+/// <remarks>
+/// The suite runs on SQLite, where a plain INTEGER PRIMARY KEY reuses the highest rowid once the
+/// top row is deleted. Every assertion below is therefore about rows inserted while the archive is
+/// non-empty, never about ID values surviving a purge.
+/// </remarks>
+public class PurgeAllScopeTests : IDisposable
+{
+    private readonly BastetDbContext _context;
+    private readonly SubnetController _subnetController;
+    private readonly HostIpController _hostIpController;
+
+    public PurgeAllScopeTests()
+    {
+        _context = TestDbContextFactory.CreateDbContext();
+
+        IUserContextService userContext = ControllerTestHelper.CreateMockUserContextService();
+        IIpUtilityService ipUtility = new IpUtilityService();
+        SubnetValidationService subnetValidation = new(ipUtility);
+        HostIpValidationService hostIpValidation = new(ipUtility, _context);
+
+        _subnetController = new SubnetController(
+            _context, ipUtility, subnetValidation, hostIpValidation, userContext,
+            ControllerTestHelper.CreateMockSubnetLockingService(), NullLogger<SubnetController>.Instance);
+        ControllerTestHelper.SetupController(_subnetController);
+
+        _hostIpController = new HostIpController(
+            _context, hostIpValidation, ipUtility, userContext,
+            ControllerTestHelper.CreateMockSubnetLockingService(), NullLogger<HostIpController>.Instance);
+        ControllerTestHelper.SetupController(_hostIpController);
+    }
+
+    private DeletedSubnet ArchiveSubnet(string name, string network)
+    {
+        DeletedSubnet row = new()
+        {
+            Name = name,
+            NetworkAddress = network,
+            Cidr = 24,
+            DeletedAt = DateTime.UtcNow,
+            DeletedBy = "test-user",
+            CreatedAt = DateTime.UtcNow
+        };
+        _context.DeletedSubnets.Add(row);
+        _context.SaveChanges();
+        return row;
+    }
+
+    private DeletedHostIpAssignment ArchiveHostIp(string ip)
+    {
+        DeletedHostIpAssignment row = new()
+        {
+            OriginalIP = ip,
+            Name = "host-" + ip,
+            OriginalSubnetId = 1,
+            DeletedAt = DateTime.UtcNow,
+            DeletedBy = "test-user",
+            CreatedAt = DateTime.UtcNow
+        };
+        _context.DeletedHostIpAssignments.Add(row);
+        _context.SaveChanges();
+        return row;
+    }
+
+    // -------------------------------------------------------------------------
+    // The subnet archive
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// The scenario the page's own sentence makes a promise about: it says "1 record", and one
+    /// record is what may be destroyed - even though eleven more were archived in the meantime.
+    /// </summary>
+    [Fact]
+    public async Task PurgeAllSubnets_DestroysOnlyWhatTheConfirmationPageCounted()
+    {
+        DeletedSubnet shown = ArchiveSubnet("solo", "10.90.0.0");
+
+        ViewResult page = Assert.IsType<ViewResult>(await _subnetController.PurgeAllDeletedSubnets());
+        PurgeAllDeletedSubnetsViewModel model =
+            Assert.IsType<PurgeAllDeletedSubnetsViewModel>(page.Model);
+        Assert.Equal(1, model.Count);
+        Assert.Equal(shown.Id, model.MaxId);
+
+        // ... and now another tab archives more, after the page was rendered.
+        DeletedSubnet later1 = ArchiveSubnet("big", "10.50.0.0");
+        DeletedSubnet later2 = ArchiveSubnet("child", "10.50.1.0");
+
+        await _subnetController.PurgeAllDeletedSubnetsConfirmed("approved", model.MaxId);
+
+        List<int> remaining = [.. _context.DeletedSubnets.Select(d => d.Id)];
+        Assert.Equal([later1.Id, later2.Id], [.. remaining.OrderBy(i => i)]);
+        Assert.Equal("Permanently purged 1 deleted subnet record(s).",
+            _subnetController.TempData["SuccessMessage"]);
+    }
+
+    /// <summary>
+    /// A POST carrying no scope must refuse rather than fall back to deleting everything, and
+    /// rather than binding 0 and silently reporting a successful purge of nothing.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task PurgeAllSubnets_WithoutAScope_RefusesAndDestroysNothing(int? confirmedMaxId)
+    {
+        ArchiveSubnet("a", "10.1.0.0");
+        ArchiveSubnet("b", "10.2.0.0");
+
+        RedirectToActionResult redirect = Assert.IsType<RedirectToActionResult>(
+            await _subnetController.PurgeAllDeletedSubnetsConfirmed("approved", confirmedMaxId));
+
+        Assert.Equal(nameof(SubnetController.PurgeAllDeletedSubnets), redirect.ActionName);
+        Assert.Equal(2, _context.DeletedSubnets.Count());
+        Assert.Null(_subnetController.TempData["SuccessMessage"]);
+        Assert.NotNull(_subnetController.TempData["ErrorMessage"]);
+    }
+
+    /// <summary>The ordinary case still purges the whole archive when nothing changed underneath.</summary>
+    [Fact]
+    public async Task PurgeAllSubnets_WhenNothingChanged_StillPurgesEverything()
+    {
+        ArchiveSubnet("a", "10.1.0.0");
+        ArchiveSubnet("b", "10.2.0.0");
+
+        ViewResult page = Assert.IsType<ViewResult>(await _subnetController.PurgeAllDeletedSubnets());
+        PurgeAllDeletedSubnetsViewModel model =
+            Assert.IsType<PurgeAllDeletedSubnetsViewModel>(page.Model);
+
+        await _subnetController.PurgeAllDeletedSubnetsConfirmed("approved", model.MaxId);
+
+        Assert.Empty(_context.DeletedSubnets);
+        Assert.Equal("Permanently purged 2 deleted subnet record(s).",
+            _subnetController.TempData["SuccessMessage"]);
+    }
+
+    // -------------------------------------------------------------------------
+    // The host IP archive - same defect, same fix
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task PurgeAllHostIps_DestroysOnlyWhatTheConfirmationPageCounted()
+    {
+        DeletedHostIpAssignment shown = ArchiveHostIp("10.60.0.5");
+
+        ViewResult page = Assert.IsType<ViewResult>(await _hostIpController.PurgeAllDeletedHostIps());
+        PurgeAllDeletedHostIpsViewModel model =
+            Assert.IsType<PurgeAllDeletedHostIpsViewModel>(page.Model);
+        Assert.Equal(1, model.Count);
+        Assert.Equal(shown.Id, model.MaxId);
+
+        DeletedHostIpAssignment later = ArchiveHostIp("10.60.0.6");
+
+        await _hostIpController.PurgeAllDeletedHostIpsConfirmed("approved", model.MaxId);
+
+        int remaining = Assert.Single(_context.DeletedHostIpAssignments.Select(d => d.Id));
+        Assert.Equal(later.Id, remaining);
+        Assert.Equal("Permanently purged 1 deleted host IP record(s).",
+            _hostIpController.TempData["SuccessMessage"]);
+    }
+
+    [Fact]
+    public async Task PurgeAllHostIps_WithoutAScope_RefusesAndDestroysNothing()
+    {
+        ArchiveHostIp("10.60.0.5");
+
+        RedirectToActionResult redirect = Assert.IsType<RedirectToActionResult>(
+            await _hostIpController.PurgeAllDeletedHostIpsConfirmed("approved", null));
+
+        Assert.Equal(nameof(HostIpController.PurgeAllDeletedHostIps), redirect.ActionName);
+        Assert.Single(_context.DeletedHostIpAssignments);
+        Assert.Null(_hostIpController.TempData["SuccessMessage"]);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
### Bug Fixes
- Azure reconcile could **delete subnets that are still live in Azure** — approving one stale target archived everything beneath it, including child subnets the same scan had just verified were present, or had explicitly withheld because your credential could not see them. Such targets are now withheld too, with a warning naming them
- The Azure import wizard could **file one VNet's subnets under a different VNet** — picking a VNet, going back and picking another while the first was still loading left the earlier subnet list on screen under the new VNet's identity, and importing wrote it that way. The resulting link cannot be edited or restored afterwards
- Bulk Azure import could **commit a plan you never saw** — when a slow preview arrived after a newer one, the pane repainted with the older plan and re-enabled Continue, while Confirm still posted the newer selection
- **"Purge All" destroyed more archive records than its confirmation page counted** — anything archived between rendering that page and submitting it was swept up as well. The purge is now bounded to the records the page actually counted, for both the subnet and host IP archives
- Bastet could try to **create a database that already exists** and abort with a misleading error about `master` permissions — SQL Server reports "cannot open database" in identical words whether the database is missing, offline, or your login has no user inside it. Startup now tells those apart and names the real cause, and no longer implies the application account needs permission to create databases
- The subnet Details page's Create-Subnet box **claimed a CIDR overlap when the field was simply empty** — clearing it, or typing non-numeric text, reported a collision with existing subnets, including on subnets that have no children at all
- The bulk import completion banner **reported all zeros for an import that did change something** — linking an existing subnet to Azure showed "created 0 … renamed 0", word for word what a no-op import shows. It now names the targets it linked
