### PR TITLE
Audit 10 Cleanup

### DIFF
--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -381,96 +381,45 @@ the shape round 9 struck under I1._
 
 # Info
 
-## J8 [x1] - Deleted-host-IP archive pages print the subnet's CURRENT prefix, so an archived address is shown inside a range that never contained it
+_J8 is fixed and committed, but **the proposed fix was declined**. Adding `OriginalNetworkAddress` and
+`OriginalCidr` to `DeletedHostIpAssignment` plus a migration is disproportionate to an info-severity
+display defect, and the verifier measured three unresolved problems with it: declared non-nullable the
+migration backfills `('', 0)` and every pre-upgrade row renders as `NAME (/0)`; the page-level header
+on the per-subnet view has no single truthful value once rows in one subnet were archived at different
+prefixes; and "populate them in both writers" is not a field copy, because the prefix is not on
+`HostIpAssignment` — `DeleteConfirmed` would need an extra read inside the open transaction and
+`ArchiveSubnetSubtreeAsync` a lookup keyed on `hostIp.SubnetId`._
 
-**Severity:** info (filed low; one verifier left it as filed, the second corrected it down after finding
-no consumer of the field beyond two Razor templates) | **Confidence:** confirmed | **Cite:**
-`src/Bastet/Controllers/HostIpController.cs:570` (live-subnet branch), `:580-581` (archived branch),
-`Models/DeletedHostIpAssignment.cs:21`
+_Taken instead: the verifier's own "only cheap and fully correct variant" — **drop the parenthetical
+range** from `AllDeletedHostIps.cshtml`. The subnet name and the `OriginalSubnetId` link are enough to
+navigate, and the column stops making a containment claim it has no data to support. A comment records
+why the range is absent, so it is not helpfully restored later._
 
-**What goes wrong.** Create `ARCHTEST = 10.150.0.0/24`, assign `10.150.0.200`, delete that host IP (it is
-archived), then narrow `ARCHTEST` to `/25` - which `Subnet/Edit` allows, because
-`ValidateSubnetCidrChangeWithHostIps` returns early when the subnet has **no live host IPs**, and
-deleting the address is precisely what empties that collection. `/HostIp/AllDeletedHostIps` then renders
-`10.150.0.200 | oldhost | ARCHTEST (10.150.0.0/25)` under a column headed **"Original Subnet"**.
-`10.150.0.200` is not in `10.150.0.0/25`. The archive row has no prefix column - only `OriginalSubnetId` -
-so the view has nothing truthful to print and re-derives it at render time.
+_Reproduced first, through ordinary UI posts only. `ARCHTEST` created as `10.150.0.0/24`,
+`10.150.0.200` assigned and deleted, then the subnet narrowed to `/25` — accepted with no validation
+error, because `ValidateSubnetCidrChangeWithHostIps` returns early when a subnet has no **live** host
+IPs, and deleting the address is precisely what empties that collection. `/HostIp/AllDeletedHostIps`
+then rendered `10.150.0.200 | oldhost | ARCHTEST (10.150.0.0/25)`, and a containment test on the
+printed range returned **False**. After the fix the same row reads `ARCHTEST`, with no range printed
+and the "Original Subnet" column header intact._
 
-That the pairing is read as a containment claim is not interpretation: `Views/HostIp/AllHostIps.cshtml:53`
-renders **live** assignments with the byte-identical string `@hostIp.SubnetName
-(@hostIp.NetworkAddress/@hostIp.Cidr)`, where containment is guaranteed by validation. And the displayed
-pairing is unconstructible - re-creating it is refused with *"IP address 10.150.0.200 is outside the
-subnet range 10.150.0.0/25"*.
+_**Orphan sweep.** Removing the only consumer left `AllDeletedHostIpItemViewModel.NetworkAddress` and
+`.Cidr` dead — nothing else reads them, no test asserts them — so both properties and their three
+population sites in `HostIpController` were removed in the same commit. The compiler reports none of
+this. `DeletedHostIpListViewModel.NetworkAddress/Cidr` are a **different** view model and are still
+live in `DeletedHostIps/_Header.cshtml`; they were left alone._
 
-**The finding's own diagnosis of the mechanism is wrong, and the defect is broader than filed.** It claims
-the column is internally inconsistent - live rows showing current values, archived rows showing historical
-ones. Both verifiers built the archived branch and it is wrong in exactly the same way: `SUBB` archived at
-`/24`, narrowed to `/25`, then deleted, prints `SUBB (deleted) (10.151.0.0/25)` over `10.151.0.200`. Both
-branches print the subnet's **last-known** prefix; neither branch has the datum. The prefix at
-host-IP-deletion time is never stored anywhere.
+_The per-subnet page header was deliberately not changed. It reads as a present-tense description of
+the subnet being viewed rather than a per-row historical claim, and it is the one place a single
+page-level prefix is defensible; verified still rendering
+"...for subnet ARCHTEST (10.150.0.0/25)". The load-bearing wrongness was the per-row pairing under an
+explicitly historical column, and that is what was removed._
 
-**Reproduction.** Every step an ordinary UI POST; four archived rows on one page, each printed range
-containment-tested:
-
-```
-step 4  POST /Subnet/Edit/1 Cidr=25  -> HTTP 302 -> /Subnet/Details/1   (accepted, no validation error)
-        SQL: ARCHTEST 10.150.0.0/25 ; LiveHostIps = 0
-
-GET /HostIp/AllDeletedHostIps:
-  IP            | "Original Subnet"                  | IP in printed range?
-  10.170.0.200  | ARCH3 (deleted) (10.170.0.0/24)    | True
-  10.160.0.10   | ARCH2 (deleted) (10.160.0.0/25)    | True
-  10.160.0.200  | ARCH2 (deleted) (10.160.0.0/25)    | False   <- archived branch
-  10.150.0.200  | ARCHTEST (10.150.0.0/25)           | False   <- live branch, as filed
-
-GET /HostIp/DeletedHostIps?subnetId=2 header:
-  "View previously deleted host IP assignments for subnet ARCH2 (10.160.0.0/25)"
-  over rows 10.160.0.10 and 10.160.0.200 - true original prefixes /25 and /24 respectively.
-
-archive row: Id 1 | OriginalIP 10.150.0.200 | Name oldhost | OriginalSubnetId 1   (no prefix column)
-POST /HostIp/Create SubnetId=1 IP=10.150.0.200 -> 200 with
-  "IP address 10.150.0.200 is outside the subnet range 10.150.0.0/25"
-```
-
-**Why info.** Nothing computes with these fields - `grep` shows the only consumers of
-`AllDeletedHostIpItemViewModel.NetworkAddress/Cidr` and `DeletedHostIpListViewModel.NetworkAddress/Cidr`
-are the two Razor templates; no test asserts them, nothing writes from them. Every load-bearing audit fact
-on the row is correct and the parenthetical is decoration. The one action a misled operator might take is
-refused with an accurate message. The per-subnet page's header is also soft - it reads as a present-tense
-description of the subnet you are viewing, and `_HostIpTable.cshtml` carries no per-row prefix at all; the
-load-bearing wrongness is `AllDeletedHostIps.cshtml:65` under an explicitly historical column header.
-
-**Fix.** Stamp the prefix onto the archive row instead of re-deriving it: add `OriginalNetworkAddress`
-(nvarchar(15)) and `OriginalCidr` (int) to `DeletedHostIpAssignment` plus a migration, populate them in
-both archive writers, and read them in the views. The two writers named are the only two -
-`HostIpController.cs:397-408` (`OriginalSubnetId` at `:401`) and
-`SubnetController.Delete.cs:196-207`; `grep` finds no third.
-
-**Verifier correction - INCOMPLETE on three counts, and the interim is UNSOUND.**
-
-1. **No backfill and no nullability decision.** Declared non-nullable, the migration fills existing rows
-   with `('', 0)` and `AllDeletedHostIps.cshtml:63` - which guards on `SubnetName != "Unknown"`, not on the
-   prefix - renders every pre-upgrade row as `NAME (/0)`. That exact output was measured. Make both columns
-   nullable and suppress the parenthetical when null, or backfill in the migration.
-2. **The `:688-692` call site is not well-defined.** `DeletedHostIpListViewModel`
-   (`DeletedHostIpViewModels.cs:6-14`) carries **one** page-level prefix used in
-   `DeletedHostIps/_Header.cshtml:5`, above N rows that can each now carry a different original prefix -
-   measured: `ARCH2`'s two rows, archived at `/24` and `/25`. There is no single value to put there.
-   Either move the prefix onto the per-row view model with a new column in `_HostIpTable.cshtml`, or leave
-   that header describing the live subnet and relabel it.
-3. **"Populate them in both writers" is not a field copy** - the prefix is not on `HostIpAssignment`. In
-   `DeleteConfirmed` the row comes from `FindAsync(ip)` with no `Include` and no subnet loaded, so it needs
-   an extra read inside the open transaction; in `ArchiveSubnetSubtreeAsync` `allHostIps` is a **flat** list
-   across the whole subtree, so it needs a lookup keyed on `hostIp.SubnetId` (`toDelete` already holds
-   every subnet).
-
-**The interim was built and produces worse output than the defect.** Dropping the assignment at
-`:570-571` renders `ARCHTEST (/0)` - the view has no discriminator to suppress the parenthetical. And the
-branch the interim deliberately keeps is equally false (`SUBB (deleted) (10.151.0.0/25)` over
-`10.151.0.200`), so "render the prefix only when it came from the archive" preserves the defect one row
-up rather than removing it. **The only cheap and fully correct variant is the fix's own last alternative:
-drop the parenthetical range from `AllDeletedHostIps.cshtml:65` altogether, or relabel it as the subnet's
-*current* range.** The subnet name plus the `OriginalSubnetId` link is enough to navigate.
+_The interim the finding proposed was **not** taken and is confirmed unsound: dropping only the
+live-subnet assignment renders `ARCHTEST (/0)`, because the view has no discriminator with which to
+suppress the parenthetical, and the archived branch it preserves is false in exactly the same way
+(`SUBB (deleted) (10.151.0.0/25)` over `10.151.0.200`). Suite unchanged at **730** — no test asserted
+these fields._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -1,0 +1,1124 @@
+# Bastet - Round-10 Audit Findings
+
+| | |
+|---|---|
+| Round | **10** (finding letter **J** - findings are `J1` ... `J9`) |
+| Target branch | `audit/round-10` |
+| HEAD | `dcc15ab` - *"Audit 9 Cleanup (#154)"*, identical tree to `main` |
+| Build | **0 warnings, 0 errors** |
+| Tests | **716 passed**, 0 failed, 0 skipped |
+| Date | 2026-07-31 |
+
+Every line number below was re-derived against the working tree at `dcc15ab` by at least one verifier.
+Round-9 citations have already moved; re-derive these before acting on them.
+
+---
+
+## Verdict
+
+**Nine findings: no critical, no high, two medium, five low, two info. Two candidates were refuted.**
+Nothing in this round is reachable by an unauthenticated caller, nothing corrupts a row silently, and
+nothing destroys data that an operator did not explicitly approve destroying. This is a quiet round.
+
+Read **J1** first. It is the only finding with deployment-wide blast radius. One Admin clicking *delete*
+in the Azure reconcile wizard, with the checkbox that ticks every row, holds the single global write
+lock for O(selected targets x total subnets): 200 targets against a 66,000-subnet catalog held
+`Bastet:SubnetOperations` for ~57 s, and during that window an ordinary `POST /Subnet/Create` issued
+**from a second replica** was refused after 30.3 s with *"The operation timed out due to high
+concurrency. Please try again."* - the message the app reserves for genuine contention. This is round
+9's I3 shape surviving in the one path that deletes, and round 9's watch list actively deters finding
+it: it records *"Delete's tree read [is] once per request"*, which is false here. It is twice per
+**selected target**, and one request carries as many targets as the operator ticked.
+
+Then **J2**: the bulk Azure import commits a plan it re-derives at commit time and never compares
+against the plan the operator approved. A subnet created by a second admin while step 3 is on screen is
+silently adopted, permanently stamped with the VNet's ARM id, renamed if the rename box is ticked, and
+thereby pulled into the reconcile wizard's deletion scope - where, once that VNet is deleted in Azure,
+it is archived into a table that stores no `AzureResourceId` and has no restore path. The sibling
+destructive endpoint does exactly the opposite on the same class of divergence: it re-derives, sees the
+mismatch and answers 409. Both mediums are Azure-path defects and both were driven end to end in real
+Chromium against real ARM.
+
+The five lows and two infos are ordered by consequence and none of them is load-bearing: a caller can
+relabel their own failed request's HTTP status (**J3**); a concurrent 4xx steals the error page's
+pending diagnostic (**J4**); a wizard's primary Next button stays live but inert after Back-then-Next
+(**J5**); Production sign-out 500s and discards the session-cookie deletion during a cold start against
+an unreachable IdP (**J6**); a corrupt `AzureResourceId` is skipped before it is classified, so the
+reconcile warning blames a subscription that does not exist (**J7**); the deleted-host-IP archive prints
+a subnet range that never contained the archived address (**J8**); and the bulk wizard greys out rows it
+does not explain (**J9**).
+
+**The fix corrections are the most valuable output of this round.** Every proposed fix was built and
+measured in a copy outside the repository, not argued from source, and **seven of the nine were found
+unsound or incomplete**:
+
+- **J9's fix does not run.** It declares a `const` at `:238` and reads it at `:236` - a temporal dead
+  zone. Razor does not parse embedded JS, so it builds at 0 warnings and then throws
+  `ReferenceError: Cannot access 'subnetBlockedByPrefix' before initialization` on every load, leaving
+  step 2 of the bulk wizard permanently spinning with zero checkboxes. Both verifiers built it and hit
+  the identical failure. **A fix that compiles clean and breaks at runtime is this round's recurring
+  trap** - J1's fix has the same shape in C#.
+- **J1's fix passes a 200-target benchmark and then 500s on the first nested target**, because the cache
+  it threads must be a *tracking* read and the finding says to copy `LoadSubnetTreeForBatchAsync`, which
+  is `AsNoTracking`. It also does not compile as written (`SubnetController.AzureReconcile.cs` has no
+  `using Microsoft.EntityFrameworkCore;` - the same trap round 9 recorded against I3).
+- **J6's fix breaks 9 shipped tests** (716 -> 707), all of them round 9's own I6 regression pins.
+- **J2's fix rests on client state that does not exist** (`lastPlan` is in the *reconcile* wizard, not
+  the bulk one) and is weaker than the precedent it invokes, because it makes the check opt-in.
+- **J8's and J4's interims were built and produce worse output than the defect** (`ARCHTEST (/0)`; a
+  favicon that headless Chromium never requests).
+
+Only **J5** and **J7** shipped fixes that survived measurement unchanged.
+
+---
+
+## How this audit ran
+
+**Twenty finders over eight beats.** The beats were `azure`, `security`, `ui`, `locking`, `logic`,
+`regression`, `regression-tests` and `deadcode`. Each was covered **twice, independently** - pass **A**
+code-first, pass **B** behaviour-first, neither seeing the other's output - plus a **deeper third
+sweep** on `security`, `azure`, `regression` and `regression-tests`. 20 launched, 20 returned.
+
+**What the tags mean.**
+
+- **`[x2]`** - both independent passes of the beat found it. Independent agreement is decent evidence
+  that the code, not the reader, is the problem.
+- **`[x1]`** - one pass found it and the other did not. Absence is weak evidence, so **every `[x1]` got
+  a second verifier** on a reachability-and-consequence lens as well as the mechanism lens, and a third
+  where the two disagreed. `[x1]` warrants **more** scrutiny at reconciliation, not less - seven of this
+  round's nine survivors are `[x1]`, including everything below medium.
+
+**Verification.** Every candidate went to at least one verifier whose brief was to *kill* it, and to
+reproduce it against a live rig rather than reason about it: real SQL Server 2022 in a container, the
+real application built from an unmodified `dcc15ab` tree, real headless Chromium where the defect is on
+screen, and **two Azure service principals with disjoint RBAC over two resource groups** so that
+"Azure denied access" and "Azure says it is gone" are distinguishable facts rather than assumptions.
+Verifiers ran their own instances on their own ports against their own catalogs, from `git archive` or
+`cp -a` copies - never from the repository working directory - and then built each proposed fix in that
+copy and measured it (`dotnet build`, `dotnet test`, and the same live request replayed).
+
+**The funnel.**
+
+| | |
+|---|---|
+| Finder agents launched / returned | 20 / 20 |
+| Beats | 8, each covered twice (A/B) + 4 deeper third sweeps |
+| Raw findings reported | 18 |
+| Candidates after dedup, merge and brief screening | **11** - 2 `[x2]`, 9 `[x1]` |
+| Survived verification | **9** |
+| Refuted by a verifier | **2** |
+| Reproduced live | **9** |
+| Proposed fixes built and measured | 9 - **2 sound, 6 incomplete, 1 unsound** |
+| Baseline | `dcc15ab` on `main`, 716 tests, 0 warnings |
+
+The seven raw findings that did not become candidates died at the **merge**, not at a verifier:
+duplicates of each other, and re-files of items rounds 5-9 list as accepted, deliberately not done, or
+already refuted.
+
+---
+
+# Medium
+
+## J1 [x2] - Azure reconcile bulk delete holds the global write lock for O(selected targets x total subnets), refusing every other write in the deployment
+
+**Severity:** medium | **Confidence:** confirmed | **Cite:**
+`src/Bastet/Controllers/SubnetController.AzureReconcile.cs:156` (the per-target save), `:143` (the
+redundant tree read), `:113` (the lock)
+
+Found by four beats (`azure`, `locking`, `regression`, `deadcode`) across passes A, B and deep - seven
+raw reports, one defect.
+
+**What goes wrong.** An Admin runs the reconcile wizard against a subscription with 200 stale
+Azure-linked subnets in an instance holding 65,996 subnets, ticks `#rec-select-all`
+(`_StepReview.cshtml:44` - there is no cap on the `[FromBody]` id list) and clicks delete.
+`POST /Subnet/BulkDeleteStaleAzureSubnets` takes 59-68 s, of which ~55 s is inside
+`ExecuteWithSubnetLockAsync`. Two O(table) terms run **once per selected target, inside the lock**:
+
+1. `ArchiveSubnetSubtreeAsync` -> `GetAllDescendantsOrdered` (`Delete.cs:174` -> `Helpers.cs:55`) issues
+   `context.Subnets.ToListAsync()` - a **tracking** read of the entire `Subnets` table - and `:143`
+   issues a second, redundant one whose result is the identical list `ArchiveSubnetSubtreeAsync` already
+   computes and throws away. 401 whole-table reads in one request.
+2. Because that tracking read leaves all 66,000 entities in the change tracker, the per-target
+   `await context.SaveChangesAsync()` at `:156` runs `DetectChanges` over all of them, 200 times. That
+   save alone accounted for 49.9 s of the in-lock time.
+
+Nothing needs the per-target save - it is all one transaction committed at `:159`.
+
+**Wrong output:** a legitimate second user's write is **refused**, not merely delayed. Server-side SQL
+time is negligible (~21 ms for the 25 reads in a 12-target control); the cost is client-side
+materialisation and `DetectChanges`.
+
+**Reproduction.** Verifier's own catalog `bastet_vc1p`, two Bastet processes (5541, 5542) on it, seeded
+`10.0.0.0/8 -> 256 x /16 -> 65,536 x /24` plus 200 Azure-linked /28 ghosts whose `AzureResourceId` names
+non-existent subnets under a real VNet, so `ConfirmProposedDeletionsAsync` gets a genuine ARM 404 per
+row. `POST /Azure/ReconcileScan` returned 200 items.
+
+```
+DELETE_HTTP=200 DELETE_TIME=67.936699
+{"success":true,"redirectUrl":"/Subnet","targetsDeleted":200,"subnetsArchived":200,"hostIpsArchived":0}
+
+rival1 (+2s,  port 5542) wait=1.669  http=302   -- fired before the lock was taken
+rival2 (+20s, port 5542) wait=30.359 http=200   -- REFUSED: page contains
+        'The operation timed out due to high concurrency. Please try again.'   (Create.cs:138)
+rival3 (+45s, port 5542) wait=23.612 http=302
+
+sys.dm_tran_locks, 1 Hz, during that request:
+  01:23:09.110  97|X|GRANT|0:[Bastet:SubnetOperations]:(b83d66a6)
+  01:23:24.598  97|X|GRANT|...  109|X|WAIT|0:[Bastet:SubnetOperations]:(b83d66a6)
+  01:24:11.425  97|X|GRANT|...  126|X|WAIT|...
+  -> 57 consecutive GRANT samples for session 97; 27 WAIT samples for the two rivals.
+
+EF command log (Development already sets Database.Command=Information):
+  401 whole-table 'FROM [Subnets] AS [s]' reads = 1 outside the lock + 2 per target inside it
+  12-target control, same 65,995-row table: exactly 25 = 1 + 2x12, DEL12_TIME=7.259461
+```
+
+The rivals were issued against **a separate process on the same catalog**, so this is the `sp_getapplock`
+and not an in-process gate. Scaling was measured independently on three rigs and is linear in
+targets x tree size: 256/512/1024/4096 targets -> 1.40 / 3.06 / 7.20 / 93.67 s; and with the *same* 1024
+targets, padding the table with rows that are never selected, archived or read took 7.28 s (pad 0) to
+43.47 s (pad 7000) - the signature of an unfiltered `ToListAsync`. A single 5,000-child subtree delete on
+the same 200k tree took 23.3 s, i.e. the cost is the scans, not the archiving. The lock plumbing itself
+is sound: holding `Bastet:SubnetOperations` from an external `sqlcmd` session made a far-instance
+`POST /Subnet/Create` fail at exactly 30.038 s while `GET /Subnet` still answered 200 in 0.093 s.
+
+**Fix.** (a) give `GetAllDescendantsOrdered` an optional `List<Subnet>? treeCache`
+(`Helpers.cs:52-55`, `treeCache ?? await context.Subnets.ToListAsync()`) and thread it through
+`ArchiveSubnetSubtreeAsync` (`Delete.cs:171,174`); load the tree once before the reconcile loop and pass
+it - subtrees are disjoint, so a snapshot taken before the first archive still names every later
+target's descendants. (b) have `ArchiveSubnetSubtreeAsync` fill an optional `List<int>?
+archivedSubnetIds` from the `toDelete` list it already builds, and delete the redundant call at `:143`.
+(c) move `await context.SaveChangesAsync()` from `:156` to after the loop - it is already one
+transaction, and `alreadyArchived` already skips any target cascaded away, so `FindAsync` never has to
+observe a deleted row. Measured: 67.9 s -> 5.81 s, 401 reads -> 2, rival create 30.3 s REFUSED -> 0.4 s
+succeeded, output byte-identical (`targetsDeleted:200, subnetsArchived:200, hostIpsArchived:0`), suite
+716/716.
+
+**Verifier correction - the fix as written is INCOMPLETE, and each gap bites.**
+
+1. **The cache must be a TRACKING read, and the finding never says so.** It says to thread the cache
+   *"exactly the way I3 threaded `LoadSubnetTreeForBatchAsync`"*, and that helper (`Helpers.cs:129-130`)
+   is `AsNoTracking()` - the only such helper in the file, so that is what an implementer will write.
+   Built that way it passes the 200-flat-leaf benchmark in 5.95 s and then 500s on the first target that
+   has descendants:
+   ```
+   {"success":false,"error":"The delete failed and no changes were saved. Details have been logged."}
+     System.InvalidOperationException: The instance of entity type 'Subnet' cannot be tracked because
+     another instance with the same key value for {'Id'} is already being tracked.
+        at InternalDbSet`1.Remove(TEntity entity)
+        at ...ArchiveSubnetSubtreeAsync(...) SubnetController.Delete.cs:line 233
+   ```
+   Cause: the per-subnet host-IP `Include` at `Delete.cs:184-186` tracks a fresh instance of every
+   descendant, and `Remove` is then called on the detached cached instance. **A flat leaf-only benchmark
+   - which is exactly the finding's 200-target scenario - cannot see this.**
+2. **It does not compile as described.** `SubnetController.AzureReconcile.cs` has no
+   `using Microsoft.EntityFrameworkCore;`, so `await context.Subnets.ToListAsync()` before the loop
+   gives `error CS0411`. Round 9 recorded this same trap against I3's fix; the finding repeats it.
+
+With a tracking cache and that `using`, both the flat and the nested cases pass and match HEAD exactly
+(nested: `targetsDeleted:1, subnetsArchived:3, hostIpsArchived:1`, identical archive rows).
+
+**Cheaper interim - sound exactly as stated, and if only one thing ships this is it.** Move
+`await context.SaveChangesAsync()` from `:156` to after the loop. One line, no signature change, builds
+clean, byte-identical output: 67.9 s -> 28.5 s, and all three rivals lifted from refused/queued to
+succeeding. Parts (a)+(b) alone are worth little - the save is the dominant term.
+
+**Two candidate fixes were built, measured, and are NOT worth taking.** Removing only the redundant
+`:143` read: 59.4 s -> 57.3 s (401 -> 201 reads; the saves still dominate). Replacing the per-subnet
+host-IP `Include` N+1 at `Delete.cs:182-192` with a single `WHERE SubnetId IN (...)`: a 20,081-subnet
+root delete went 22.50 s -> 22.74 s, i.e. nothing, despite removing 20,081 round trips. Do not re-propose
+either.
+
+---
+
+## J2 [x2] - Bulk Azure import commits a re-derived plan without checking it still matches the plan the operator approved
+
+**Severity:** medium | **Confidence:** confirmed | **Cite:**
+`src/Bastet/Controllers/SubnetController.BulkAzure.cs:62` (the re-plan), `:156` (rename write),
+`:190` (the ARM-id stamp)
+
+**What goes wrong.** Admin opens `/Azure/BulkImport`, selects VNet `rig-jb-div` (10.151.0.0/16) and
+previews. Step 3 renders *"New top-level - create rig-jb-div (10.151.0.0/16)"*. While that screen is up,
+a second admin creates an unrelated Bastet subnet `10.151.0.0/16` named `Finance-Prod-Reserved`
+(description *"Reserved by the network team. Not an Azure VNet."*, no Azure link) through the ordinary
+`/Subnet/Create` form. The first admin clicks **Confirm Import** on a screen that says *"apply the plan
+to Bastet"*.
+
+`BulkCreateFromAzurePlanCore` re-runs the planner against the now-changed tree (`:61-62`), gets a
+different plan - `TargetType` flips from `AutoCreateTopLevel` to `ExactMatch` - and executes **that**
+plan with no comparison against what was approved. The commit posts the *selection*, never the plan: the
+preview and commit request bodies are byte-identical on the wire. It stamps
+`AzureResourceId=/subscriptions/<sub>/.../virtualNetworks/rig-jb-div` onto `Finance-Prod-Reserved`
+(`:190`) and parents the Azure children under it; with the rename box ticked it also overwrites the
+operator's name (`:156`).
+
+**Wrong output, and it is irreversible in-app:** `AzureResourceId` is written only by the two import
+paths and **never cleared**; `EditSubnetViewModel` does not carry the field and `Views/Subnet/Edit.cshtml`
+never mentions it, so there is no unlink. The row's CIDR also becomes uneditable
+(`SubnetController.Edit.cs:92` throws when the field is non-empty). The row is now inside the reconcile
+wizard's deletion scope, and when the VNet is later deleted in Azure it is archived - into a
+`DeletedSubnets` table with no `AzureResourceId` column and no restore path anywhere in the app.
+
+**The sibling destructive endpoint does the opposite on this exact class of divergence:**
+`SubnetController.AzureReconcile.cs:77-92` rebuilds the plan and returns **409 Conflict**, deleting
+nothing. The single-VNet wizard is immune because `BatchCreateChildSubnetsCore(int parentId, ...)` pins
+its target with `FindAsync(parentId)`.
+
+**Reproduction.** Real headless Chromium driving the real wizard against real ARM, verifier's own
+catalog and instances; `interleave.sh` is the second admin.
+
+```
+PLAN_SHOWN:   VNet "rig-v10c2-div" - prefix 10.152.0.0/16  New top-level  create rig-v10c2-div ...
+INTERLEAVE:   hand-create HTTP 302 | 1 Finance-Prod-Reserved 10.152.0.0/16 arm=<null>
+PLAN_STILL_SHOWN: (unchanged - the screen never repaints)
+COMMIT_SCREEN: "Click the button below to apply the plan to Bastet. This is performed in a single
+                transaction; if anything fails, no changes are saved."  Confirm Import
+POSTED_TO BulkCreateFromAzurePlan: <byte-identical to the preview post>
+COMMIT_RESULT: SUCCESS[Bulk import completed. Created 0 VNet target(s), 2 child subnet(s), renamed 0
+                target(s), linked 1 existing target(s) to Azure, ...]
+CONSOLE_ERRORS: 0
+
+DB after:  1 | Finance-Prod-Reserved | 10.152.0.0/16 | desc='Reserved by the network team...'
+               arm=/subscriptions/.../virtualNetworks/rig-v10c2-div
+           2,3 | rig-v10c2-s1, rig-v10c2-s2 | parent=1
+
+Approved plan, in machine form:
+  ITEM prefix=10.152.0.0/16 targetType=2 (AutoCreateTopLevel) existingTargetSubnetId=None
+Executed plan: ExactMatch onto subnet 1.
+```
+
+Consequence chain, run to the end: `az network vnet delete` -> `ResourceNotFound`;
+`POST /Azure/ReconcileScan` -> `id=1 Finance-Prod-Reserved 10.152.0.0/16 status=VNetDeleted
+descendants=2`; `POST /Subnet/BulkDeleteStaleAzureSubnets {subnetIds:[1]}` -> 200
+`{"targetsDeleted":1,"subnetsArchived":3}`; `SELECT` over `10.152.*` -> 0 rows; `DeletedSubnets` holds
+`Finance-Prod-Reserved` with its original description and **no** `AzureResourceId` column. Rename
+variant: same commit returned `renamedTargets:1, linkedTargets:1` and the row became `rig-v10c2-div`
+with the operator's description preserved - proving it is the same row. Sibling asymmetry, same session:
+`POST /Subnet/BulkDeleteStaleAzureSubnets {subnetIds:[99]}` -> **409**, nothing deleted.
+
+Control: three concurrent identical commits gave 1x200 and 2x400 (*"already exists in Bastet"*), so the
+lock and the re-plan do work - the gap is specifically that nothing compares the re-derived plan with
+the approved one.
+
+**Fix.** Make the commit refuse a plan that is not the plan that was approved, exactly as
+`BulkDeleteStaleAzureSubnets` already does. Add an optional per-prefix expectation to
+`BulkImportSelectionDto` (`{vNetResourceId, addressPrefix, targetType, existingTargetSubnetId,
+autoCreateParentSubnetId, willRename, newName, willMarkFullyAllocated}`), populated by the wizard from
+the preview response; compare each re-derived item against its expectation immediately after `BuildPlan`
+at `:62` and return **409 Conflict** listing the differences. **Cheaper interim:** send and compare only
+`targetType` and `existingTargetSubnetId` - about fifteen lines each side, and it does close the
+reproduced case (approved `AutoCreateTopLevel`/null vs re-derived `ExactMatch`/1 diverges on both
+fields).
+
+**Verifier correction - INCOMPLETE.** The shape is right and the DTO is a plain POCO
+(`AzureBulkImportViewModels.cs:192-208`), so an added nullable property breaks no caller. Two problems:
+
+1. **A stated premise is false.** The fix says the wizard already holds the preview response *"in
+   `lastPlan` (`_BulkScripts.cshtml` renderPlan/commitImport)"*. `grep -n lastPlan` over that file
+   returns **nothing** - `lastPlan` exists only in `_ReconcileScripts.cshtml`. The bulk wizard's state is
+   `lastSelection` and `previewSeq`. `renderPlan(result.plan)` does receive the plan, so stashing it is a
+   two-line addition - but the fix must say it is *adding* client state, not reusing it.
+2. **It is weaker than the precedent it invokes, in the way that matters.**
+   `BulkDeleteStaleAzureSubnets` takes ids only and re-derives server-side; the client cannot opt out.
+   Making the expectation optional so *"leaving the field null keeps the documented direct-JSON-API
+   behaviour unchanged"* means the server is safe only when the client volunteers to be checked - a
+   browser holding a cached older script, or any direct caller, keeps today's behaviour on the Admin-only
+   endpoint that is dangerous precisely because it writes. If the field must stay optional, the null case
+   needs its own recorded decision (log it, or refuse server-side the narrow `ExactMatch`-onto-a-row-that-
+   was-not-in-the-approved-plan case), not silence.
+3. Not mentioned by the fix: the nested expectation object arrives **unsanitized**, because
+   `GlobalSanitizationFilter` does not descend into the nested selection list. Harmless while it is only
+   compared, but it must not be echoed into the 409 body unescaped.
+
+**Both of the fix's rejections are correct and were checked.** *"Re-run the preview at commit time"* is
+the same defect one step later - the operator has already left the preview screen. And a server-only
+rule *"refuse ExactMatch onto a subnet not already linked to this VNet"* really would break the
+advertised adopt path: `AzureBulkImportPlanner.cs:225-226` sets `WillUpdateExisting` with reason *"Will
+import into existing Bastet subnet"* for exactly the unlinked case, and that is what the wizard renders
+as selectable.
+
+---
+
+# Low
+
+## J3 [x1] - Error page binds its status code from the POST body, so a caller picks the status of any re-executed bodiless 4xx
+
+**Severity:** low (filed medium; **corrected down by both verifiers**) | **Confidence:** confirmed |
+**Cite:** `src/Bastet/Controllers/ErrorController.cs:17`
+
+**What goes wrong.** `UseStatusCodePagesWithReExecute("/Error/{0}")` (`Program.cs:524` Development,
+`:529` Production) re-executes the pipeline for the **same** request - same method, same body - with the
+path rewritten to `/Error/<real status>`. `HttpStatusCodeHandler(int statusCode)` binds through MVC's
+default composite value provider, where `FormValueProviderFactory` precedes `RouteValueProviderFactory`.
+A form field named `statusCode` in the original POST body therefore **beats the route segment the
+middleware just set**. The guard at `:32` only clamps outside 400-599, so 400 -> 404 passes untouched.
+
+Two legs survive verification:
+
+- **Status laundering of empty-bodied framework statuses.** An authenticated user posting
+  `Name=x&statusCode=404` to `/Subnet/Create` with a stale antiforgery token gets **404 Not Found** on
+  the wire and in the request log, though the framework produced 400. `POST /No/Such/Path` with
+  `statusCode=451` answers **451**. Anonymous in Production: `POST /Error/404` with `statusCode=451`
+  answers **451**.
+- **A malformed form becomes a server fault, with no attacker at all.** `Name=x%00y` (a NUL in any form
+  value) makes `FormPipeReader` throw, `CompositeValueProvider.TryCreateAsync` abandons binding for every
+  parameter, `statusCode = 0`, and the `:32` guard turns that into **500 Internal Server Error** with the
+  page printing *"Status Code: 0"*. The same happens for a malformed multipart POST (bad boundary,
+  truncated upload) - an ordinary client bug reported as a server fault.
+
+**The two verifiers disagree on the 403 leg, and the disagreement matters.** The finding's headline is
+that a View-role user's 403 launders into 404, hiding an authorization denial from log analysis. That
+leg was only ever reproduced on a rig copy whose `DevAuthHandler` reads roles from an `X-Rig-Roles`
+header. On the **shipped** build the second verifier established no launderable bodiless 401/403 exists:
+Development's `DevAuthHandler` issues Admin (`DevAuthHandler.cs:31`), satisfying all four policies;
+Production's cookie handler sets `AccessDeniedPath` (`Program.cs:200`), so a Forbid is a 302; and the
+three literal `StatusCode(403, <json>)` sites write a body, which `StatusCodePagesMiddleware` skips.
+Measured both ways on one endpoint: `POST /Subnet/BatchCreateChildSubnets` **with** a valid token
+returns 400 with `{"subnets":[...]}` unlaundered; **without** a token (empty-bodied 400) returns 451.
+Treat the 403 leg as mechanism-only until a deployment that emits a bodiless 403 is demonstrated.
+
+Two further legs were **struck** as pre-existing and already documented: `POST /Error/451` answering 451
+and `GET /Error/200` answering 500 with *"Status Code: 200"* both happen through the **route** alone, and
+round 7 recorded that the route segment is caller-supplied (`ErrorControllerTests.cs:99-101` pins it).
+Only the framework-generated-4xx half is new ground.
+
+**Reproduction.** Pristine shipped DLL, Development, no source modification:
+
+```
+POST /Subnet/Create  Name=x                -> HTTP/1.1 400 Bad Request        (control, "Status Code: 400")
+POST /Subnet/Create  Name=x&statusCode=404 -> HTTP/1.1 404 Not Found          ("Resource Not Found")
+POST /Subnet/Create  Name=x&statusCode=451 -> HTTP/1.1 451 Unavailable For Legal Reasons
+POST /Subnet/Create  Name=x%00y            -> HTTP/1.1 500                    ("Status Code: 0")
+POST /No/Such/Path   statusCode=451        -> 451     (404 without the field)
+GET  /Error/404?statusCode=451             -> 404     (query loses to route; only the form wins)
+malformed multipart on a 400 path          -> 500     ("Status Code: 0")
+
+app log, antiforgery leg:  "Executing StatusCodeResult, setting HTTP status code 400"
+                        -> "Executing endpoint '...ErrorController.HttpStatusCodeHandler'"
+                        -> "Request finished HTTP/1.1 POST .../Subnet/Create - 404"
+Production (anonymous):  POST /Error/404 statusCode=451 -> 451 ; a=x%00b -> 500
+```
+
+Note the log line is Development-only evidence: `Program.cs:22` pins `Microsoft.AspNetCore` to `Warning`
+outside Development, and a Production instance logged **0** `Request finished` / `Authorization failed`
+lines across the same requests. The wire-level relabelling is what stands.
+
+**Why low.** No data change, no disclosure, no privilege change, no XSS (`@Model.StatusCode` is an
+`int`), no cross-user effect (`Cache-Control: no-store,no-cache`), and the caller cannot reach 2xx or
+3xx. A caller relabels *their own* failed request.
+
+**Fix.** `public IActionResult HttpStatusCodeHandler([FromRoute] int statusCode)`. Built and driven:
+closes the laundering completely (400 stays 400, `POST /No/Such` stays 404), leaves the redirect path
+intact (`GET /Subnet/Details/99999` followed -> 404, `GET /Error/409` -> 409), builds 0/0, **716 passed,
+0 failed** - the four `ErrorControllerTests` call sites that invoke `HttpStatusCodeHandler(int)` directly
+still compile.
+
+**Verifier correction - INCOMPLETE against the finding's own scenario 4.** `[FromRoute]` does **not** fix
+the unreadable-form leg: when the form reader throws, binding is abandoned for every source, so the NUL
+and malformed-multipart POSTs are still 500 *"Status Code: 0"*. Closing that too needs the value read
+outside model binding - a parameterless signature with
+`int statusCode = int.TryParse(RouteData.Values["statusCode"] as string, out int r) ? r : Response.StatusCode;`
+- which was built and verified to fix all four legs (NUL POST -> 400, page says *"Status Code: 400"*) but
+breaks the four test call sites with `error CS1501: No overload for method 'HttpStatusCodeHandler' takes
+1 arguments` (`ErrorControllerTests.cs:32, 46, 94, 112`). Recommendation: take the parameterless variant
+plus the four one-line test updates; take `[FromRoute]` alone if only the laundering is in scope. No
+sibling call site is missed either way - the eleven `RedirectToAction(..., new { statusCode = N })` sites
+generate `/Error/N` and are followed by a fresh GET with no form body.
+
+---
+
+## J4 [x1] - A concurrent 4xx anywhere in the session steals the pending error-page message: the unrelated page prints it, the intended page loses it
+
+**Severity:** low | **Confidence:** confirmed | **Cite:**
+`src/Bastet/Controllers/ErrorController.cs:22`
+
+**What goes wrong.** `ErrorController.HttpStatusCodeHandler` is two things at once: the explicit
+redirect target of eleven controller sites that first stash a diagnostic in
+`TempData["ErrorPageMessage"]` (`Read.cs:43`, `Delete.cs:22`, `:127`, `Edit.cs:22/:59/:190/:251`,
+`AzureController.cs:24/:36/:184/:292`), and the automatic target of `UseStatusCodePagesWithReExecute`
+for every bodiless 4xx/5xx. Line 22 reads that key **unconditionally**, and a TempData read *consumes*
+it. Any unrelated 4xx that lands between a controller's 302 and the browser following it takes the
+message.
+
+Tab A requests `GET /Subnet/Edit/999` (row archived): the controller stashes *"The subnet with ID 999
+could not be found or may have been deleted."* and 302s to `/Error/404`. Tab B, on a form with a stale
+antiforgery token, posts `/Subnet/Create`. **Wrong output:** tab B is served an HTTP 400 page titled
+*"Bad Request"*, *"Status Code: 400"*, whose body reads *"The subnet with ID 999 could not be found or
+may have been deleted."* - a statement about a request that browser never made - and tab A then gets the
+generic *"The resource you requested could not be found."*
+
+**Reachability is wider than filed, in two directions found by the verifiers.** (a) **No concurrency is
+required at all:** an abandoned redirect (user hits Stop, closes the tab, the follow-up fails) leaves the
+message pending indefinitely - 30 unrelated 200s later, a mistyped URL rendered the stale subnet message.
+(b) **Two stale rows in two tabs is the most reachable path and it is not the filed one:** 10 of 12
+real-Chromium trials had one tab printing the *other* tab's diagnostic. (c) A 4xx re-execute with
+*nothing* pending still emits a TempData-clearing `Set-Cookie`, so an overlapping 4xx that started before
+the 302 silently **deletes** the message rather than stealing it (3 of 36 runs).
+
+**Reproduction.** One cookie jar = one browser, pristine `dcc15ab`:
+
+```
+GET /Subnet/Edit/999  -> 302 Location: /Error/404 ; Set-Cookie: .AspNetCore.Mvc.CookieTempDataProvider=...
+GET /css/nope.css     -> 404, Content-Type: text/html, 6369 bytes
+                         Set-Cookie: .AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970
+                         body: "Status Code: 404" + "The subnet with ID 999 could not be found..."
+GET /Error/404        -> 404, SPECIFIC MESSAGE ABSENT: "The resource you requested could not be found."
+
+POST /Subnet/Create (stale token) -> 400, <title>Bad Request - BASTET</title>,
+                                     "The subnet with ID 999 could not be found or may have been deleted."
+GET /Error/403 with the message pending -> 403, "Status Code: 403" + the same sentence.
+
+Control: GET /Subnet (200) does NOT consume it - only a request reaching /Error does.
+Real Chromium, 36 runs: clean=26, wrong-page-printed-it=10, tab-A-lost-it=3.
+Real Chromium, two stale rows in two tabs, 12 trials: 10 crossed.
+```
+
+**Why low.** The text is server-composed from an int id (round 3's B6 removed the query-string source),
+`_ErrorLayout.cshtml:7` Razor-encodes it, and the cookie is `SameSite=lax; httponly` and same-origin - so
+no injection, no cross-user leak. What is left is a misleading diagnostic on the wrong page and a lost one
+on the right page.
+
+**Fix.** Only read the stashed message when the request really is the explicit redirect, not the
+automatic re-execute. With `using Microsoft.AspNetCore.Diagnostics;`:
+
+```csharp
+string? errorMessage = HttpContext.Features.Get<IStatusCodeReExecuteFeature>() is null
+    ? TempData["ErrorPageMessage"] as string
+    : null;
+```
+
+Built and measured: 0 warnings, **716/716**, the interleaved `/css/nope.css` and antiforgery-400 pages
+render their own generic text and the message survives to `/Error/404`, the intended redirect path is
+unchanged, and as a bonus the patched re-execute emits no `Set-Cookie` at all, closing the silent-delete
+variant. Unit tests are unaffected because `DefaultHttpContext` carries no such feature.
+
+**Verifier correction - INCOMPLETE, and the interim is unsupported.**
+
+1. **Redirect-vs-redirect collisions are not covered**, because neither request carries the feature.
+   Measured on the *patched* build: `GET /Subnet/Edit/999` (stashes) then `GET /Azure/BulkImport` ->
+   `/Error/403` (overwrites with *"Azure Import feature is not enabled"*); `/Error/404` then renders the
+   Azure sentence and `/Error/403` renders the generic default. Same wrong output, after the fix. This is
+   also the 10-of-12 real-browser path, i.e. the fix misses the variant an operator is most likely to hit.
+   Direct navigation to `/Error/{code}` likewise still consumes a pending message.
+2. **The "cheaper interim" (ship a `wwwroot/favicon.ico`) is not supported by measurement.** `/favicon.ico`
+   does 404 with a 6348-byte HTML page, but real headless Chromium issued **zero** favicon requests across
+   ~40 navigations, and a favicon fetch is triggered by a document that has already loaded - i.e. after the
+   ~1 ms window, never inside it. Keep it only as *"removes one stray 404"*, never as *"removes the most
+   common thief"*.
+3. Side effect worth stating rather than discovering: because re-executes no longer flush the key, an
+   abandoned message now survives strictly longer. It is never rendered wrongly, so this is not a
+   regression.
+
+The change that closes the whole class is making the message request-scoped instead of session-scoped -
+answering in place from the eleven sites rather than round-tripping a diagnostic through a single-slot
+browser cookie. That is the round-9 watch-list item, and it subsumes all three variants.
+
+---
+
+## J5 [x1] - Single-VNet import wizard: "Next: Select Subnets" stays enabled when `loadVNets` repopulates the dropdown, leaving a live-but-inert primary button
+
+**Severity:** low | **Confidence:** confirmed | **Cite:**
+`src/Bastet/Views/Azure/Import/_ImportScripts.cshtml:188` (`loadVNets`' `beforeSend`)
+
+**What goes wrong.** On `/Azure/Import/{id}`: pick the subscription, click **Next: Select VNet**, pick a
+VNet (the change handler at `:107-114` enables `#select-vnet-btn`), click **Back to Subscriptions**, then
+**Next: Select VNet** again. No change event fires anywhere, `loadVNets` re-runs, and its success branch
+does `$dropdown.empty()` (`:199`) and re-appends the disabled/selected placeholder (`:200`), which resets
+the select's value to `""` **without** firing `change`. `beforeSend` (`:188-193`) resets `#vnet-loading`,
+`#vnet-selection`, `#vnet-error` and `#no-vnets` but not the button, and `:110`/`:112` inside the change
+handler are the **only** code in the tree that touches its disabled state.
+
+**Wrong output:** the dropdown reads *"-- Select a Virtual Network --"* while **Next: Select Subnets**
+renders as a fully saturated, hit-testable `btn-primary`. Clicking it hits
+`selectedVNetId = $("#vnet-select").val()` -> `""` -> the `if (selectedVNetId)` guard at `:59` falls
+through: no request, no step change, no spinner, no message. The wizard's primary Next button silently
+does nothing.
+
+This is the step-2 twin of round 7's G10, which fixed exactly this class for step 3's
+`#select-all-subnets` / `#import-subnets-btn` by resetting them in `loadSubnets`' `beforeSend`
+(`:255-256`); `loadVNets` never got the same treatment. The in-repo name for this shape is
+`_ReconcileScripts.cshtml:68-72`: *"A permanently live, inert button"*.
+
+**Reproduction.** Real headless Chromium (jQuery 4.0.0, Bootstrap 5.3.8), two verifiers with independently
+written harnesses, four runs, identical result. One measured with a raw `page.Mouse.ClickAsync` so that
+"the click landed" is not doing inferential work:
+
+```
+B first entry to step 2 : value=""  disabledProp=true  :disabled=true  opacity=0.65  pointer-events=none
+C after picking a VNet  : value=".../virtualNetworks/rig-vnet-visible"  disabledProp=false  opacity=1
+  [REQ] GET /Azure/GetVNets?subscriptionId=...&subnetId=1        (the second load)
+E re-entry to step 2    : value=""  text="-- Select a Virtual Network --"  optionCount=3
+                          disabledProp=false  hasDisabledAttr=false  opacity=1  pointer-events=auto
+F CLICK ACCEPTED -> Azure requests after the click: []   count=0
+                    step3 pill still DISABLED; #subnet-selection/#subnet-error/#no-subnets all d-none
+                    #vnet-resource-id = ''      CONSOLE_ERRORS: 0
+G control: pick a VNet -> GET /Azure/GetSubnets?vnetResourceId=...  -> step 3 ACTIVE, 2 rows
+```
+
+Screenshot of state F shows a solid blue **Next: Select Subnets** directly under the placeholder text.
+Leg G proves the button is not broken, only mis-enabled.
+
+**Reachability is slightly wider than filed:** `invalidateVNetStep()` (`:84-88`), which runs when the
+subscription dropdown changes, disables `#step2-tab`, `#step3-tab` and `#import-subnets-btn` but likewise
+never touches `#select-vnet-btn`, so switching subscriptions lands in the same state. Not claimed as
+reproduced - the rig tenant exposes only one subscription.
+
+**Fix - SOUND, and the only fix this round that needed no correction.** One line in `loadVNets`'
+`beforeSend`, beside the four panel resets:
+
+```javascript
+$("#select-vnet-btn").prop("disabled", true);
+```
+
+Same placement and pattern `loadSubnets`' `beforeSend` already uses, so the wizard ends up with one rule
+rather than two that disagree. Built and driven on the patched build: state E flips to
+`disabled / :disabled / opacity 0.65 / pointer-events none`, Playwright then **refuses** the click, the
+happy path is untouched (leg G still issues `GetSubnets` and activates step 3), 0 console errors, build
+0/0, suite **716/716**. `loadVNets` has exactly one caller (`:43`), so `beforeSend` covers every entry;
+`loadAzureSubscriptions()` is called once at document-ready and needs no equivalent.
+
+**Two notes on the alternatives.** The "cheaper interim"
+(`prop("disabled", !$("#vnet-select").val())` after the `$.each`) does close the reproduced path but is
+strictly worse - it leaves the button stale on the error and no-vnets branches. Those branches are
+currently unreachable to a user (`#vnet-selection` keeps its `d-none`, and the button's box is
+zero-sized), so `beforeSend` placement is defence-in-depth there rather than a second live defect; that
+is still the right home. **Do NOT fix this with `$("#vnet-select").trigger("change")`** - it would re-run
+`invalidateSubnetStep()` as a side effect and reintroduce the synthetic-event pattern round 4's D1
+removed.
+
+---
+
+## J6 [x1] - Production sign-out answers 500 and silently discards the session-cookie deletion when the OIDC discovery document is unavailable
+
+**Severity:** low (filed medium; **corrected down by both verifiers** to match round 9's I6, which shipped
+the byte-identical consequence at low) | **Confidence:** confirmed | **Cite:**
+`src/Bastet/Controllers/AccountController.cs:67`
+
+**What goes wrong.** Round 9's I6 fixed one way for `GET /Account/Logout` to answer 500 with the session
+still alive (a non-ASCII `returnUrl` reaching the Location header). The same failure mode survives at the
+sibling statement the fix did not touch, and needs no crafted input.
+
+Preconditions: Production, `BASTET_OIDC_AUTHORITY` configured, and the process has not yet successfully
+fetched `{authority}/.well-known/openid-configuration` - i.e. it started or restarted during an IdP
+outage, a DNS/firewall change, or a misconfigured authority. `Program.cs` never touches the discovery
+document at startup, so a Production process starts happily against an unreachable authority, and the
+user's ticket survives the restart because the DataProtection key ring is DB-persisted
+(`Program.cs:115-119`).
+
+A user with a valid `.AspNetCore.Cookies` ticket clicks Logout. `:51-54` queues a `Set-Cookie` deletion
+for every request cookie; `:67-70` returns
+`SignOut(props, CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme)`.
+The cookie handler queues its own deletion, then `OpenIdConnectHandler.SignOutAsync` throws
+`IDX20803`. Because `SignOut(...)` is an `IActionResult`, the throw happens during **result execution**,
+after the action returned, so nothing in the action can intercept it - and `UseExceptionHandler("/Error")`
+calls `Response.Clear()`, taking every queued `Set-Cookie` with it (the source says so at
+`Program.cs:539-546`).
+
+**Wrong output:** HTTP 500 with **zero** `Set-Cookie` headers. The browser keeps its ticket, the cookie
+handler validates it locally without contacting the IdP, and a privileged session the operator explicitly
+asked to end keeps running for up to the 1 h sliding expiry.
+
+**Reproduction.** Two Production instances of the **same** pristine DLL, differing only in whether
+discovery resolves - a genuine same-branch control, unlike a Development comparison which returns through
+`Redirect(target)` at `:74`:
+
+```
+A. discovery never fetched:
+   HTTP/1.1 500 Internal Server Error ; set-cookie count: 0
+   System.InvalidOperationException: IDX20803: Unable to obtain configuration from ... Connection refused
+     at ConfigurationManager`1.GetConfigurationAsync
+     at OpenIdConnectHandler.SignOutAsync
+     at AuthenticationService.SignOutAsync
+     at Microsoft.AspNetCore.Mvc.SignOutResult.ExecuteAsync(HttpContext httpContext)
+     at ExceptionHandlerMiddlewareImpl
+
+B. same build, discovery reachable:
+   HTTP/1.1 302 Found ; Location: https://.../endsession?post_logout_redirect_uri=...
+   Set-Cookie: .AspNetCore.Cookies=; expires=Thu, 01 Jan 1970 ...; secure; samesite=lax; httponly
+
+C. scoping: kill the IdP AFTER B has cached the document, repeat -> still 302 + Set-Cookie.
+```
+
+One verifier went further and minted a genuine `.AspNetCore.Cookies` ticket against the same DB-persisted
+key ring: `GET /Account/Roles` 200 rendering the user before Logout, 500 with zero `Set-Cookie` on Logout,
+**200 again after** on the same jar, and the surviving session still reached the Admin-gated
+`/HostIp/PurgeAllDeletedHostIps` (302 to the "nothing archived" redirect *inside* the action, where an
+unauthorized request 500s).
+
+**Why low, honestly stated.** The window is narrow and self-sealing - one successful discovery fetch
+anywhere in the process's life closes it permanently. Inside that window the deployment is already
+comprehensively broken: an unauthenticated `GET /` also returns 500 through the OIDC *challenge*, so
+nobody can sign in at all, and the user sees a 500 page rather than a signed-out page (the finding's
+*"while believing they signed out"* is overstated). What keeps it a real finding: every other 500 in that
+window fails **closed**; this one fails **open**.
+
+**Fix.** Do not let the local session teardown depend on the remote round trip, and do not perform the
+remote leg as an `IActionResult`:
+
+```csharp
+if (!environment.IsDevelopment())
+{
+    await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+    try
+    {
+        await HttpContext.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme,
+            new AuthenticationProperties { RedirectUri = target });
+        return new EmptyResult();
+    }
+    catch (Exception)
+    {
+        return Redirect(target);
+    }
+}
+```
+
+Built: 0 warnings / 0 errors, no missing using. Patched build against an unreachable authority: **302
+Location: /Account/SignedOut** with the deletion header present, and `/Account/SignedOut` renders 200
+anonymously during the outage. Healthy path byte-equivalent to HEAD (same 302 to the real
+`end_session_endpoint`, same two `Set-Cookie` headers). The finding is right that a `try` around
+`SignOut(...)` as currently written would be unreachable code, and right that all three cheaper interims
+fail (queue-order changes are all erased by `Response.Clear()`; pre-loading discovery at startup does not
+help, because the trigger *is* the IdP being unavailable at process start).
+
+**Verifier correction - INCOMPLETE.**
+
+1. **It breaks 9 of the 716 shipped tests, and the fix does not mention them.** `dotnet test` on the
+   patched copy: `total: 716, failed: 9, succeeded: 707`. All nine are in
+   `test/Bastet.Tests/Security/AccountControllerLogoutTests.cs` - the four
+   `Logout_Production_NonLocalOrMissingReturnUrl_RedirectsToSignedOutPage` cases (`:79`),
+   `Logout_Production_LocalReturnUrl_IsPreserved` (`:90`) and the four
+   `Logout_Production_ReturnUrlKestrelCannotWrite_RedirectsToSignedOutPage` cases (`:117`), each
+   `Assert.IsType() Failure: Expected typeof(SignOutResult), Actual typeof(EmptyResult)`. **These are
+   round 9's own I6 regression pins**, and they read `signOut.Properties.RedirectUri` - the only place
+   `target` is pinned. They must be rewritten in the same commit to assert on the mocked
+   `IAuthenticationService.SignOutAsync(context, OpenIdConnectDefaults.AuthenticationScheme, props)` (the
+   mock already exists in that file's helper and captures the properties), plus a new case that makes the
+   mock throw and asserts a `RedirectResult` to `SignedOutPath` - the regression test this finding
+   actually needs and does not propose.
+2. **The cookie leg should carry `AuthenticationProperties`.** `CookieAuthenticationDefaults.LogoutPath`
+   is `/Account/Logout`, which equals the request path, so `HandleSignOutAsync` takes its redirect branch
+   with a null `RedirectUri` and writes `Location: /Account/Logout` - a self-redirect. Harmless today only
+   because both exits overwrite `Location`, i.e. the fix is correct by accident. Pass
+   `new AuthenticationProperties { RedirectUri = target }` to the cookie leg too.
+3. `catch (Exception)` also swallows `OperationCanceledException` on a client abort and is silent.
+   `AccountController` has no logger; add `ILogger<AccountController>` to the primary constructor to
+   match `Program.cs:257-268`'s `Bastet.Authentication` warning for the sign-in half.
+
+No sibling call site: `SignOut(` appears exactly once in `src/`.
+
+---
+
+## J7 [x1] - Reconcile scopes a subnet by subscription before it recognises its resource ID, so a corrupt Azure link is never classified and the cascade guard blames a subscription that does not exist
+
+**Severity:** low (filed medium; **corrected down by both verifiers** - both consequences are diagnostic,
+nothing is destroyed and nothing becomes deletable) | **Confidence:** confirmed | **Cite:**
+`src/Bastet/Services/Azure/AzureReconciler.cs:83`
+
+**What goes wrong.** A Bastet subnet carries an `AzureResourceId` that is not a parseable ARM id - a
+typo, a truncated value, a migrated string. `AzureResourceId` is free text on the entity
+(`AzureResourceIdentity.cs:26` says so verbatim) and the only write-side check on the import paths is a
+length check, so the app's **own** Admin API will write one: `POST /Subnet/BatchCreateChildSubnets` with
+`subnets[0].AzureResourceId=this-is-not-an-arm-id` returned `{"success":true,"subnetIds":[2]}` and
+persisted it verbatim. No hand-edited row is required.
+
+In `BuildPlan` the subscription-scope test at `:83` runs **before** the three-way recognition at
+`:94-108`. `BelongsToSubscription` is `resourceId.StartsWith($"/subscriptions/{subscriptionId}/")`, so
+such a row fails it for **every** subscription id, is added to `notCovered` and `continue`d. It never
+reaches the `UnrecognisedResourceId` arm at `:105-107` that exists precisely for it - whose own comment
+says *"It is reported for review instead, so the operator can correct the row rather than have it
+silently offered for archival."*
+
+Two wrong outputs:
+
+- **(A)** With no Azure-linked ancestor the scan returns empty `items`, `reviewItems`, `warnings` and
+  `globalErrors`, so the wizard renders its nothing-to-clean banner over a subnet the scan never
+  classified.
+- **(B)** With such a row beneath a stale ancestor, `dcc15ab`'s new `notCovered` guard (`:137-140`)
+  withholds the ancestor with *"...would also archive Azure-linked subnet(s) beneath them that **belong
+  to a different subscription** and were not checked by this scan: 'stale-parent'."* That is **false** -
+  the child names no subscription at all - and unactionable: the offending child is named nowhere in the
+  response, and rescanning any other subscription will never surface it. The reconcile delete then answers
+  409 with the same false reason.
+
+**Reproduction.** All state created through real HTTP endpoints, then one scan over one tree with two
+rows that are both "neither a VNet nor a subnet":
+
+```
+items       : []
+reviewItems : [(3, 'control-storage-acct', 'UnrecognisedResourceId',
+                'The recorded Azure resource ID names neither a VNet nor a subnet, so nothing can be
+                 established about it. Correct or clear the link on this subnet.')]
+Row 2 (AzureResourceId='this-is-not-an-arm-id') appears in NEITHER list. Only the prefix differs.
+
+Under a stale ancestor:
+  warnings: ["1 subnet(s) were withheld from deletion because archiving them would also archive
+             Azure-linked subnet(s) beneath them that belong to a different subscription and were not
+             checked by this scan: 'rig-vnet-gone-vc11'."]
+  POST /Subnet/BulkDeleteStaleAzureSubnets {subnetIds:[4]} -> HTTP 409, same warning, DeletedSubnets = 0
+
+Real Chromium, standalone broken row:
+  SCAN-ERROR panel visible=False ; STALE/REVIEW sections visible=False
+  NOTHING-TO-CLEAN BANNER visible=True
+    "Everything imported from this subscription still exists in Azure. There is nothing to clean up."
+  CONSOLE_ERRORS: 0
+```
+
+**Widened by one verifier:** a **truncated** id that names the scanned subscription itself
+(`/subscriptions/<scanned-guid>`, no trailing slash) is skipped identically and produces the same
+"different subscription" warning - which is then not merely unestablished but directly contradicted by
+the row's own content.
+
+**Two of the finding's claims are corrected, both narrowing it.** (1) The banner text quoted in the
+finding (*"Everything still exists in Azure..."*) exists only in a code comment; the rendered banner is
+subscription-scoped, and the defect case is byte-identical to a genuine other-subscription row, which is
+the shipped, deliberate design. So (A) is better stated as *"a row that is in no subscription is reported
+in no scan"* than as a false clean bill. (2) *"The stale ancestor can never be archived through the app"*
+is **false**: `POST /Subnet/Delete/{id}` with `confirmation=approved` archived it immediately - the
+ordinary delete page carries no Azure gate. The 409 is confined to the reconcile path, and it fires
+identically on the *correct* control case, i.e. that refusal is the intended protection.
+
+**Fix - SOUND.** Recognise the resource ID before scoping it: hoist the type test above `:83`, report an
+unrecognised id as a `ReviewItems` entry, and `continue`; the `else` arm at `:103-108` then collapses.
+
+```csharp
+bool recognised = AzureResourceIdentity.IsAzureSubnet(snapshot.AzureResourceId)
+                  || AzureResourceIdentity.IsAzureVNet(snapshot.AzureResourceId);
+if (!recognised) { plan.ReviewItems.Add(Item(snapshot, AzureReconcileStatus.UnrecognisedResourceId, true,
+        "The recorded Azure resource ID names neither a VNet nor a subnet, so nothing can be established "
+        + "about it. Correct or clear the link on this subnet.")); continue; }
+if (!BelongsToSubscription(snapshot.AzureResourceId, subscriptionId)) { notCovered.Add(snapshot.Id); continue; }
+```
+
+Built by both verifiers: 0 warnings / 0 errors, **716/716** - including the three tests the brief flags
+as arrange-sensitive (`ApplyConfirmations_TargetWhoseDescendantIsAReviewItem_IsAlsoWithheld`,
+`SubnetFromOtherSubscription_Ignored`, `StaleAncestorOverOtherSubscriptionDescendant_IsWithheld`), which
+survive because this moves *classification*, not a guard, and their helpers emit parseable ARM ids. Live:
+the broken child lands in `reviewItems`, the ancestor is still withheld with the honest wording
+(*"...subnet(s) beneath them that were withheld from deletion"*), and a genuine other-subscription
+descendant still produces the "different subscription" warning, so I2's regression path is intact.
+
+Two caveats on implementation, from measurement rather than reading:
+
+- **Write it as a two-way `if/else`.** Simply deleting the `else` arm leaves `AzureReconcileItem? item;`
+  unassigned on one path and will not compile.
+- **Do not oversell it.** The ancestor stays withheld after the fix and the 409 would still be returned;
+  what the fix buys is that the operator is finally told *which row to correct*, so the dead end becomes
+  escapable. A broken link now appears on every subscription's scan instead of none - which is correct,
+  because it is in no subscription - and it lands in `ReviewItems`, which is never offered for deletion.
+
+**The proposed cheaper interim is UNSOUND - do not ship it.** It adds a second
+`WithholdTargetsWhoseCascadeIsBlocked` call with its own wording. That method returns early on
+`if (protectedSubnetIds.Count == 0 || plan.Items.Count == 0)` (`:269`) and its first act on firing is
+`plan.Items.RemoveAll(blocked.Contains)` (`:282`), so on an ancestor whose subtree holds **both** an
+unrecognised row and a genuine foreign-subscription row, whichever guard runs first empties `plan.Items`
+and the second returns silently - the new reason is swallowed and the operator still reads only "a
+different subscription". Observed live. It also re-proposes the shape round 9 struck under I1 (*"a second
+guard with its own wording is new surface for no measured gain"*) for strictly less benefit than the
+two-line reorder.
+
+**Regression test** (proposed and confirmed to fail on HEAD, pass on the patch): mirror
+`StaleAncestorOverOtherSubscriptionDescendant_IsWithheld` with a `Linked(...)` whose resource id is
+`"not-an-arm-id"`, asserting `Assert.Single(plan.ReviewItems)` and
+`Assert.DoesNotContain(plan.Warnings, w => w.Contains("different subscription"))`. Add a second case for
+the truncated `/subscriptions/<scanned-sub>` shape - that is the one where the shipped warning
+contradicts the row's own text. Note the existing
+`UnrecognisedResourceId_IsReviewedNotOfferedForDeletion` theory uses only ids prefixed with the scanned
+subscription, so it pins exactly the half that works.
+
+---
+
+# Info
+
+## J8 [x1] - Deleted-host-IP archive pages print the subnet's CURRENT prefix, so an archived address is shown inside a range that never contained it
+
+**Severity:** info (filed low; one verifier left it as filed, the second corrected it down after finding
+no consumer of the field beyond two Razor templates) | **Confidence:** confirmed | **Cite:**
+`src/Bastet/Controllers/HostIpController.cs:570` (live-subnet branch), `:580-581` (archived branch),
+`Models/DeletedHostIpAssignment.cs:21`
+
+**What goes wrong.** Create `ARCHTEST = 10.150.0.0/24`, assign `10.150.0.200`, delete that host IP (it is
+archived), then narrow `ARCHTEST` to `/25` - which `Subnet/Edit` allows, because
+`ValidateSubnetCidrChangeWithHostIps` returns early when the subnet has **no live host IPs**, and
+deleting the address is precisely what empties that collection. `/HostIp/AllDeletedHostIps` then renders
+`10.150.0.200 | oldhost | ARCHTEST (10.150.0.0/25)` under a column headed **"Original Subnet"**.
+`10.150.0.200` is not in `10.150.0.0/25`. The archive row has no prefix column - only `OriginalSubnetId` -
+so the view has nothing truthful to print and re-derives it at render time.
+
+That the pairing is read as a containment claim is not interpretation: `Views/HostIp/AllHostIps.cshtml:53`
+renders **live** assignments with the byte-identical string `@hostIp.SubnetName
+(@hostIp.NetworkAddress/@hostIp.Cidr)`, where containment is guaranteed by validation. And the displayed
+pairing is unconstructible - re-creating it is refused with *"IP address 10.150.0.200 is outside the
+subnet range 10.150.0.0/25"*.
+
+**The finding's own diagnosis of the mechanism is wrong, and the defect is broader than filed.** It claims
+the column is internally inconsistent - live rows showing current values, archived rows showing historical
+ones. Both verifiers built the archived branch and it is wrong in exactly the same way: `SUBB` archived at
+`/24`, narrowed to `/25`, then deleted, prints `SUBB (deleted) (10.151.0.0/25)` over `10.151.0.200`. Both
+branches print the subnet's **last-known** prefix; neither branch has the datum. The prefix at
+host-IP-deletion time is never stored anywhere.
+
+**Reproduction.** Every step an ordinary UI POST; four archived rows on one page, each printed range
+containment-tested:
+
+```
+step 4  POST /Subnet/Edit/1 Cidr=25  -> HTTP 302 -> /Subnet/Details/1   (accepted, no validation error)
+        SQL: ARCHTEST 10.150.0.0/25 ; LiveHostIps = 0
+
+GET /HostIp/AllDeletedHostIps:
+  IP            | "Original Subnet"                  | IP in printed range?
+  10.170.0.200  | ARCH3 (deleted) (10.170.0.0/24)    | True
+  10.160.0.10   | ARCH2 (deleted) (10.160.0.0/25)    | True
+  10.160.0.200  | ARCH2 (deleted) (10.160.0.0/25)    | False   <- archived branch
+  10.150.0.200  | ARCHTEST (10.150.0.0/25)           | False   <- live branch, as filed
+
+GET /HostIp/DeletedHostIps?subnetId=2 header:
+  "View previously deleted host IP assignments for subnet ARCH2 (10.160.0.0/25)"
+  over rows 10.160.0.10 and 10.160.0.200 - true original prefixes /25 and /24 respectively.
+
+archive row: Id 1 | OriginalIP 10.150.0.200 | Name oldhost | OriginalSubnetId 1   (no prefix column)
+POST /HostIp/Create SubnetId=1 IP=10.150.0.200 -> 200 with
+  "IP address 10.150.0.200 is outside the subnet range 10.150.0.0/25"
+```
+
+**Why info.** Nothing computes with these fields - `grep` shows the only consumers of
+`AllDeletedHostIpItemViewModel.NetworkAddress/Cidr` and `DeletedHostIpListViewModel.NetworkAddress/Cidr`
+are the two Razor templates; no test asserts them, nothing writes from them. Every load-bearing audit fact
+on the row is correct and the parenthetical is decoration. The one action a misled operator might take is
+refused with an accurate message. The per-subnet page's header is also soft - it reads as a present-tense
+description of the subnet you are viewing, and `_HostIpTable.cshtml` carries no per-row prefix at all; the
+load-bearing wrongness is `AllDeletedHostIps.cshtml:65` under an explicitly historical column header.
+
+**Fix.** Stamp the prefix onto the archive row instead of re-deriving it: add `OriginalNetworkAddress`
+(nvarchar(15)) and `OriginalCidr` (int) to `DeletedHostIpAssignment` plus a migration, populate them in
+both archive writers, and read them in the views. The two writers named are the only two -
+`HostIpController.cs:397-408` (`OriginalSubnetId` at `:401`) and
+`SubnetController.Delete.cs:196-207`; `grep` finds no third.
+
+**Verifier correction - INCOMPLETE on three counts, and the interim is UNSOUND.**
+
+1. **No backfill and no nullability decision.** Declared non-nullable, the migration fills existing rows
+   with `('', 0)` and `AllDeletedHostIps.cshtml:63` - which guards on `SubnetName != "Unknown"`, not on the
+   prefix - renders every pre-upgrade row as `NAME (/0)`. That exact output was measured. Make both columns
+   nullable and suppress the parenthetical when null, or backfill in the migration.
+2. **The `:688-692` call site is not well-defined.** `DeletedHostIpListViewModel`
+   (`DeletedHostIpViewModels.cs:6-14`) carries **one** page-level prefix used in
+   `DeletedHostIps/_Header.cshtml:5`, above N rows that can each now carry a different original prefix -
+   measured: `ARCH2`'s two rows, archived at `/24` and `/25`. There is no single value to put there.
+   Either move the prefix onto the per-row view model with a new column in `_HostIpTable.cshtml`, or leave
+   that header describing the live subnet and relabel it.
+3. **"Populate them in both writers" is not a field copy** - the prefix is not on `HostIpAssignment`. In
+   `DeleteConfirmed` the row comes from `FindAsync(ip)` with no `Include` and no subnet loaded, so it needs
+   an extra read inside the open transaction; in `ArchiveSubnetSubtreeAsync` `allHostIps` is a **flat** list
+   across the whole subtree, so it needs a lookup keyed on `hostIp.SubnetId` (`toDelete` already holds
+   every subnet).
+
+**The interim was built and produces worse output than the defect.** Dropping the assignment at
+`:570-571` renders `ARCHTEST (/0)` - the view has no discriminator to suppress the parenthetical. And the
+branch the interim deliberately keeps is equally false (`SUBB (deleted) (10.151.0.0/25)` over
+`10.151.0.200`), so "render the prefix only when it came from the archive" preserves the defect one row
+up rather than removing it. **The only cheap and fully correct variant is the fix's own last alternative:
+drop the parenthetical range from `AllDeletedHostIps.cshtml:65` altogether, or relabel it as the subnet's
+*current* range.** The subnet name plus the `OriginalSubnetId` link is enough to navigate.
+
+---
+
+## J9 [x1] - Bulk import greys out Azure-subnet rows whose parent prefix is blocked, but prints no badge and no reason for them
+
+**Severity:** info (filed low; one verifier corrected it down, the other left it as filed) |
+**Confidence:** confirmed | **Cite:**
+`src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:238` (the reason condition), `:232` (the disabled
+condition), `:161` (`availabilityBadge` returning `""` for `"Available"`)
+
+**What goes wrong.** `:232` disables a subnet checkbox when `!subnet.isSelectable ||
+!prefixInfo.isSelectable`, but `:238-240` appends the explanatory reason only when
+`!subnet.isSelectable`, and the badge helper returns the empty string for `Available`. So the rows
+disabled **because their VNet prefix is blocked** render as a greyed-out checkbox with no badge and no
+text - while the sibling row directly above them, disabled by the same line of code, carries both. That
+asymmetry is the signature of `:238` not being updated when the `|| !prefixInfo.isSelectable` cascade was
+added at `:232`; the in-file comment at `:229-231` documents the cascade and says nothing about
+suppressing the reason.
+
+This is also the steady state after any successful bulk import: the imported parent then has children, so
+`AnnotatePrefix` returns `Blocked` on every later run while any Azure subnet added since is `Available`.
+
+**Reproduction.** Real ARM, real headless Chromium, DOM dump of `#bulk-vnet-tree .form-check`:
+
+```
+bulk-prefix-3-0   disabled=true  badges=[10.60.0.0/16, Cannot import]
+                  reason="Bastet subnet 'Rig Parent 10.60' already has child subnets. Already imported?"
+bulk-subnet-3-0-0 disabled=true  badges=[Cannot import]
+                  reason="Bastet subnet 'child-of-1060' already uses 10.60.1.0/24."
+bulk-subnet-3-0-1 disabled=true  badges=[]  reason=(NONE)     <- rig-subnet-beta 10.60.2.0/24
+bulk-subnet-4-0-0..3 disabled=true badges=[] reason=(NONE)    <- gamma2/delta2/eps2/zeta2
+CONSOLE_ERRORS: 0
+
+server payload for those rows: "statusName":"Available","reason":null,"isSelectable":true
+"Hide unavailable" ON: both 10.60 cards vanish entirely; EMPTY_STATE "(none)" - no explanation either way.
+select-all then preview: zero blocked rows submitted -> display-only defect.
+```
+
+**Two of the finding's claims are corrected, both narrowing it.** (1) It says six rows; it is **five** -
+the sixth (`rig-full-span`) needs the 10.92 VNet imported first and renders **enabled** from the stated
+inputs. (2) *"Zero explanation ... cannot tell them apart from rows unclickable by accident"* is too
+strong: each such row sits indented inside its prefix's own card, directly beneath a red **Cannot import**
+badge and a full sentence of reason, and the two can never be separated. The legend framing is the weakest
+part of the finding: `_StepSelection.cshtml:8` is a badge glossary, not an invariant, and it is **already**
+loose in the other direction at HEAD - a `Will update existing` prefix is neither greyed nor unselectable
+(measured: `bulk-prefix-1-0 | disabled=false`).
+
+**Fix - UNSOUND AS WRITTEN. It does not run.** The fix declares
+`const subnetBlockedByPrefix` at the reason site (`:238`) and references it in the label built at
+`:233-236` - a temporal dead zone. Razor never parses the embedded JS, so the project **builds clean**,
+and then:
+
+```
+SELECTION_VISIBLE: False   LOADING_VISIBLE: True   TREE_ROWS: 0   ENABLED PREFIXES: 0
+PAGEERROR: ReferenceError: Cannot access 'subnetBlockedByPrefix' before initialization
+    at Object.<anonymous> (/Azure/BulkImport:574:40) at renderVNetTree (:520:15) at Object.success (:481:21)
+```
+
+`renderVNetTree` throws before `#bulk-vnet-selection` is un-`d-none`d, so step 2 of the bulk wizard spins
+forever with zero checkboxes - strictly worse than the defect it repairs. Both verifiers built it
+independently and hit the identical failure.
+
+**Repair, built and measured:** hoist the declaration to just after `const $subnetDiv = ...`, before the
+checkbox and label. All five rows then render `badges=[Cannot import]` plus *"Its VNet prefix cannot be
+imported, so this subnet cannot be either."*, `rig-subnet-alpha` keeps its own specific reason, the
+preview still builds the correct plan for the selectable VNets, and console errors are 0.
+
+**Three further notes.**
+
+- **The fix misses its own sibling case.** The `if (!subnet.isSelectable)` guard also swallows the reason
+  of a *selectable* subnet, and `AnnotateSubnet` produces exactly one: the encompassing subnet, whose
+  reason is *"Covers the whole VNet prefix, so it marks the target fully allocated instead of being
+  created."* Measured `reason=(NONE)` on screen **before and after** the proposed fix. The smaller and more
+  complete change is to append `reasonHtml(subnet.reason)` unconditionally and add the prefix-blocked
+  sentence only when the row has no reason of its own - which also removes the extra branch.
+- The `else if (subnetBlockedByPrefix)` is redundant inside the else (`subnet.isSelectable` is necessarily
+  true there), and reusing the `bg-danger` **Cannot import** badge trades one legend inaccuracy for
+  another - the legend defines that badge as *"conflicts with something already in BASTET"*, which is false
+  for `rig-subnet-beta`. A distinct badge would keep the legend honest.
+- The cheaper interim (soften the legend at `_StepSelection.cshtml:8`) is fine but incomplete: any legend
+  rewrite must fix **both** directions, not only add the "sits under a greyed prefix" clause.
+
+No sibling call site: `isSelectable` appears in exactly one view, and the only other `prop('disabled'`
+view is the unrelated CIDR calculator.
+
+---
+
+# Refuted
+
+| Candidate | What it claimed | Why it was killed |
+|---|---|---|
+| **Security-header middleware is bypassed by two responses written above it** - `src/Bastet/Program.cs:547`, filed **info**, `[x1]` | That the header middleware at `:547` sits *below* both error handlers, so two responses ship without `X-Content-Type-Options`, `Referrer-Policy`, `CSP: frame-ancestors` or `X-Frame-Options`: **(a)** the Development developer-exception page, which calls `Response.Clear()` and writes its own body carrying the `SqlException` text, catalog name, source paths, query string and cookie values; and **(b)** the Production plain-HTTP `307` from `UseHttpsRedirection` at `:536`, which short-circuits before `:547`. | **Both mechanisms reproduce byte for byte on the pristine build; neither is a defect.** **(b)** is an automatic refutation on this round's own list - it exists only where the deployment is configured for HTTPS. Controls run: with no `ASPNETCORE_HTTPS_PORT` there is no 307 at all and the response carries 4/4; with `X-Forwarded-Proto: https` (i.e. behind the TLS-terminating proxy) the redirect is suppressed and the response carries 4/4. The 307 is a bodyless `Content-Length: 0` hop with nothing to sniff, no document to frame and no navigation to leak a referrer from. **(a)** is Development-only and its consequence was measured to be nil: in real Chromium the page frames (so the header is genuinely absent and would be effective) but the attacker origin cannot read it - `BLOCKED:TypeError`; the `<script src>` include ERRORs; direct navigation gets an explicitly-typed `text/html` with the injected `<script>alert(1)</script>` HTML-encoded; the page has 0 anchors, 0 forms, 0 external subresources. Round 4 already priced these four headers on exactly this class of page (`AUDIT-FINDINGS-4.md:227-228`: *"framing it accomplishes nothing and MIME-sniffing is moot on a Razor `text/html` body"*). **The load-bearing overstatement was proved, not asserted:** the finding's stated wrong output is the *body* - which is `UseDeveloperExceptionPage` doing exactly what it is built to do - and running the finding's own proposed fix produced 4/4 headers **and** the identical body, `SECRETVALUE123` still twice, `QUERYSECRET456` still once, the catalog still four times. A fix that closes the cited gap and changes none of the narrated harm is a fix for a different problem. And the regime itself is permanently-accepted item 2: Development has no authentication at all (an anonymous curl renders "Admin" on `/Account/Roles` and passes the Admin-only purge gate), so a deployment reaching (a) has already handed full Admin to every anonymous visitor. What is left - *"the comment at `:497` says every response and it does not"* - is comment accuracy with no measurable wrong behaviour behind it. |
+| **Single-VNet import wizard offers a VNet-spanning Azure subnet as an ordinary importable child; importing it creates nothing and silently flips the parent to fully-allocated** - `src/Bastet/Views/Azure/Import/_ImportScripts.cshtml:311`, filed **info**, `[x1]` | That `fullyEncompassesVNetPrefix` is carried in a hidden input at `:310` but never surfaced in the label, so the row renders like any other; ticking it imports **zero** subnets, sets `IsFullyAllocated = true`, overwrites the parent description, permanently bars child subnets and host IPs, and locks the operator out of the import wizard - with the only way back a button buried in the *Host IP Assignments* card footer. The bulk wizard states the same outcome up front (`AzureBulkImportPlanner.cs:273`, `_BulkScripts.cshtml:519-521`), so the codebase already treats it as something the operator must be told. | **Every mechanical claim reproduces at the cited lines; three of the consequence claims are false, measured.** *"Silently flips"* - the redirect target states it in the success banner, in the description, and in two "Fully Allocated" alerts. *"Permanently barred ... buried in the card footer"* - the **Mark as Not Fully Allocated** button is on that same landing page at docTop 958 of a 1098px document, no confirm and no navigation; one click restores *Add Child Subnet* and makes `/Azure/Import/1` answer 200 as the wizard. *"Overwrites the parent description"* - `AppendFullyAllocatedNote` (`SubnetController.Azure.cs:85-101`) **appends** and preserves; over 1000 chars it keeps the existing description and drops the note. *"Importing it creates nothing"* is vacuous and the aggravated case is unreachable: the encompassing branch fires only when the Azure prefix equals the parent's network **and** cidr exactly, and ARM refuses a second same-VNet subnet nested inside it (`NetcfgSubnetRangesOverlap`, run live) - `ROW_COUNT` was 1 and is 1 by construction, so the `:380` skip never discards anything the operator ticked. With the row unticked the Import button stays disabled, so the only two reachable outcomes are the correct row or nothing. Nothing wrong is written either: when the flag is true the Azure subnet genuinely **is** the whole VNet, and the write is server-validated first (prefix equality `:302-311`, `ValidateSubnetCanBeFullyAllocated` `:313`), so the wizard cannot reach a state the manual path forbids. What survives is one sentence of UI copy - a badge the bulk wizard's row carries and this one does not - which is the shape round 7 killed for F10 and which this round's rules put on the wrong side of *"not a runtime defect is not a finding"*. Residue, too small to file: after un-flagging, the appended note *"Fully allocated by Azure subnet 'rig-full-span'..."* stays in the description (`DescLen 91` with `IsFullyAllocated=0`). |
+
+---
+
+# Watch list
+
+Not findings. Known, accepted, deferred, or measured dead ends. Knowing these stops a later round filing
+something already understood - and several are the *reason* a nearby defect is worth more or less than it
+looks.
+
+## Corrections to earlier rounds' watch lists
+
+- **Round 9's entry "Delete's tree read is once per request" is FALSE for the reconcile delete path.**
+  It is **twice per selected target** (`AzureReconcile.cs:143` plus the one inside
+  `ArchiveSubnetSubtreeAsync`), and one request carries as many targets as the operator ticked. That
+  entry is exactly what would have deterred filing J1. Re-derive scaling claims per *path*, not per
+  method.
+- **Round 7's `/Error/*` note recorded that the route segment is caller-supplied; it did not record that
+  the FORM outranks the route.** `FormValueProviderFactory` precedes `RouteValueProviderFactory` in the
+  default composite value provider. That is J3.
+
+## Measured dead ends - do not re-propose
+
+- **The per-subnet host-IP `Include` N+1 at `SubnetController.Delete.cs:182-192` is not worth fixing.**
+  Replacing it with a single `WHERE SubnetId IN (...)` moved a 20,081-subnet root delete from 22.50 s to
+  **22.74 s**, despite removing 20,081 round trips.
+- **Removing only the redundant `GetAllDescendantsOrdered` at `AzureReconcile.cs:143` is not worth taking
+  on its own** - 59.4 s -> 57.3 s. The per-target `SaveChangesAsync` is the dominant term.
+- **Do not add a second `WithholdTargetsWhoseCascadeIsBlocked` call with its own wording.** It returns
+  early when `plan.Items` is empty and empties `plan.Items` on firing, so whichever guard runs first
+  swallows the other's warning. Round 9 reached the same conclusion under I1 by a different route.
+- **Do not fix a stale control with `$(...).trigger("change")`** - it re-runs the invalidate cascade as a
+  side effect and reintroduces the synthetic-event pattern round 4's D1 removed.
+- **A `wwwroot/favicon.ico` fixes nothing.** Real headless Chromium issued **zero** favicon requests
+  across ~40 navigations, and a favicon fetch always lands after the document that already consumed the
+  message.
+
+## Traps for anyone writing these fixes
+
+- **Razor does not parse embedded `<script>` JS.** A view-embedded JS error - TDZ, typo, wrong scope -
+  **builds at 0 warnings / 0 errors** and fails only at runtime, and a wizard step that throws in a
+  render loop is left permanently spinning. Two of this round's proposed fixes were exactly this shape.
+  Anything touching a `.cshtml` script block must be driven in a browser before it is called done.
+- **`SubnetController.AzureReconcile.cs` has no `using Microsoft.EntityFrameworkCore;`.** Any async LINQ
+  call added there is `error CS0411`. Round 9 recorded the same trap in `AccountController.cs`.
+- **Any cached subnet tree passed into `ArchiveSubnetSubtreeAsync` must be a TRACKING read.** The
+  per-subnet host-IP `Include` at `Delete.cs:184-186` tracks fresh instances of every descendant, and
+  `Remove()` on a detached cached instance throws *"another instance with the same key value is already
+  being tracked"*. A flat leaf-only benchmark cannot see this - test nesting.
+- **`ArchiveSubnetSubtreeAsync` has exactly two callers** (`Delete.cs:136`, `AzureReconcile.cs:144`) and
+  **`GetAllDescendantsOrdered` exactly two** (`Delete.cs:174`, `AzureReconcile.cs:143`). Optional
+  parameters leave the single-subnet delete path unchanged.
+- **The nine `AccountControllerLogoutTests` assert on the returned `SignOutResult` and read
+  `Properties.RedirectUri`.** Any change to `Logout`'s return type breaks all nine (716 -> 707). They are
+  round 9's own I6 pins - rewrite them in the same commit, against the mocked `IAuthenticationService`.
+- **`CookieAuthenticationDefaults.LogoutPath` is `/Account/Logout`**, so a cookie-scheme sign-out on that
+  path self-redirects unless given a `RedirectUri`. `AccountController` has no `ILogger` injected.
+- **`lastPlan` exists only in `_ReconcileScripts.cshtml`.** The bulk wizard's client state is
+  `lastSelection` and `previewSeq`. Do not write a fix that "reuses" it.
+- **`ErrorControllerTests.cs:32, 46, 94, 112` call `HttpStatusCodeHandler(int)` directly.** Any signature
+  change is `CS1501` in four places.
+
+## Behaviour of the framework and the app that shaped this round's verdicts
+
+- **`StatusCodePagesMiddleware` skips any response that already has a `Content-Type`.** The three literal
+  `StatusCode(403, <json>)` sites are therefore never re-executed; only bodiless framework statuses reach
+  `/Error/{code}`. Measured both ways on one endpoint.
+- **Development's `DevAuthHandler` issues Admin** (satisfying all four policies) and Production's cookie
+  handler has `AccessDeniedPath`, so a Forbid is a 302. The shipped build emits **no launderable bodiless
+  401/403**. Any finding about denial-status handling must say which of those it assumes away.
+- **`Program.cs:22` pins `Microsoft.AspNetCore` to `Warning` outside Development**, so Production logs
+  neither `Request finished` nor `Authorization failed` at default levels - measured 0 lines. Do not build
+  a consequence on request-log content without stating the log level.
+- **The OIDC `ConfigurationManager` is lazy and caches.** One successful discovery fetch closes J6's window
+  permanently for that process; and inside the window an unauthenticated `GET /` is already 500 through the
+  challenge, so the deployment is loudly broken, not silently.
+- **`ValidateSubnetCidrChangeWithHostIps` returns early when a subnet has no LIVE host IPs.** Deleting a
+  host IP is the prerequisite for narrowing, so **the archive is the one place an address can survive the
+  very edit that would have blocked it.**
+- **`POST /Subnet/BatchCreateChildSubnets` writes `AzureResourceId` verbatim.** The only write-side check
+  is length (500 chars); `AzureResourceIdentity.cs:26` states the column is free text. The app will not
+  self-inflict a corrupt id, but its own Admin API will write one.
+- **The ordinary delete page has no Azure gate.** `POST /Subnet/Delete/{id}` archives a stale Azure-linked
+  ancestor that `BulkDeleteStaleAzureSubnets` refuses with 409. "The reconcile wizard refuses it" never
+  means "the app refuses it".
+- **`AzureResourceId` is written only by the two import paths and never cleared.** `EditSubnetViewModel`
+  does not carry it, no view offers an unlink, and `SubnetController.Edit.cs:92` makes a CIDR change throw
+  when it is non-empty. `DeletedSubnets` archives no `AzureResourceId` and **there is no restore path
+  anywhere in the app** - re-confirmed from the live schema. This is what makes J2 unrecoverable.
+- **`GlobalSanitizationFilter` does not descend into the nested bulk selection list** (which is why
+  `AzureBulkImportPlanner` sanitizes names itself). Any new nested DTO field arrives unsanitized.
+- **The reconcile delete re-derives its verdict server-side from ids alone and answers 409 on divergence;
+  the bulk import commit trusts the posted selection.** That asymmetry is J2.
+- **`appsettings.Development.json` already sets `Microsoft.EntityFrameworkCore.Database.Command` to
+  `Information`** - no instrumentation is needed to count queries in Development.
+
+## Rig and method notes
+
+- **Playwright's `ClickAsync` refuses a disabled control**, so "the click was accepted" is itself the
+  enabled-ness proof - and "the click was refused" is the proof a fix landed. To measure a click that must
+  land regardless of state, use raw `page.Mouse.ClickAsync` at the element centre.
+- **Two service principals with disjoint RBAC is what makes an Azure verdict falsifiable.** SP_B scanning a
+  resource it cannot read produces *"Azure denied access when asked about them directly"* and correctly
+  **suppresses** the nothing-to-clean banner - the design working, and the control that shows a missing
+  banner is a real signal rather than an artefact.
+- **An untracked `idp.pid` appeared in the repository root mid-round** (from another agent's stub IdP) and
+  was reported by three verifiers as not theirs. The working tree must be verified clean immediately before
+  any commit; `git status --porcelain` was empty at HEAD `dcc15ab` at the start and end of every verified
+  session otherwise.
+- **Round-9 line numbers had already moved; round-10's will move again.** Re-derive every citation before
+  acting on it.

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -265,76 +265,31 @@ three observed variants without restructuring eleven actions' return types for a
 
 ---
 
-## J5 [x1] - Single-VNet import wizard: "Next: Select Subnets" stays enabled when `loadVNets` repopulates the dropdown, leaving a live-but-inert primary button
+_J5 is fixed and committed, exactly as proposed — the only fix this round that needed no correction.
+One line in `loadVNets`' `beforeSend`, beside the four panel resets:
+`$("#select-vnet-btn").prop("disabled", true);`. Same placement and pattern `loadSubnets`' `beforeSend`
+already uses, so the wizard now has one rule rather than two that disagree, and it covers the error and
+no-vnets branches for free._
 
-**Severity:** low | **Confidence:** confirmed | **Cite:**
-`src/Bastet/Views/Azure/Import/_ImportScripts.cshtml:188` (`loadVNets`' `beforeSend`)
+_Measured in real headless Chromium against the live rig, before and after, walking subscription →
+Next: Select VNet → pick a VNet → Back to Subscriptions → Next: Select VNet. **Before:** state E read
+`value="" disabled=false opacity=1 pointer-events=auto` — a fully saturated primary button over the
+"-- Select a Virtual Network --" placeholder — and the click was **accepted** while issuing zero Azure
+requests and never opening step 3. **After:** state E reads
+`value="" disabled=true opacity=0.65 pointer-events=none` and Playwright **refuses** the click, which
+is itself the proof, since it will not click a disabled control. The happy path is untouched: picking a
+VNet still enables the button, still issues `GetSubnets`, and still advances. 0 console errors and 0
+page errors in both runs._
 
-**What goes wrong.** On `/Azure/Import/{id}`: pick the subscription, click **Next: Select VNet**, pick a
-VNet (the change handler at `:107-114` enables `#select-vnet-btn`), click **Back to Subscriptions**, then
-**Next: Select VNet** again. No change event fires anywhere, `loadVNets` re-runs, and its success branch
-does `$dropdown.empty()` (`:199`) and re-appends the disabled/selected placeholder (`:200`), which resets
-the select's value to `""` **without** firing `change`. `beforeSend` (`:188-193`) resets `#vnet-loading`,
-`#vnet-selection`, `#vnet-error` and `#no-vnets` but not the button, and `:110`/`:112` inside the change
-handler are the **only** code in the tree that touches its disabled state.
+_No test ships with this. It is view-embedded JavaScript with no unit-testable seam — the repo has no
+harness for driving a Razor script block, and the verification above is recorded as prose for that
+reason. Suite unchanged at **725**._
 
-**Wrong output:** the dropdown reads *"-- Select a Virtual Network --"* while **Next: Select Subnets**
-renders as a fully saturated, hit-testable `btn-primary`. Clicking it hits
-`selectedVNetId = $("#vnet-select").val()` -> `""` -> the `if (selectedVNetId)` guard at `:59` falls
-through: no request, no step change, no spinner, no message. The wizard's primary Next button silently
-does nothing.
-
-This is the step-2 twin of round 7's G10, which fixed exactly this class for step 3's
-`#select-all-subnets` / `#import-subnets-btn` by resetting them in `loadSubnets`' `beforeSend`
-(`:255-256`); `loadVNets` never got the same treatment. The in-repo name for this shape is
-`_ReconcileScripts.cshtml:68-72`: *"A permanently live, inert button"*.
-
-**Reproduction.** Real headless Chromium (jQuery 4.0.0, Bootstrap 5.3.8), two verifiers with independently
-written harnesses, four runs, identical result. One measured with a raw `page.Mouse.ClickAsync` so that
-"the click landed" is not doing inferential work:
-
-```
-B first entry to step 2 : value=""  disabledProp=true  :disabled=true  opacity=0.65  pointer-events=none
-C after picking a VNet  : value=".../virtualNetworks/rig-vnet-visible"  disabledProp=false  opacity=1
-  [REQ] GET /Azure/GetVNets?subscriptionId=...&subnetId=1        (the second load)
-E re-entry to step 2    : value=""  text="-- Select a Virtual Network --"  optionCount=3
-                          disabledProp=false  hasDisabledAttr=false  opacity=1  pointer-events=auto
-F CLICK ACCEPTED -> Azure requests after the click: []   count=0
-                    step3 pill still DISABLED; #subnet-selection/#subnet-error/#no-subnets all d-none
-                    #vnet-resource-id = ''      CONSOLE_ERRORS: 0
-G control: pick a VNet -> GET /Azure/GetSubnets?vnetResourceId=...  -> step 3 ACTIVE, 2 rows
-```
-
-Screenshot of state F shows a solid blue **Next: Select Subnets** directly under the placeholder text.
-Leg G proves the button is not broken, only mis-enabled.
-
-**Reachability is slightly wider than filed:** `invalidateVNetStep()` (`:84-88`), which runs when the
-subscription dropdown changes, disables `#step2-tab`, `#step3-tab` and `#import-subnets-btn` but likewise
-never touches `#select-vnet-btn`, so switching subscriptions lands in the same state. Not claimed as
-reproduced - the rig tenant exposes only one subscription.
-
-**Fix - SOUND, and the only fix this round that needed no correction.** One line in `loadVNets`'
-`beforeSend`, beside the four panel resets:
-
-```javascript
-$("#select-vnet-btn").prop("disabled", true);
-```
-
-Same placement and pattern `loadSubnets`' `beforeSend` already uses, so the wizard ends up with one rule
-rather than two that disagree. Built and driven on the patched build: state E flips to
-`disabled / :disabled / opacity 0.65 / pointer-events none`, Playwright then **refuses** the click, the
-happy path is untouched (leg G still issues `GetSubnets` and activates step 3), 0 console errors, build
-0/0, suite **716/716**. `loadVNets` has exactly one caller (`:43`), so `beforeSend` covers every entry;
-`loadAzureSubscriptions()` is called once at document-ready and needs no equivalent.
-
-**Two notes on the alternatives.** The "cheaper interim"
-(`prop("disabled", !$("#vnet-select").val())` after the `$.each`) does close the reproduced path but is
-strictly worse - it leaves the button stale on the error and no-vnets branches. Those branches are
-currently unreachable to a user (`#vnet-selection` keeps its `d-none`, and the button's box is
-zero-sized), so `beforeSend` placement is defence-in-depth there rather than a second live defect; that
-is still the right home. **Do NOT fix this with `$("#vnet-select").trigger("change")`** - it would re-run
-`invalidateSubnetStep()` as a side effect and reintroduce the synthetic-event pattern round 4's D1
-removed.
+_Two alternatives left unused, both on the finding's own evidence. The "cheaper interim"
+(`prop("disabled", !$("#vnet-select").val())` after the `$.each`) closes the reproduced path but leaves
+the button stale on the error and no-vnets branches, so `beforeSend` is the better home. And
+`$("#vnet-select").trigger("change")` was **not** used: it would re-run `invalidateSubnetStep()` as a
+side effect and reintroduce the synthetic-event pattern round 4's D1 removed._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -119,115 +119,36 @@ already refuted.
 
 # Medium
 
-## J1 [x2] - Azure reconcile bulk delete holds the global write lock for O(selected targets x total subnets), refusing every other write in the deployment
+_J1 is fixed and committed. All three parts were taken: `GetAllDescendantsOrdered`
+(`SubnetController.Helpers.cs`) and `ArchiveSubnetSubtreeAsync` (`SubnetController.Delete.cs`) each
+gained an optional `treeCache`, the archive path also fills an optional `archivedSubnetIds` so the
+reconcile loop no longer needs its own descendant walk, the redundant `GetAllDescendantsOrdered` call
+in the loop is gone, and the per-target `SaveChangesAsync` moved to a single save after the loop. The
+missing `using Microsoft.EntityFrameworkCore;` was added, as the verifier warned. **The cache is a
+tracking read**, and the two XML doc blocks say why rather than leaving it to be rediscovered: the
+verifier's `AsNoTracking` trap was reproduced here before the fix was written — built that way the
+request returns the 500 path (`ObjectResult`, "another instance with the same key value is already
+being tracked") on the first target with descendants._
 
-**Severity:** medium | **Confidence:** confirmed | **Cite:**
-`src/Bastet/Controllers/SubnetController.AzureReconcile.cs:156` (the per-target save), `:143` (the
-redundant tree read), `:113` (the lock)
+_Measured on a nested rig rather than the finding's flat 200-leaf benchmark, which by construction
+cannot see the tracking fault: six targets, each a root/child/grandchild subtree with a host IP,
+alongside 200 unrelated subnets. Unfiltered whole-table `Subnets` reads went **13 → 2** (13 = 1 + 2
+per target, exactly the formula the finding gives), with the outcome byte-identical before and
+after — 218 subnets before, 200 remaining, 18 archived, 6 host IPs archived. The lock-hold and
+rival-write timings in the finding were not re-measured at 66,000-subnet scale; the read count is the
+mechanism, and it is now flat in target count._
 
-Found by four beats (`azure`, `locking`, `regression`, `deadcode`) across passes A, B and deep - seven
-raw reports, one defect.
+_Two regression tests added (`SubnetControllerAzureReconcileScalingTests`), 716 → **718**. The scaling
+test deliberately asserts that the read count for 2 targets **equals** the count for 8 rather than
+pinning a magic number — an exact count would break on unrelated query changes while still admitting
+the defect back. Confirmed failing against unfixed code with the defect's own signature (expected 5,
+actual 17) before the fix landed. The second test pins nested-subtree-with-host-IP archiving, which is
+what the tracking requirement protects._
 
-**What goes wrong.** An Admin runs the reconcile wizard against a subscription with 200 stale
-Azure-linked subnets in an instance holding 65,996 subnets, ticks `#rec-select-all`
-(`_StepReview.cshtml:44` - there is no cap on the `[FromBody]` id list) and clicks delete.
-`POST /Subnet/BulkDeleteStaleAzureSubnets` takes 59-68 s, of which ~55 s is inside
-`ExecuteWithSubnetLockAsync`. Two O(table) terms run **once per selected target, inside the lock**:
-
-1. `ArchiveSubnetSubtreeAsync` -> `GetAllDescendantsOrdered` (`Delete.cs:174` -> `Helpers.cs:55`) issues
-   `context.Subnets.ToListAsync()` - a **tracking** read of the entire `Subnets` table - and `:143`
-   issues a second, redundant one whose result is the identical list `ArchiveSubnetSubtreeAsync` already
-   computes and throws away. 401 whole-table reads in one request.
-2. Because that tracking read leaves all 66,000 entities in the change tracker, the per-target
-   `await context.SaveChangesAsync()` at `:156` runs `DetectChanges` over all of them, 200 times. That
-   save alone accounted for 49.9 s of the in-lock time.
-
-Nothing needs the per-target save - it is all one transaction committed at `:159`.
-
-**Wrong output:** a legitimate second user's write is **refused**, not merely delayed. Server-side SQL
-time is negligible (~21 ms for the 25 reads in a 12-target control); the cost is client-side
-materialisation and `DetectChanges`.
-
-**Reproduction.** Verifier's own catalog `bastet_vc1p`, two Bastet processes (5541, 5542) on it, seeded
-`10.0.0.0/8 -> 256 x /16 -> 65,536 x /24` plus 200 Azure-linked /28 ghosts whose `AzureResourceId` names
-non-existent subnets under a real VNet, so `ConfirmProposedDeletionsAsync` gets a genuine ARM 404 per
-row. `POST /Azure/ReconcileScan` returned 200 items.
-
-```
-DELETE_HTTP=200 DELETE_TIME=67.936699
-{"success":true,"redirectUrl":"/Subnet","targetsDeleted":200,"subnetsArchived":200,"hostIpsArchived":0}
-
-rival1 (+2s,  port 5542) wait=1.669  http=302   -- fired before the lock was taken
-rival2 (+20s, port 5542) wait=30.359 http=200   -- REFUSED: page contains
-        'The operation timed out due to high concurrency. Please try again.'   (Create.cs:138)
-rival3 (+45s, port 5542) wait=23.612 http=302
-
-sys.dm_tran_locks, 1 Hz, during that request:
-  01:23:09.110  97|X|GRANT|0:[Bastet:SubnetOperations]:(b83d66a6)
-  01:23:24.598  97|X|GRANT|...  109|X|WAIT|0:[Bastet:SubnetOperations]:(b83d66a6)
-  01:24:11.425  97|X|GRANT|...  126|X|WAIT|...
-  -> 57 consecutive GRANT samples for session 97; 27 WAIT samples for the two rivals.
-
-EF command log (Development already sets Database.Command=Information):
-  401 whole-table 'FROM [Subnets] AS [s]' reads = 1 outside the lock + 2 per target inside it
-  12-target control, same 65,995-row table: exactly 25 = 1 + 2x12, DEL12_TIME=7.259461
-```
-
-The rivals were issued against **a separate process on the same catalog**, so this is the `sp_getapplock`
-and not an in-process gate. Scaling was measured independently on three rigs and is linear in
-targets x tree size: 256/512/1024/4096 targets -> 1.40 / 3.06 / 7.20 / 93.67 s; and with the *same* 1024
-targets, padding the table with rows that are never selected, archived or read took 7.28 s (pad 0) to
-43.47 s (pad 7000) - the signature of an unfiltered `ToListAsync`. A single 5,000-child subtree delete on
-the same 200k tree took 23.3 s, i.e. the cost is the scans, not the archiving. The lock plumbing itself
-is sound: holding `Bastet:SubnetOperations` from an external `sqlcmd` session made a far-instance
-`POST /Subnet/Create` fail at exactly 30.038 s while `GET /Subnet` still answered 200 in 0.093 s.
-
-**Fix.** (a) give `GetAllDescendantsOrdered` an optional `List<Subnet>? treeCache`
-(`Helpers.cs:52-55`, `treeCache ?? await context.Subnets.ToListAsync()`) and thread it through
-`ArchiveSubnetSubtreeAsync` (`Delete.cs:171,174`); load the tree once before the reconcile loop and pass
-it - subtrees are disjoint, so a snapshot taken before the first archive still names every later
-target's descendants. (b) have `ArchiveSubnetSubtreeAsync` fill an optional `List<int>?
-archivedSubnetIds` from the `toDelete` list it already builds, and delete the redundant call at `:143`.
-(c) move `await context.SaveChangesAsync()` from `:156` to after the loop - it is already one
-transaction, and `alreadyArchived` already skips any target cascaded away, so `FindAsync` never has to
-observe a deleted row. Measured: 67.9 s -> 5.81 s, 401 reads -> 2, rival create 30.3 s REFUSED -> 0.4 s
-succeeded, output byte-identical (`targetsDeleted:200, subnetsArchived:200, hostIpsArchived:0`), suite
-716/716.
-
-**Verifier correction - the fix as written is INCOMPLETE, and each gap bites.**
-
-1. **The cache must be a TRACKING read, and the finding never says so.** It says to thread the cache
-   *"exactly the way I3 threaded `LoadSubnetTreeForBatchAsync`"*, and that helper (`Helpers.cs:129-130`)
-   is `AsNoTracking()` - the only such helper in the file, so that is what an implementer will write.
-   Built that way it passes the 200-flat-leaf benchmark in 5.95 s and then 500s on the first target that
-   has descendants:
-   ```
-   {"success":false,"error":"The delete failed and no changes were saved. Details have been logged."}
-     System.InvalidOperationException: The instance of entity type 'Subnet' cannot be tracked because
-     another instance with the same key value for {'Id'} is already being tracked.
-        at InternalDbSet`1.Remove(TEntity entity)
-        at ...ArchiveSubnetSubtreeAsync(...) SubnetController.Delete.cs:line 233
-   ```
-   Cause: the per-subnet host-IP `Include` at `Delete.cs:184-186` tracks a fresh instance of every
-   descendant, and `Remove` is then called on the detached cached instance. **A flat leaf-only benchmark
-   - which is exactly the finding's 200-target scenario - cannot see this.**
-2. **It does not compile as described.** `SubnetController.AzureReconcile.cs` has no
-   `using Microsoft.EntityFrameworkCore;`, so `await context.Subnets.ToListAsync()` before the loop
-   gives `error CS0411`. Round 9 recorded this same trap against I3's fix; the finding repeats it.
-
-With a tracking cache and that `using`, both the flat and the nested cases pass and match HEAD exactly
-(nested: `targetsDeleted:1, subnetsArchived:3, hostIpsArchived:1`, identical archive rows).
-
-**Cheaper interim - sound exactly as stated, and if only one thing ships this is it.** Move
-`await context.SaveChangesAsync()` from `:156` to after the loop. One line, no signature change, builds
-clean, byte-identical output: 67.9 s -> 28.5 s, and all three rivals lifted from refused/queued to
-succeeding. Parts (a)+(b) alone are worth little - the save is the dominant term.
-
-**Two candidate fixes were built, measured, and are NOT worth taking.** Removing only the redundant
-`:143` read: 59.4 s -> 57.3 s (401 -> 201 reads; the saves still dominate). Replacing the per-subnet
-host-IP `Include` N+1 at `Delete.cs:182-192` with a single `WHERE SubnetId IN (...)`: a 20,081-subnet
-root delete went 22.50 s -> 22.74 s, i.e. nothing, despite removing 20,081 round trips. Do not re-propose
-either.
+_Not done, on the finding's own evidence: the redundant `:143` read was not removed on its own (59.4 s
+→ 57.3 s alone — it is only worth taking as part of this change), and the per-subnet host-IP `Include`
+N+1 at `Delete.cs:182-192` was left alone (measured 22.50 s → 22.74 s, i.e. nothing, despite removing
+20,081 round trips). Both remain on the watch list as measured dead ends._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -1,16 +1,75 @@
 # Bastet - Round-10 Audit Findings
 
-| | |
-|---|---|
-| Round | **10** (finding letter **J** - findings are `J1` ... `J9`) |
-| Target branch | `audit/round-10` |
-| HEAD | `dcc15ab` - *"Audit 9 Cleanup (#154)"*, identical tree to `main` |
-| Build | **0 warnings, 0 errors** |
-| Tests | **716 passed**, 0 failed, 0 skipped |
-| Date | 2026-07-31 |
+| | Audit | After reconciliation |
+|---|---|---|
+| Round | **10** (finding letter **J** - findings are `J1` ... `J9`) | |
+| Branch | `audit/round-10` | one commit per finding |
+| HEAD | `dcc15ab` - *"Audit 9 Cleanup (#154)"*, identical tree to `main` | |
+| Build | **0 warnings, 0 errors** | **0 warnings, 0 errors** (clean rebuild, `bin`/`obj` deleted) |
+| Tests | **716 passed**, 0 failed, 0 skipped | **730 passed**, 0 failed, 0 skipped (+14) |
+| Working tree | clean at start and at finish | clean |
+| Date | 2026-07-31 | 2026-08-01 |
 
-Every line number below was re-derived against the working tree at `dcc15ab` by at least one verifier.
-Round-9 citations have already moved; re-derive these before acting on them.
+Every line number in the original findings was re-derived against the working tree at `dcc15ab` by at
+least one verifier. The struck entries below cite the **post-fix** lines.
+
+**All nine findings were fixed - none was refuted on re-verification.** Each was reproduced against the
+unfixed build before being fixed and re-measured afterwards, one commit per finding, each carrying its
+own struck entry.
+
+**Seven of the nine proposed fixes were rejected or corrected on evidence**, which the audit had itself
+predicted; every rejection is recorded in the relevant struck entry. Four are worth surfacing here
+because they look reasonable and will be re-proposed:
+
+- **J9's fix does not run.** It declares a `const` at the reason site and reads it in the label built
+  above - a temporal dead zone. Razor does not parse embedded JS, so it builds at 0 warnings and then
+  throws `ReferenceError` inside the render loop, leaving step 2 of the bulk wizard spinning with zero
+  checkboxes.
+- **J1's cache must be a TRACKING read.** The finding says to copy `LoadSubnetTreeForBatchAsync`,
+  which is `AsNoTracking`; built that way the request 500s on the first target that has descendants,
+  and a flat leaf-only benchmark - which is the finding's own 200-target scenario - cannot see it.
+- **J4's proposed guard fixes the wrong variant.** An `IStatusCodeReExecuteFeature` check closes the
+  re-execute leg and leaves redirect-vs-redirect open, which is the path an operator actually hits.
+- **J8's schema change was declined** as disproportionate to an info finding, and its interim produces
+  worse output than the defect (`NAME (/0)`).
+
+### Final verification sweep
+
+- **Clean rebuild** with `bin`/`obj` deleted: 0 warnings, 0 errors. **Full suite: 730 passed**, 0
+  failed, 0 skipped (716 -> 730, +14; no test was deleted or disabled). Nine of round 9's I6 pins were
+  rewritten rather than removed, and still assert the same guarantee one layer down.
+- **Real app against real SQL Server 2022**, every major area asserted on **content**, not status
+  codes: **21 of 21 passed** - subnet list/details/create/edit/delete, host IP list and edit,
+  per-subnet and global deleted-host-IP listings, deleted subnets, the purge confirmation, all three
+  Azure wizards, roles, access-denied, and the error pages. Security headers still ride on a normal
+  200 (`X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy: frame-ancestors 'none'`).
+- **Log read and classified:** zero `fail:` lines and zero exceptions across the whole sweep. The only
+  warnings are three identical EF `MultipleCollectionIncludeWarning` advisories from the two-collection
+  `Include` in the delete path - pre-existing at `dcc15ab` and untouched by this round.
+- **Both Azure surfaces driven end to end against live ARM** with two service principals holding
+  **disjoint RBAC at resource-group scope** (each `Owner` on its own group, `AuthorizationFailed` on
+  the other - verified before anything was measured, since a subscription-scoped assignment would have
+  made the whole experiment vacuous). Discovery, single-VNet import, bulk preview and commit, the
+  bulk-commit 409 divergence case, reconcile scan and reconcile delete commit all exercised. Both
+  counter-tests pass, so the reconciler **discriminates** rather than merely blocking: a resource the
+  credential cannot see was **withheld** with a warning naming it and stating that Azure denied access,
+  while a genuinely deleted resource was still **offered and deleted** (`targetsDeleted: 1`) - and the
+  unreadable row survived that delete.
+
+### Deliberately not done
+
+- **J8's two new columns and migration.** Declined; the parenthetical range was removed instead. See
+  J8's struck entry for the three unresolved problems the schema change carries.
+- **J4's structural fix** - answering in place from the eleven redirect sites rather than round-tripping
+  a diagnostic through a single-slot cookie. All three observed variants are closed without
+  restructuring eleven actions' return types for a low-severity finding; the round-9 watch-list item
+  stands.
+- **The measured dead ends were left alone**: the `:143` redundant read on its own, the per-subnet
+  host-IP `Include` N+1, a second `WithholdTargetsWhoseCascadeIsBlocked` call, `wwwroot/favicon.ico`,
+  and `trigger("change")`. Each is recorded in the watch list with the measurement that killed it.
+- **No test was written for J5 or J9.** Both are view-embedded JavaScript with no unit-testable seam;
+  the repo has no harness for driving a Razor script block, and both were verified in real headless
+  Chromium instead.
 
 ---
 

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -198,89 +198,32 @@ refusing `ExactMatch` onto an unlinked row would break the adopt path that
 
 # Low
 
-## J3 [x1] - Error page binds its status code from the POST body, so a caller picks the status of any re-executed bodiless 4xx
+_J3 is fixed and committed. `HttpStatusCodeHandler` is now parameterless and reads the status off
+`RouteData`, falling back to the status already on the response. The verifier's recommendation was
+taken over the finding's own `[FromRoute]` suggestion, because `[FromRoute]` closes only three of the
+four legs: when the form reader throws, MVC abandons binding for **every** source, not just the form,
+so the NUL-byte and malformed-multipart posts would still have arrived as `statusCode = 0` and been
+turned into 500 by the out-of-range guard._
 
-**Severity:** low (filed medium; **corrected down by both verifiers**) | **Confidence:** confirmed |
-**Cite:** `src/Bastet/Controllers/ErrorController.cs:17`
+_Measured against the live app on real SQL Server, Development, before and after. Laundering:
+`POST /Subnet/Create Name=x&statusCode=404` **404 → 400**, `statusCode=451` **451 → 400**,
+`POST /No/Such/Path statusCode=451` **451 → 404**; the control with no field was 400 throughout.
+Unreadable body: `Name=x%00y` **500 → 400**, with the page text going from *"Status Code: 0"* to
+*"Status Code: 400"*. Nothing else moved: `GET /Subnet/Details/99999` followed still lands on 404,
+`/Error/409` still answers 409, and `/Error/200` still answers 500, so the deliberate guard against a
+caller-supplied route segment reaching a 2xx is intact._
 
-**What goes wrong.** `UseStatusCodePagesWithReExecute("/Error/{0}")` (`Program.cs:524` Development,
-`:529` Production) re-executes the pipeline for the **same** request - same method, same body - with the
-path rewritten to `/Error/<real status>`. `HttpStatusCodeHandler(int statusCode)` binds through MVC's
-default composite value provider, where `FormValueProviderFactory` precedes `RouteValueProviderFactory`.
-A form field named `statusCode` in the original POST body therefore **beats the route segment the
-middleware just set**. The guard at `:32` only clamps outside 400-599, so 400 -> 404 passes untouched.
+_The four `ErrorControllerTests` call sites were updated through a single `Invoke` helper that sets
+the route value, rather than four separate edits — the action is no longer callable with an argument,
+which is the point. One regression test added for the leg that motivated the parameterless variant
+(`HttpStatusCodeHandler_NoRouteValue_UsesTheStatusAlreadyOnTheResponse`), 723 → **724**._
 
-Two legs survive verification:
-
-- **Status laundering of empty-bodied framework statuses.** An authenticated user posting
-  `Name=x&statusCode=404` to `/Subnet/Create` with a stale antiforgery token gets **404 Not Found** on
-  the wire and in the request log, though the framework produced 400. `POST /No/Such/Path` with
-  `statusCode=451` answers **451**. Anonymous in Production: `POST /Error/404` with `statusCode=451`
-  answers **451**.
-- **A malformed form becomes a server fault, with no attacker at all.** `Name=x%00y` (a NUL in any form
-  value) makes `FormPipeReader` throw, `CompositeValueProvider.TryCreateAsync` abandons binding for every
-  parameter, `statusCode = 0`, and the `:32` guard turns that into **500 Internal Server Error** with the
-  page printing *"Status Code: 0"*. The same happens for a malformed multipart POST (bad boundary,
-  truncated upload) - an ordinary client bug reported as a server fault.
-
-**The two verifiers disagree on the 403 leg, and the disagreement matters.** The finding's headline is
-that a View-role user's 403 launders into 404, hiding an authorization denial from log analysis. That
-leg was only ever reproduced on a rig copy whose `DevAuthHandler` reads roles from an `X-Rig-Roles`
-header. On the **shipped** build the second verifier established no launderable bodiless 401/403 exists:
-Development's `DevAuthHandler` issues Admin (`DevAuthHandler.cs:31`), satisfying all four policies;
-Production's cookie handler sets `AccessDeniedPath` (`Program.cs:200`), so a Forbid is a 302; and the
-three literal `StatusCode(403, <json>)` sites write a body, which `StatusCodePagesMiddleware` skips.
-Measured both ways on one endpoint: `POST /Subnet/BatchCreateChildSubnets` **with** a valid token
-returns 400 with `{"subnets":[...]}` unlaundered; **without** a token (empty-bodied 400) returns 451.
-Treat the 403 leg as mechanism-only until a deployment that emits a bodiless 403 is demonstrated.
-
-Two further legs were **struck** as pre-existing and already documented: `POST /Error/451` answering 451
-and `GET /Error/200` answering 500 with *"Status Code: 200"* both happen through the **route** alone, and
-round 7 recorded that the route segment is caller-supplied (`ErrorControllerTests.cs:99-101` pins it).
-Only the framework-generated-4xx half is new ground.
-
-**Reproduction.** Pristine shipped DLL, Development, no source modification:
-
-```
-POST /Subnet/Create  Name=x                -> HTTP/1.1 400 Bad Request        (control, "Status Code: 400")
-POST /Subnet/Create  Name=x&statusCode=404 -> HTTP/1.1 404 Not Found          ("Resource Not Found")
-POST /Subnet/Create  Name=x&statusCode=451 -> HTTP/1.1 451 Unavailable For Legal Reasons
-POST /Subnet/Create  Name=x%00y            -> HTTP/1.1 500                    ("Status Code: 0")
-POST /No/Such/Path   statusCode=451        -> 451     (404 without the field)
-GET  /Error/404?statusCode=451             -> 404     (query loses to route; only the form wins)
-malformed multipart on a 400 path          -> 500     ("Status Code: 0")
-
-app log, antiforgery leg:  "Executing StatusCodeResult, setting HTTP status code 400"
-                        -> "Executing endpoint '...ErrorController.HttpStatusCodeHandler'"
-                        -> "Request finished HTTP/1.1 POST .../Subnet/Create - 404"
-Production (anonymous):  POST /Error/404 statusCode=451 -> 451 ; a=x%00b -> 500
-```
-
-Note the log line is Development-only evidence: `Program.cs:22` pins `Microsoft.AspNetCore` to `Warning`
-outside Development, and a Production instance logged **0** `Request finished` / `Authorization failed`
-lines across the same requests. The wire-level relabelling is what stands.
-
-**Why low.** No data change, no disclosure, no privilege change, no XSS (`@Model.StatusCode` is an
-`int`), no cross-user effect (`Cache-Control: no-store,no-cache`), and the caller cannot reach 2xx or
-3xx. A caller relabels *their own* failed request.
-
-**Fix.** `public IActionResult HttpStatusCodeHandler([FromRoute] int statusCode)`. Built and driven:
-closes the laundering completely (400 stays 400, `POST /No/Such` stays 404), leaves the redirect path
-intact (`GET /Subnet/Details/99999` followed -> 404, `GET /Error/409` -> 409), builds 0/0, **716 passed,
-0 failed** - the four `ErrorControllerTests` call sites that invoke `HttpStatusCodeHandler(int)` directly
-still compile.
-
-**Verifier correction - INCOMPLETE against the finding's own scenario 4.** `[FromRoute]` does **not** fix
-the unreadable-form leg: when the form reader throws, binding is abandoned for every source, so the NUL
-and malformed-multipart POSTs are still 500 *"Status Code: 0"*. Closing that too needs the value read
-outside model binding - a parameterless signature with
-`int statusCode = int.TryParse(RouteData.Values["statusCode"] as string, out int r) ? r : Response.StatusCode;`
-- which was built and verified to fix all four legs (NUL POST -> 400, page says *"Status Code: 400"*) but
-breaks the four test call sites with `error CS1501: No overload for method 'HttpStatusCodeHandler' takes
-1 arguments` (`ErrorControllerTests.cs:32, 46, 94, 112`). Recommendation: take the parameterless variant
-plus the four one-line test updates; take `[FromRoute]` alone if only the laundering is in scope. No
-sibling call site is missed either way - the eleven `RedirectToAction(..., new { statusCode = N })` sites
-generate `/Error/N` and are followed by a fresh GET with no form body.
+_Scope, unchanged from the finding: the 403-laundering leg was **not** treated as live. The second
+verifier established the shipped build emits no launderable bodiless 401/403 — Development's
+`DevAuthHandler` issues Admin, Production's cookie handler has `AccessDeniedPath` so a Forbid is a
+302, and the three literal `StatusCode(403, <json>)` sites write a body, which
+`StatusCodePagesMiddleware` skips. The fix closes it as mechanism regardless; no deployment emitting
+such a response was demonstrated, and none was invented to justify a wider change._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -227,91 +227,41 @@ such a response was demonstrated, and none was invented to justify a wider chang
 
 ---
 
-## J4 [x1] - A concurrent 4xx anywhere in the session steals the pending error-page message: the unrelated page prints it, the intended page loses it
+_J4 is fixed and committed, but **not with the fix as proposed**. The suggested
+`IStatusCodeReExecuteFeature` guard was rejected on the verifier's own measurement: it closes the
+re-execute leg while leaving redirect-vs-redirect untouched, and that is the 10-of-12 real-browser
+path — neither request in that pair is a re-execute, so neither carries the feature. Shipping it would
+have fixed the variant an operator is least likely to hit._
 
-**Severity:** low | **Confidence:** confirmed | **Cite:**
-`src/Bastet/Controllers/ErrorController.cs:22`
+_Instead each redirect now gets its own slot. A new `ErrorPageMessages` helper mints an opaque token,
+stores the diagnostic against it, and puts the token in the redirect's route; `ErrorController` reads
+only the entry its own token names. All eleven stashing sites (`Read.cs`, `Delete.cs` x2, `Edit.cs`
+x4, `AzureController.cs` x4) became one-line `this.RedirectToErrorPage(status, message)` calls, which
+also removes eleven copies of the stash-then-redirect pair. Round 3's B6 is not reintroduced: the
+token is a lookup key that is never rendered, and the message text still comes from TempData set
+server-side, never from the URL. Pending messages are capped at five, oldest dropped first, because
+TempData keeps anything unread and an abandoned redirect would otherwise accumulate in the cookie for
+the whole session — the finding notes that abandonment already leaves a message pending indefinitely._
 
-**What goes wrong.** `ErrorController.HttpStatusCodeHandler` is two things at once: the explicit
-redirect target of eleven controller sites that first stash a diagnostic in
-`TempData["ErrorPageMessage"]` (`Read.cs:43`, `Delete.cs:22`, `:127`, `Edit.cs:22/:59/:190/:251`,
-`AzureController.cs:24/:36/:184/:292`), and the automatic target of `UseStatusCodePagesWithReExecute`
-for every bodiless 4xx/5xx. Line 22 reads that key **unconditionally**, and a TempData read *consumes*
-it. Any unrelated 4xx that lands between a controller's 302 and the browser following it takes the
-message.
+_All three variants measured against the live app, one cookie jar per browser. **(1)** With
+`/Subnet/Edit/999` pending, an unrelated `GET /css/nope.css` now renders the generic "The resource you
+requested could not be found." and the intended page still renders "ID 999 could not be found or may
+have been deleted" — before, those were the other way round. **(2)** Redirect-vs-redirect: tab A
+(`Edit/999`) and tab B (`Details/888`) each now receive their own message; before, tab A received tab
+B's and tab B got the generic. **(3)** The silent-delete variant: after an unrelated 404, a pending
+message still arrives, because a request with no token neither reads nor clears anything._
 
-Tab A requests `GET /Subnet/Edit/999` (row archived): the controller stashes *"The subnet with ID 999
-could not be found or may have been deleted."* and 302s to `/Error/404`. Tab B, on a form with a stale
-antiforgery token, posts `/Subnet/Create`. **Wrong output:** tab B is served an HTTP 400 page titled
-*"Bad Request"*, *"Status Code: 400"*, whose body reads *"The subnet with ID 999 could not be found or
-may have been deleted."* - a statement about a request that browser never made - and tab A then gets the
-generic *"The resource you requested could not be found."*
+_Four existing tests asserted the single shared slot and were rewritten against the new mechanism —
+they now read the message back through the redirect's own token, which is what the page does. Two
+regression tests added, including one pinning that another redirect's message is **neither shown nor
+consumed**, 724 → **725**. `ErrorPageMessages` is public rather than internal so the tests exercise the
+real path instead of reimplementing its storage format; the assembly has no `InternalsVisibleTo`._
 
-**Reachability is wider than filed, in two directions found by the verifiers.** (a) **No concurrency is
-required at all:** an abandoned redirect (user hits Stop, closes the tab, the follow-up fails) leaves the
-message pending indefinitely - 30 unrelated 200s later, a mistyped URL rendered the stale subnet message.
-(b) **Two stale rows in two tabs is the most reachable path and it is not the filed one:** 10 of 12
-real-Chromium trials had one tab printing the *other* tab's diagnostic. (c) A 4xx re-execute with
-*nothing* pending still emits a TempData-clearing `Set-Cookie`, so an overlapping 4xx that started before
-the 302 silently **deletes** the message rather than stealing it (3 of 36 runs).
-
-**Reproduction.** One cookie jar = one browser, pristine `dcc15ab`:
-
-```
-GET /Subnet/Edit/999  -> 302 Location: /Error/404 ; Set-Cookie: .AspNetCore.Mvc.CookieTempDataProvider=...
-GET /css/nope.css     -> 404, Content-Type: text/html, 6369 bytes
-                         Set-Cookie: .AspNetCore.Mvc.CookieTempDataProvider=; expires=Thu, 01 Jan 1970
-                         body: "Status Code: 404" + "The subnet with ID 999 could not be found..."
-GET /Error/404        -> 404, SPECIFIC MESSAGE ABSENT: "The resource you requested could not be found."
-
-POST /Subnet/Create (stale token) -> 400, <title>Bad Request - BASTET</title>,
-                                     "The subnet with ID 999 could not be found or may have been deleted."
-GET /Error/403 with the message pending -> 403, "Status Code: 403" + the same sentence.
-
-Control: GET /Subnet (200) does NOT consume it - only a request reaching /Error does.
-Real Chromium, 36 runs: clean=26, wrong-page-printed-it=10, tab-A-lost-it=3.
-Real Chromium, two stale rows in two tabs, 12 trials: 10 crossed.
-```
-
-**Why low.** The text is server-composed from an int id (round 3's B6 removed the query-string source),
-`_ErrorLayout.cshtml:7` Razor-encodes it, and the cookie is `SameSite=lax; httponly` and same-origin - so
-no injection, no cross-user leak. What is left is a misleading diagnostic on the wrong page and a lost one
-on the right page.
-
-**Fix.** Only read the stashed message when the request really is the explicit redirect, not the
-automatic re-execute. With `using Microsoft.AspNetCore.Diagnostics;`:
-
-```csharp
-string? errorMessage = HttpContext.Features.Get<IStatusCodeReExecuteFeature>() is null
-    ? TempData["ErrorPageMessage"] as string
-    : null;
-```
-
-Built and measured: 0 warnings, **716/716**, the interleaved `/css/nope.css` and antiforgery-400 pages
-render their own generic text and the message survives to `/Error/404`, the intended redirect path is
-unchanged, and as a bonus the patched re-execute emits no `Set-Cookie` at all, closing the silent-delete
-variant. Unit tests are unaffected because `DefaultHttpContext` carries no such feature.
-
-**Verifier correction - INCOMPLETE, and the interim is unsupported.**
-
-1. **Redirect-vs-redirect collisions are not covered**, because neither request carries the feature.
-   Measured on the *patched* build: `GET /Subnet/Edit/999` (stashes) then `GET /Azure/BulkImport` ->
-   `/Error/403` (overwrites with *"Azure Import feature is not enabled"*); `/Error/404` then renders the
-   Azure sentence and `/Error/403` renders the generic default. Same wrong output, after the fix. This is
-   also the 10-of-12 real-browser path, i.e. the fix misses the variant an operator is most likely to hit.
-   Direct navigation to `/Error/{code}` likewise still consumes a pending message.
-2. **The "cheaper interim" (ship a `wwwroot/favicon.ico`) is not supported by measurement.** `/favicon.ico`
-   does 404 with a 6348-byte HTML page, but real headless Chromium issued **zero** favicon requests across
-   ~40 navigations, and a favicon fetch is triggered by a document that has already loaded - i.e. after the
-   ~1 ms window, never inside it. Keep it only as *"removes one stray 404"*, never as *"removes the most
-   common thief"*.
-3. Side effect worth stating rather than discovering: because re-executes no longer flush the key, an
-   abandoned message now survives strictly longer. It is never rendered wrongly, so this is not a
-   regression.
-
-The change that closes the whole class is making the message request-scoped instead of session-scoped -
-answering in place from the eleven sites rather than round-tripping a diagnostic through a single-slot
-browser cookie. That is the round-9 watch-list item, and it subsumes all three variants.
+_Not done, on the finding's own evidence: no `wwwroot/favicon.ico` — real headless Chromium issued
+zero favicon requests across ~40 navigations, and a favicon fetch lands after the document has already
+consumed the message. The round-9 watch-list item about answering in place from the eleven sites
+rather than round-tripping through a cookie remains the larger structural change; this closes all
+three observed variants without restructuring eleven actions' return types for a low-severity finding._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -423,87 +423,46 @@ these fields._
 
 ---
 
-## J9 [x1] - Bulk import greys out Azure-subnet rows whose parent prefix is blocked, but prints no badge and no reason for them
+_J9 is fixed and committed, but **not with the fix as written, which does not run**. It declares
+`const subnetBlockedByPrefix` at the reason site and reads it in the label built above — a temporal
+dead zone. Razor never parses the embedded script, so the project builds at 0 warnings and then throws
+`ReferenceError: Cannot access 'subnetBlockedByPrefix' before initialization` inside `renderVNetTree`,
+before `#bulk-vnet-selection` is un-hidden: step 2 spins forever with zero checkboxes, strictly worse
+than the defect it repairs. Both verifiers built it independently and hit the identical failure._
 
-**Severity:** info (filed low; one verifier corrected it down, the other left it as filed) |
-**Confidence:** confirmed | **Cite:**
-`src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:238` (the reason condition), `:232` (the disabled
-condition), `:161` (`availabilityBadge` returning `""` for `"Available"`)
+_Taken instead, the verifier's smaller and more complete repair: the declaration is hoisted to just
+after `$subnetDiv` is created, and `reasonHtml(subnet.reason)` is appended **unconditionally** with the
+prefix-blocked sentence added only when the row has no reason of its own. That removes the
+`if (!subnet.isSelectable)` branch rather than adding one, and it fixes the sibling case the proposed
+fix misses — the guard also swallowed the reason of a *selectable* row, and `AnnotateSubnet` produces
+exactly one: the encompassing subnet's "Covers the whole VNet prefix, so it marks the target fully
+allocated instead of being created."_
 
-**What goes wrong.** `:232` disables a subnet checkbox when `!subnet.isSelectable ||
-!prefixInfo.isSelectable`, but `:238-240` appends the explanatory reason only when
-`!subnet.isSelectable`, and the badge helper returns the empty string for `Available`. So the rows
-disabled **because their VNet prefix is blocked** render as a greyed-out checkbox with no badge and no
-text - while the sibling row directly above them, disabled by the same line of code, carries both. That
-asymmetry is the signature of `:238` not being updated when the `|| !prefixInfo.isSelectable` cascade was
-added at `:232`; the in-file comment at `:229-231` documents the cascade and says nothing about
-suppressing the reason.
+_The badge is deliberately **not** the red "Cannot import". The legend defines that as conflicting with
+something already in BASTET, which is untrue of a row whose own status is Available and which is
+unselectable only because its prefix is; reusing it would trade one legend inaccuracy for another. A
+distinct neutral "Blocked by VNet prefix" badge is used instead._
 
-This is also the steady state after any successful bulk import: the imported parent then has children, so
-`AnnotatePrefix` returns `Blocked` on every later run while any Azure subnet added since is `Available`.
+_Measured in real headless Chromium against real ARM, before and after, with a DOM dump of every row.
+Fixtures: Azure VNet `rec-vnet-blk` 10.60.0.0/16 with `rec-b1` 10.60.1.0/24 and `rec-b2` 10.60.2.0/24,
+against a Bastet `10.60.0.0/16` that already has a child — so the prefix annotates Blocked while
+`rec-b2` stays Available, which is J9's exact shape. **Before:** `bulk-subnet-0-0-1`
+`disabled=true badges=[] reason=(NONE)`, beside a sibling disabled by the same line of code carrying
+both a badge and a full sentence. **After:** `badges=['Blocked by VNet prefix']` and
+*"Its VNet prefix cannot be imported, so this subnet cannot be either."*, while `bulk-subnet-0-0-0`
+keeps its own specific reason rather than being overwritten by the generic one, and the selectable
+rows are unchanged. **0 console errors and 0 page errors**, and the wizard still previews and commits
+end to end (1 VNet target, 2 child subnets). The tree renders — which is the whole point, given how
+the proposed fix failed._
 
-**Reproduction.** Real ARM, real headless Chromium, DOM dump of `#bulk-vnet-tree .form-check`:
+_No test ships with this: it is view-embedded JavaScript with no unit-testable seam, and the browser
+run is the verification. Suite unchanged at **730**._
 
-```
-bulk-prefix-3-0   disabled=true  badges=[10.60.0.0/16, Cannot import]
-                  reason="Bastet subnet 'Rig Parent 10.60' already has child subnets. Already imported?"
-bulk-subnet-3-0-0 disabled=true  badges=[Cannot import]
-                  reason="Bastet subnet 'child-of-1060' already uses 10.60.1.0/24."
-bulk-subnet-3-0-1 disabled=true  badges=[]  reason=(NONE)     <- rig-subnet-beta 10.60.2.0/24
-bulk-subnet-4-0-0..3 disabled=true badges=[] reason=(NONE)    <- gamma2/delta2/eps2/zeta2
-CONSOLE_ERRORS: 0
-
-server payload for those rows: "statusName":"Available","reason":null,"isSelectable":true
-"Hide unavailable" ON: both 10.60 cards vanish entirely; EMPTY_STATE "(none)" - no explanation either way.
-select-all then preview: zero blocked rows submitted -> display-only defect.
-```
-
-**Two of the finding's claims are corrected, both narrowing it.** (1) It says six rows; it is **five** -
-the sixth (`rig-full-span`) needs the 10.92 VNet imported first and renders **enabled** from the stated
-inputs. (2) *"Zero explanation ... cannot tell them apart from rows unclickable by accident"* is too
-strong: each such row sits indented inside its prefix's own card, directly beneath a red **Cannot import**
-badge and a full sentence of reason, and the two can never be separated. The legend framing is the weakest
-part of the finding: `_StepSelection.cshtml:8` is a badge glossary, not an invariant, and it is **already**
-loose in the other direction at HEAD - a `Will update existing` prefix is neither greyed nor unselectable
-(measured: `bulk-prefix-1-0 | disabled=false`).
-
-**Fix - UNSOUND AS WRITTEN. It does not run.** The fix declares
-`const subnetBlockedByPrefix` at the reason site (`:238`) and references it in the label built at
-`:233-236` - a temporal dead zone. Razor never parses the embedded JS, so the project **builds clean**,
-and then:
-
-```
-SELECTION_VISIBLE: False   LOADING_VISIBLE: True   TREE_ROWS: 0   ENABLED PREFIXES: 0
-PAGEERROR: ReferenceError: Cannot access 'subnetBlockedByPrefix' before initialization
-    at Object.<anonymous> (/Azure/BulkImport:574:40) at renderVNetTree (:520:15) at Object.success (:481:21)
-```
-
-`renderVNetTree` throws before `#bulk-vnet-selection` is un-`d-none`d, so step 2 of the bulk wizard spins
-forever with zero checkboxes - strictly worse than the defect it repairs. Both verifiers built it
-independently and hit the identical failure.
-
-**Repair, built and measured:** hoist the declaration to just after `const $subnetDiv = ...`, before the
-checkbox and label. All five rows then render `badges=[Cannot import]` plus *"Its VNet prefix cannot be
-imported, so this subnet cannot be either."*, `rig-subnet-alpha` keeps its own specific reason, the
-preview still builds the correct plan for the selectable VNets, and console errors are 0.
-
-**Three further notes.**
-
-- **The fix misses its own sibling case.** The `if (!subnet.isSelectable)` guard also swallows the reason
-  of a *selectable* subnet, and `AnnotateSubnet` produces exactly one: the encompassing subnet, whose
-  reason is *"Covers the whole VNet prefix, so it marks the target fully allocated instead of being
-  created."* Measured `reason=(NONE)` on screen **before and after** the proposed fix. The smaller and more
-  complete change is to append `reasonHtml(subnet.reason)` unconditionally and add the prefix-blocked
-  sentence only when the row has no reason of its own - which also removes the extra branch.
-- The `else if (subnetBlockedByPrefix)` is redundant inside the else (`subnet.isSelectable` is necessarily
-  true there), and reusing the `bg-danger` **Cannot import** badge trades one legend inaccuracy for
-  another - the legend defines that badge as *"conflicts with something already in BASTET"*, which is false
-  for `rig-subnet-beta`. A distinct badge would keep the legend honest.
-- The cheaper interim (soften the legend at `_StepSelection.cshtml:8`) is fine but incomplete: any legend
-  rewrite must fix **both** directions, not only add the "sits under a greyed prefix" clause.
-
-No sibling call site: `isSelectable` appears in exactly one view, and the only other `prop('disabled'`
-view is the unrelated CIDR calculator.
+_The finding's two self-corrections were confirmed rather than taken on trust: it is five rows, not
+six, and the legend framing was the weakest part of it — `_StepSelection.cshtml:8` is a badge glossary,
+not an invariant, and it is already loose in the other direction at HEAD. The cheaper interim
+(softening the legend) was **not** taken; it is incomplete on its own terms, since any legend rewrite
+would have to fix both directions._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -293,123 +293,42 @@ side effect and reintroduce the synthetic-event pattern round 4's D1 removed._
 
 ---
 
-## J6 [x1] - Production sign-out answers 500 and silently discards the session-cookie deletion when the OIDC discovery document is unavailable
+_J6 is fixed and committed, with all three of the verifier's corrections the fix itself omitted. The
+local session is now ended first and separately — `await HttpContext.SignOutAsync(cookie, properties)`
+— then the OIDC leg runs inside a `try`, returning `EmptyResult` on success and `Redirect(target)` if
+it throws. Doing it in the action rather than returning `SignOut(...)` is the whole point: as a
+`SignOutResult` both legs ran during **result execution**, after the action had returned, where
+nothing could intercept the throw and `UseExceptionHandler`'s `Response.Clear()` discarded every
+queued `Set-Cookie` with it._
 
-**Severity:** low (filed medium; **corrected down by both verifiers** to match round 9's I6, which shipped
-the byte-identical consequence at low) | **Confidence:** confirmed | **Cite:**
-`src/Bastet/Controllers/AccountController.cs:67`
+_The corrections: **(1)** `AuthenticationProperties` is passed to the **cookie** leg too —
+`CookieAuthenticationDefaults.LogoutPath` is `/Account/Logout`, this very path, so without it
+`HandleSignOutAsync` takes its redirect branch with a null `RedirectUri` and writes a self-redirect,
+correct today only by accident because both exits overwrite `Location`. **(2)**
+`ILogger<AccountController>` is injected and the swallowed exception is logged at warning, matching
+`Program.cs`'s `Bastet.Authentication` warning for the sign-in half; the controller previously had no
+logger at all. **(3)** The nine round-9 I6 pins were **rewritten in this commit**, not deleted._
 
-**What goes wrong.** Round 9's I6 fixed one way for `GET /Account/Logout` to answer 500 with the session
-still alive (a non-ASCII `returnUrl` reaching the Location header). The same failure mode survives at the
-sibling statement the fix did not touch, and needs no crafted input.
+_Measured with two Production instances of the same build differing only in the fix, both pointed at
+an authority with nothing listening, so discovery can never succeed — a genuine same-branch control
+rather than a Development comparison, which returns through a different branch. **Unfixed:**
+`GET /Account/Logout` → **HTTP 500 with zero `Set-Cookie` headers**; the browser keeps its ticket.
+**Fixed:** → **HTTP 302 `Location: /Account/SignedOut`** carrying
+`.AspNetCore.Cookies=; expires=Thu, 01 Jan 1970 ...; secure; samesite=lax; httponly`, and
+`/Account/SignedOut` renders 200 anonymously during the outage. Fail-open became fail-closed._
 
-Preconditions: Production, `BASTET_OIDC_AUTHORITY` configured, and the process has not yet successfully
-fetched `{authority}/.well-known/openid-configuration` - i.e. it started or restarted during an IdP
-outage, a DNS/firewall change, or a misconfigured authority. `Program.cs` never touches the discovery
-document at startup, so a Production process starts happily against an unreachable authority, and the
-user's ticket survives the restart because the DataProtection key ring is DB-persisted
-(`Program.cs:115-119`).
+_The nine pins now assert on the mocked `IAuthenticationService` rather than on
+`SignOutResult.Properties.RedirectUri`, which no longer exists — same guarantee, one layer down,
+through a small `LogoutHarness` that captures the properties handed to each scheme. All four
+`NonLocalOrMissingReturnUrl` cases, `LocalReturnUrl_IsPreserved` and all four
+`ReturnUrlKestrelCannotWrite` cases survive, so round 9's I6 protection is intact. Two tests added: the
+unreachable-IdP case (the regression test this finding needed and did not propose) and one pinning
+that the cookie leg carries the redirect target. 725 → **727**._
 
-A user with a valid `.AspNetCore.Cookies` ticket clicks Logout. `:51-54` queues a `Set-Cookie` deletion
-for every request cookie; `:67-70` returns
-`SignOut(props, CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme)`.
-The cookie handler queues its own deletion, then `OpenIdConnectHandler.SignOutAsync` throws
-`IDX20803`. Because `SignOut(...)` is an `IActionResult`, the throw happens during **result execution**,
-after the action returned, so nothing in the action can intercept it - and `UseExceptionHandler("/Error")`
-calls `Response.Clear()`, taking every queued `Set-Cookie` with it (the source says so at
-`Program.cs:539-546`).
-
-**Wrong output:** HTTP 500 with **zero** `Set-Cookie` headers. The browser keeps its ticket, the cookie
-handler validates it locally without contacting the IdP, and a privileged session the operator explicitly
-asked to end keeps running for up to the 1 h sliding expiry.
-
-**Reproduction.** Two Production instances of the **same** pristine DLL, differing only in whether
-discovery resolves - a genuine same-branch control, unlike a Development comparison which returns through
-`Redirect(target)` at `:74`:
-
-```
-A. discovery never fetched:
-   HTTP/1.1 500 Internal Server Error ; set-cookie count: 0
-   System.InvalidOperationException: IDX20803: Unable to obtain configuration from ... Connection refused
-     at ConfigurationManager`1.GetConfigurationAsync
-     at OpenIdConnectHandler.SignOutAsync
-     at AuthenticationService.SignOutAsync
-     at Microsoft.AspNetCore.Mvc.SignOutResult.ExecuteAsync(HttpContext httpContext)
-     at ExceptionHandlerMiddlewareImpl
-
-B. same build, discovery reachable:
-   HTTP/1.1 302 Found ; Location: https://.../endsession?post_logout_redirect_uri=...
-   Set-Cookie: .AspNetCore.Cookies=; expires=Thu, 01 Jan 1970 ...; secure; samesite=lax; httponly
-
-C. scoping: kill the IdP AFTER B has cached the document, repeat -> still 302 + Set-Cookie.
-```
-
-One verifier went further and minted a genuine `.AspNetCore.Cookies` ticket against the same DB-persisted
-key ring: `GET /Account/Roles` 200 rendering the user before Logout, 500 with zero `Set-Cookie` on Logout,
-**200 again after** on the same jar, and the surviving session still reached the Admin-gated
-`/HostIp/PurgeAllDeletedHostIps` (302 to the "nothing archived" redirect *inside* the action, where an
-unauthorized request 500s).
-
-**Why low, honestly stated.** The window is narrow and self-sealing - one successful discovery fetch
-anywhere in the process's life closes it permanently. Inside that window the deployment is already
-comprehensively broken: an unauthenticated `GET /` also returns 500 through the OIDC *challenge*, so
-nobody can sign in at all, and the user sees a 500 page rather than a signed-out page (the finding's
-*"while believing they signed out"* is overstated). What keeps it a real finding: every other 500 in that
-window fails **closed**; this one fails **open**.
-
-**Fix.** Do not let the local session teardown depend on the remote round trip, and do not perform the
-remote leg as an `IActionResult`:
-
-```csharp
-if (!environment.IsDevelopment())
-{
-    await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-    try
-    {
-        await HttpContext.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme,
-            new AuthenticationProperties { RedirectUri = target });
-        return new EmptyResult();
-    }
-    catch (Exception)
-    {
-        return Redirect(target);
-    }
-}
-```
-
-Built: 0 warnings / 0 errors, no missing using. Patched build against an unreachable authority: **302
-Location: /Account/SignedOut** with the deletion header present, and `/Account/SignedOut` renders 200
-anonymously during the outage. Healthy path byte-equivalent to HEAD (same 302 to the real
-`end_session_endpoint`, same two `Set-Cookie` headers). The finding is right that a `try` around
-`SignOut(...)` as currently written would be unreachable code, and right that all three cheaper interims
-fail (queue-order changes are all erased by `Response.Clear()`; pre-loading discovery at startup does not
-help, because the trigger *is* the IdP being unavailable at process start).
-
-**Verifier correction - INCOMPLETE.**
-
-1. **It breaks 9 of the 716 shipped tests, and the fix does not mention them.** `dotnet test` on the
-   patched copy: `total: 716, failed: 9, succeeded: 707`. All nine are in
-   `test/Bastet.Tests/Security/AccountControllerLogoutTests.cs` - the four
-   `Logout_Production_NonLocalOrMissingReturnUrl_RedirectsToSignedOutPage` cases (`:79`),
-   `Logout_Production_LocalReturnUrl_IsPreserved` (`:90`) and the four
-   `Logout_Production_ReturnUrlKestrelCannotWrite_RedirectsToSignedOutPage` cases (`:117`), each
-   `Assert.IsType() Failure: Expected typeof(SignOutResult), Actual typeof(EmptyResult)`. **These are
-   round 9's own I6 regression pins**, and they read `signOut.Properties.RedirectUri` - the only place
-   `target` is pinned. They must be rewritten in the same commit to assert on the mocked
-   `IAuthenticationService.SignOutAsync(context, OpenIdConnectDefaults.AuthenticationScheme, props)` (the
-   mock already exists in that file's helper and captures the properties), plus a new case that makes the
-   mock throw and asserts a `RedirectResult` to `SignedOutPath` - the regression test this finding
-   actually needs and does not propose.
-2. **The cookie leg should carry `AuthenticationProperties`.** `CookieAuthenticationDefaults.LogoutPath`
-   is `/Account/Logout`, which equals the request path, so `HandleSignOutAsync` takes its redirect branch
-   with a null `RedirectUri` and writes `Location: /Account/Logout` - a self-redirect. Harmless today only
-   because both exits overwrite `Location`, i.e. the fix is correct by accident. Pass
-   `new AuthenticationProperties { RedirectUri = target }` to the cookie leg too.
-3. `catch (Exception)` also swallows `OperationCanceledException` on a client abort and is silent.
-   `AccountController` has no logger; add `ILogger<AccountController>` to the primary constructor to
-   match `Program.cs:257-268`'s `Bastet.Authentication` warning for the sign-in half.
-
-No sibling call site: `SignOut(` appears exactly once in `src/`.
+_The finding's own judgements were confirmed rather than taken on trust: a `try` around `SignOut(...)`
+as written really would be unreachable code, and all three cheaper interims really do fail —
+queue-order changes are all erased by `Response.Clear()`, and pre-loading discovery at startup cannot
+help when the trigger is the IdP being unavailable at process start._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -332,122 +332,50 @@ help when the trigger is the IdP being unavailable at process start._
 
 ---
 
-## J7 [x1] - Reconcile scopes a subnet by subscription before it recognises its resource ID, so a corrupt Azure link is never classified and the cascade guard blames a subscription that does not exist
+_J7 is fixed and committed, as proposed. The three-way recognition now runs **before** the
+subscription-scope test in `BuildPlan`: a link that is neither a VNet nor a subnet id goes straight to
+`ReviewItems` and `continue`s, and the remaining branch is a two-way conditional. Written that way on
+the verifier's warning — simply deleting the `else` arm leaves `AzureReconcileItem? item;` unassigned
+on one path and does not compile._
 
-**Severity:** low (filed medium; **corrected down by both verifiers** - both consequences are diagnostic,
-nothing is destroyed and nothing becomes deletable) | **Confidence:** confirmed | **Cite:**
-`src/Bastet/Services/Azure/AzureReconciler.cs:83`
+_Why it mattered: `BelongsToSubscription` is a `StartsWith` over `"/subscriptions/{id}/"`, so a value
+that names no subscription failed it for **every** subscription, landed in `notCovered`, and never
+reached the `UnrecognisedResourceId` arm that exists precisely for it. The row was reported in no list
+on any scan, and rescanning a different subscription could never surface it either._
 
-**What goes wrong.** A Bastet subnet carries an `AzureResourceId` that is not a parseable ARM id - a
-typo, a truncated value, a migrated string. `AzureResourceId` is free text on the entity
-(`AzureResourceIdentity.cs:26` says so verbatim) and the only write-side check on the import paths is a
-length check, so the app's **own** Admin API will write one: `POST /Subnet/BatchCreateChildSubnets` with
-`subnets[0].AzureResourceId=this-is-not-an-arm-id` returned `{"success":true,"subnetIds":[2]}` and
-persisted it verbatim. No hand-edited row is required.
+_Measured live against real ARM through the app's own endpoints. The corrupt row was created by the
+application itself, not hand-edited: `POST /Subnet/BatchCreateChildSubnets` with
+`subnets[0].AzureResourceId=this-is-not-an-arm-id` returned `{"success":true,"subnetIds":[7]}` and
+persisted it verbatim, confirming the finding's claim that the only write-side check is length. A real
+`POST /Azure/ReconcileScan` then returned `reviewItems: [(7, UnrecognisedResourceId, "The recorded
+Azure resource ID names neither a VNet nor a subnet...")]` with `items` empty and no warnings — where
+before the fix that row appeared in **neither** list._
 
-In `BuildPlan` the subscription-scope test at `:83` runs **before** the three-way recognition at
-`:94-108`. `BelongsToSubscription` is `resourceId.StartsWith($"/subscriptions/{subscriptionId}/")`, so
-such a row fails it for **every** subscription id, is added to `notCovered` and `continue`d. It never
-reaches the `UnrecognisedResourceId` arm at `:105-107` that exists precisely for it - whose own comment
-says *"It is reported for review instead, so the operator can correct the row rather than have it
-silently offered for archival."*
+_Three regression cases added (`UnparseableResourceId_IsReviewed_NotSilentlySkipped` for both
+`not-an-arm-id` and the truncated `/subscriptions/<scanned-sub>` shape, plus
+`StaleAncestorOverUnparseableDescendant_IsWithheldWithoutBlamingASubscription`), 727 → **730**. All
+three confirmed failing against the unfixed reconciler with "collection was empty" — the ReviewItems
+list the row never reached. The existing
+`UnrecognisedResourceId_IsReviewedNotOfferedForDeletion` theory uses only ids prefixed with the
+scanned subscription, so it pinned exactly the half that already worked._
 
-Two wrong outputs:
+_One correction to the finding, found while writing the test rather than by reading. It says the
+ancestor "stays withheld after the fix"; that is true, but **not at `BuildPlan` time**. The
+review-item cascade guard runs inside `ApplyConfirmations` (round 9's I1 design), so the ancestor is
+still in `plan.Items` after the scan and is withheld only once Azure confirms its VNet is gone — which
+is the point at which the delete path asks. The test asserts it through `ApplyConfirmations` for that
+reason, and confirms the honest wording replaces the false "belongs to a different subscription"._
 
-- **(A)** With no Azure-linked ancestor the scan returns empty `items`, `reviewItems`, `warnings` and
-  `globalErrors`, so the wizard renders its nothing-to-clean banner over a subnet the scan never
-  classified.
-- **(B)** With such a row beneath a stale ancestor, `dcc15ab`'s new `notCovered` guard (`:137-140`)
-  withholds the ancestor with *"...would also archive Azure-linked subnet(s) beneath them that **belong
-  to a different subscription** and were not checked by this scan: 'stale-parent'."* That is **false** -
-  the child names no subscription at all - and unactionable: the offending child is named nowhere in the
-  response, and rescanning any other subscription will never surface it. The reconcile delete then answers
-  409 with the same false reason.
+_The three tests the brief flagged as arrange-sensitive
+(`ApplyConfirmations_TargetWhoseDescendantIsAReviewItem_IsAlsoWithheld`,
+`SubnetFromOtherSubscription_Ignored`, `StaleAncestorOverOtherSubscriptionDescendant_IsWithheld`) all
+survive unchanged, and a genuine other-subscription descendant still produces the "different
+subscription" warning, so I2's regression path is intact._
 
-**Reproduction.** All state created through real HTTP endpoints, then one scan over one tree with two
-rows that are both "neither a VNet nor a subnet":
-
-```
-items       : []
-reviewItems : [(3, 'control-storage-acct', 'UnrecognisedResourceId',
-                'The recorded Azure resource ID names neither a VNet nor a subnet, so nothing can be
-                 established about it. Correct or clear the link on this subnet.')]
-Row 2 (AzureResourceId='this-is-not-an-arm-id') appears in NEITHER list. Only the prefix differs.
-
-Under a stale ancestor:
-  warnings: ["1 subnet(s) were withheld from deletion because archiving them would also archive
-             Azure-linked subnet(s) beneath them that belong to a different subscription and were not
-             checked by this scan: 'rig-vnet-gone-vc11'."]
-  POST /Subnet/BulkDeleteStaleAzureSubnets {subnetIds:[4]} -> HTTP 409, same warning, DeletedSubnets = 0
-
-Real Chromium, standalone broken row:
-  SCAN-ERROR panel visible=False ; STALE/REVIEW sections visible=False
-  NOTHING-TO-CLEAN BANNER visible=True
-    "Everything imported from this subscription still exists in Azure. There is nothing to clean up."
-  CONSOLE_ERRORS: 0
-```
-
-**Widened by one verifier:** a **truncated** id that names the scanned subscription itself
-(`/subscriptions/<scanned-guid>`, no trailing slash) is skipped identically and produces the same
-"different subscription" warning - which is then not merely unestablished but directly contradicted by
-the row's own content.
-
-**Two of the finding's claims are corrected, both narrowing it.** (1) The banner text quoted in the
-finding (*"Everything still exists in Azure..."*) exists only in a code comment; the rendered banner is
-subscription-scoped, and the defect case is byte-identical to a genuine other-subscription row, which is
-the shipped, deliberate design. So (A) is better stated as *"a row that is in no subscription is reported
-in no scan"* than as a false clean bill. (2) *"The stale ancestor can never be archived through the app"*
-is **false**: `POST /Subnet/Delete/{id}` with `confirmation=approved` archived it immediately - the
-ordinary delete page carries no Azure gate. The 409 is confined to the reconcile path, and it fires
-identically on the *correct* control case, i.e. that refusal is the intended protection.
-
-**Fix - SOUND.** Recognise the resource ID before scoping it: hoist the type test above `:83`, report an
-unrecognised id as a `ReviewItems` entry, and `continue`; the `else` arm at `:103-108` then collapses.
-
-```csharp
-bool recognised = AzureResourceIdentity.IsAzureSubnet(snapshot.AzureResourceId)
-                  || AzureResourceIdentity.IsAzureVNet(snapshot.AzureResourceId);
-if (!recognised) { plan.ReviewItems.Add(Item(snapshot, AzureReconcileStatus.UnrecognisedResourceId, true,
-        "The recorded Azure resource ID names neither a VNet nor a subnet, so nothing can be established "
-        + "about it. Correct or clear the link on this subnet.")); continue; }
-if (!BelongsToSubscription(snapshot.AzureResourceId, subscriptionId)) { notCovered.Add(snapshot.Id); continue; }
-```
-
-Built by both verifiers: 0 warnings / 0 errors, **716/716** - including the three tests the brief flags
-as arrange-sensitive (`ApplyConfirmations_TargetWhoseDescendantIsAReviewItem_IsAlsoWithheld`,
-`SubnetFromOtherSubscription_Ignored`, `StaleAncestorOverOtherSubscriptionDescendant_IsWithheld`), which
-survive because this moves *classification*, not a guard, and their helpers emit parseable ARM ids. Live:
-the broken child lands in `reviewItems`, the ancestor is still withheld with the honest wording
-(*"...subnet(s) beneath them that were withheld from deletion"*), and a genuine other-subscription
-descendant still produces the "different subscription" warning, so I2's regression path is intact.
-
-Two caveats on implementation, from measurement rather than reading:
-
-- **Write it as a two-way `if/else`.** Simply deleting the `else` arm leaves `AzureReconcileItem? item;`
-  unassigned on one path and will not compile.
-- **Do not oversell it.** The ancestor stays withheld after the fix and the 409 would still be returned;
-  what the fix buys is that the operator is finally told *which row to correct*, so the dead end becomes
-  escapable. A broken link now appears on every subscription's scan instead of none - which is correct,
-  because it is in no subscription - and it lands in `ReviewItems`, which is never offered for deletion.
-
-**The proposed cheaper interim is UNSOUND - do not ship it.** It adds a second
-`WithholdTargetsWhoseCascadeIsBlocked` call with its own wording. That method returns early on
-`if (protectedSubnetIds.Count == 0 || plan.Items.Count == 0)` (`:269`) and its first act on firing is
-`plan.Items.RemoveAll(blocked.Contains)` (`:282`), so on an ancestor whose subtree holds **both** an
-unrecognised row and a genuine foreign-subscription row, whichever guard runs first empties `plan.Items`
-and the second returns silently - the new reason is swallowed and the operator still reads only "a
-different subscription". Observed live. It also re-proposes the shape round 9 struck under I1 (*"a second
-guard with its own wording is new surface for no measured gain"*) for strictly less benefit than the
-two-line reorder.
-
-**Regression test** (proposed and confirmed to fail on HEAD, pass on the patch): mirror
-`StaleAncestorOverOtherSubscriptionDescendant_IsWithheld` with a `Linked(...)` whose resource id is
-`"not-an-arm-id"`, asserting `Assert.Single(plan.ReviewItems)` and
-`Assert.DoesNotContain(plan.Warnings, w => w.Contains("different subscription"))`. Add a second case for
-the truncated `/subscriptions/<scanned-sub>` shape - that is the one where the shipped warning
-contradicts the row's own text. Note the existing
-`UnrecognisedResourceId_IsReviewedNotOfferedForDeletion` theory uses only ids prefixed with the scanned
-subscription, so it pins exactly the half that works.
+_The proposed cheaper interim was **not** taken, and its rejection is confirmed: a second
+`WithholdTargetsWhoseCascadeIsBlocked` call returns early when `plan.Items` is empty and empties
+`plan.Items` on firing, so whichever guard runs first swallows the other's reason. It also re-proposes
+the shape round 9 struck under I1._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-10.md
+++ b/docs/AUDIT-FINDINGS-10.md
@@ -152,111 +152,47 @@ N+1 at `Delete.cs:182-192` was left alone (measured 22.50 s → 22.74 s, i.e. no
 
 ---
 
-## J2 [x2] - Bulk Azure import commits a re-derived plan without checking it still matches the plan the operator approved
+_J2 is fixed and committed. `BulkImportSelectedVNetPrefixDto` gained an optional `Expected`
+(`BulkImportExpectedTargetDto`: target type by name, the two target subnet ids, the rename pair and
+the fully-allocated flag), the bulk wizard stashes each previewed outcome onto the very object the
+commit posts (`attachApprovedOutcomes`, new client state — the finding's claim that the wizard already
+holds this in `lastPlan` is false, that exists only in `_ReconcileScripts.cshtml`), and
+`BulkCreateFromAzurePlanCore` compares the re-derived plan against it immediately after `BuildPlan`,
+answering **409** with the differences and writing nothing — the same discipline
+`BulkDeleteStaleAzureSubnets` already applies._
 
-**Severity:** medium | **Confidence:** confirmed | **Cite:**
-`src/Bastet/Controllers/SubnetController.BulkAzure.cs:62` (the re-plan), `:156` (rename write),
-`:190` (the ARM-id stamp)
+_**Two decisions the finding left open.** The expectation stays optional, so the documented direct
+JSON API keeps working; a prefix that carries none is counted and written to the log as an unverified
+commit rather than passing silently, which is the verifier's "log it" option. And because
+`GlobalSanitizationFilter` does not descend into the nested selection list, **nothing from the caller
+is echoed into the 409 body** — every divergence is described from the server's own re-derived plan,
+targets are labelled with the plan's parsed `PrefixNetworkAddress/PrefixCidr`, a prefix with no plan
+item is identified by its position in the submitted list, and a changed rename target is reported as
+"the name has changed" without repeating it. A test pins that the caller's description string does not
+come back._
 
-**What goes wrong.** Admin opens `/Azure/BulkImport`, selects VNet `rig-jb-div` (10.151.0.0/16) and
-previews. Step 3 renders *"New top-level - create rig-jb-div (10.151.0.0/16)"*. While that screen is up,
-a second admin creates an unrelated Bastet subnet `10.151.0.0/16` named `Finance-Prod-Reserved`
-(description *"Reserved by the network team. Not an Azure VNet."*, no Azure link) through the ordinary
-`/Subnet/Create` form. The first admin clicks **Confirm Import** on a screen that says *"apply the plan
-to Bastet"*.
+_Measured on the live rig — real ARM (`rec-vnet-div` 10.151.0.0/16 with two subnets), real headless
+Chromium, real SQL Server. Control: preview then commit with no interference imports normally
+(1 target, 2 children), 0 console errors, 0 page errors. Interleaved: with the plan on screen showing
+"New top-level — create rec-vnet-div", a second admin creates `10.151.0.0/16` by hand through
+`/Subnet/Create`; the commit now answers **409** "The plan changed since it was previewed, so nothing
+was imported", and the hand-made row survives with `AzureResourceId` still null — unadopted, unstamped
+and unrenamed, where before it was adopted. The audit's own diagnostic that "the preview and commit
+request bodies are byte-identical on the wire" is no longer true: the commit now carries the approved
+outcome._
 
-`BulkCreateFromAzurePlanCore` re-runs the planner against the now-changed tree (`:61-62`), gets a
-different plan - `TargetType` flips from `AutoCreateTopLevel` to `ExactMatch` - and executes **that**
-plan with no comparison against what was approved. The commit posts the *selection*, never the plan: the
-preview and commit request bodies are byte-identical on the wire. It stamps
-`AzureResourceId=/subscriptions/<sub>/.../virtualNetworks/rig-jb-div` onto `Finance-Prod-Reserved`
-(`:190`) and parents the Azure children under it; with the rename box ticked it also overwrites the
-operator's name (`:156`).
+_Five regression tests added (`SubnetControllerBulkAzureImportTests`), 718 → **723**. Two pin the
+refusal and the divergence message; three pin what must NOT break — an unchanged plan still commits,
+an adoption that was itself previewed and approved still commits (the advertised adopt path, which the
+finding correctly says a blanket server-side rule would have broken), and a caller with no expectation
+is not refused. Confirmed failing against unfixed code by reverting only the guard hunk while keeping
+the DTO, so the failure is behavioural rather than a compile error: both refusal tests returned
+`OkObjectResult` — the commit adopting the subnet — instead of `ConflictObjectResult`._
 
-**Wrong output, and it is irreversible in-app:** `AzureResourceId` is written only by the two import
-paths and **never cleared**; `EditSubnetViewModel` does not carry the field and `Views/Subnet/Edit.cshtml`
-never mentions it, so there is no unlink. The row's CIDR also becomes uneditable
-(`SubnetController.Edit.cs:92` throws when the field is non-empty). The row is now inside the reconcile
-wizard's deletion scope, and when the VNet is later deleted in Azure it is archived - into a
-`DeletedSubnets` table with no `AzureResourceId` column and no restore path anywhere in the app.
-
-**The sibling destructive endpoint does the opposite on this exact class of divergence:**
-`SubnetController.AzureReconcile.cs:77-92` rebuilds the plan and returns **409 Conflict**, deleting
-nothing. The single-VNet wizard is immune because `BatchCreateChildSubnetsCore(int parentId, ...)` pins
-its target with `FindAsync(parentId)`.
-
-**Reproduction.** Real headless Chromium driving the real wizard against real ARM, verifier's own
-catalog and instances; `interleave.sh` is the second admin.
-
-```
-PLAN_SHOWN:   VNet "rig-v10c2-div" - prefix 10.152.0.0/16  New top-level  create rig-v10c2-div ...
-INTERLEAVE:   hand-create HTTP 302 | 1 Finance-Prod-Reserved 10.152.0.0/16 arm=<null>
-PLAN_STILL_SHOWN: (unchanged - the screen never repaints)
-COMMIT_SCREEN: "Click the button below to apply the plan to Bastet. This is performed in a single
-                transaction; if anything fails, no changes are saved."  Confirm Import
-POSTED_TO BulkCreateFromAzurePlan: <byte-identical to the preview post>
-COMMIT_RESULT: SUCCESS[Bulk import completed. Created 0 VNet target(s), 2 child subnet(s), renamed 0
-                target(s), linked 1 existing target(s) to Azure, ...]
-CONSOLE_ERRORS: 0
-
-DB after:  1 | Finance-Prod-Reserved | 10.152.0.0/16 | desc='Reserved by the network team...'
-               arm=/subscriptions/.../virtualNetworks/rig-v10c2-div
-           2,3 | rig-v10c2-s1, rig-v10c2-s2 | parent=1
-
-Approved plan, in machine form:
-  ITEM prefix=10.152.0.0/16 targetType=2 (AutoCreateTopLevel) existingTargetSubnetId=None
-Executed plan: ExactMatch onto subnet 1.
-```
-
-Consequence chain, run to the end: `az network vnet delete` -> `ResourceNotFound`;
-`POST /Azure/ReconcileScan` -> `id=1 Finance-Prod-Reserved 10.152.0.0/16 status=VNetDeleted
-descendants=2`; `POST /Subnet/BulkDeleteStaleAzureSubnets {subnetIds:[1]}` -> 200
-`{"targetsDeleted":1,"subnetsArchived":3}`; `SELECT` over `10.152.*` -> 0 rows; `DeletedSubnets` holds
-`Finance-Prod-Reserved` with its original description and **no** `AzureResourceId` column. Rename
-variant: same commit returned `renamedTargets:1, linkedTargets:1` and the row became `rig-v10c2-div`
-with the operator's description preserved - proving it is the same row. Sibling asymmetry, same session:
-`POST /Subnet/BulkDeleteStaleAzureSubnets {subnetIds:[99]}` -> **409**, nothing deleted.
-
-Control: three concurrent identical commits gave 1x200 and 2x400 (*"already exists in Bastet"*), so the
-lock and the re-plan do work - the gap is specifically that nothing compares the re-derived plan with
-the approved one.
-
-**Fix.** Make the commit refuse a plan that is not the plan that was approved, exactly as
-`BulkDeleteStaleAzureSubnets` already does. Add an optional per-prefix expectation to
-`BulkImportSelectionDto` (`{vNetResourceId, addressPrefix, targetType, existingTargetSubnetId,
-autoCreateParentSubnetId, willRename, newName, willMarkFullyAllocated}`), populated by the wizard from
-the preview response; compare each re-derived item against its expectation immediately after `BuildPlan`
-at `:62` and return **409 Conflict** listing the differences. **Cheaper interim:** send and compare only
-`targetType` and `existingTargetSubnetId` - about fifteen lines each side, and it does close the
-reproduced case (approved `AutoCreateTopLevel`/null vs re-derived `ExactMatch`/1 diverges on both
-fields).
-
-**Verifier correction - INCOMPLETE.** The shape is right and the DTO is a plain POCO
-(`AzureBulkImportViewModels.cs:192-208`), so an added nullable property breaks no caller. Two problems:
-
-1. **A stated premise is false.** The fix says the wizard already holds the preview response *"in
-   `lastPlan` (`_BulkScripts.cshtml` renderPlan/commitImport)"*. `grep -n lastPlan` over that file
-   returns **nothing** - `lastPlan` exists only in `_ReconcileScripts.cshtml`. The bulk wizard's state is
-   `lastSelection` and `previewSeq`. `renderPlan(result.plan)` does receive the plan, so stashing it is a
-   two-line addition - but the fix must say it is *adding* client state, not reusing it.
-2. **It is weaker than the precedent it invokes, in the way that matters.**
-   `BulkDeleteStaleAzureSubnets` takes ids only and re-derives server-side; the client cannot opt out.
-   Making the expectation optional so *"leaving the field null keeps the documented direct-JSON-API
-   behaviour unchanged"* means the server is safe only when the client volunteers to be checked - a
-   browser holding a cached older script, or any direct caller, keeps today's behaviour on the Admin-only
-   endpoint that is dangerous precisely because it writes. If the field must stay optional, the null case
-   needs its own recorded decision (log it, or refuse server-side the narrow `ExactMatch`-onto-a-row-that-
-   was-not-in-the-approved-plan case), not silence.
-3. Not mentioned by the fix: the nested expectation object arrives **unsanitized**, because
-   `GlobalSanitizationFilter` does not descend into the nested selection list. Harmless while it is only
-   compared, but it must not be echoed into the 409 body unescaped.
-
-**Both of the fix's rejections are correct and were checked.** *"Re-run the preview at commit time"* is
-the same defect one step later - the operator has already left the preview screen. And a server-only
-rule *"refuse ExactMatch onto a subnet not already linked to this VNet"* really would break the
-advertised adopt path: `AzureBulkImportPlanner.cs:225-226` sets `WillUpdateExisting` with reason *"Will
-import into existing Bastet subnet"* for exactly the unlinked case, and that is what the wizard renders
-as selectable.
+_Not done: the finding's two rejected alternatives were left rejected, and its reasoning confirmed.
+Re-running the preview at commit time is the same defect one step later, and a server-only rule
+refusing `ExactMatch` onto an unlinked row would break the adopt path that
+`AzureBulkImportPlanner.cs:225-226` advertises as selectable._
 
 ---
 

--- a/src/Bastet/Controllers/AccountController.cs
+++ b/src/Bastet/Controllers/AccountController.cs
@@ -8,7 +8,10 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Bastet.Controllers;
 
-public class AccountController(IWebHostEnvironment environment, IUserContextService userContextService) : Controller
+public class AccountController(
+    IWebHostEnvironment environment,
+    IUserContextService userContextService,
+    ILogger<AccountController> logger) : Controller
 {
     /// <summary>
     /// Anonymous: this is the configured AccessDeniedPath, so it must be reachable by a user who
@@ -63,11 +66,38 @@ public class AccountController(IWebHostEnvironment environment, IUserContextServ
         // If we're in production, also sign out from the identity provider
         if (!environment.IsDevelopment())
         {
-            // Redirect to OIDC provider for logout
-            return SignOut(
-                new AuthenticationProperties { RedirectUri = target },
-                CookieAuthenticationDefaults.AuthenticationScheme,
-                OpenIdConnectDefaults.AuthenticationScheme);
+            // The local session is ended first, and separately, so it does not depend on a remote
+            // round trip succeeding. Returning SignOut(...) performed both legs during *result*
+            // execution, after the action had returned: when the OIDC handler could not fetch the
+            // discovery document it threw IDX20803 there, UseExceptionHandler called Response.Clear()
+            // - taking every queued Set-Cookie with it - and sign-out answered 500 with the session
+            // still alive. Every other failure in that window fails closed; that one failed open.
+            //
+            // RedirectUri is passed to the cookie leg too. CookieAuthenticationDefaults.LogoutPath is
+            // /Account/Logout, which is this very path, so without it HandleSignOutAsync takes its
+            // redirect branch with a null RedirectUri and writes a self-redirect - harmless today
+            // only because both exits below overwrite Location.
+            AuthenticationProperties properties = new() { RedirectUri = target };
+
+            await HttpContext.SignOutAsync(
+                CookieAuthenticationDefaults.AuthenticationScheme, properties);
+
+            try
+            {
+                await HttpContext.SignOutAsync(OpenIdConnectDefaults.AuthenticationScheme, properties);
+
+                // The handler has written the redirect to the IdP's end-session endpoint itself.
+                return new EmptyResult();
+            }
+            catch (Exception ex)
+            {
+                // The IdP being unreachable must not keep a privileged session alive. The local
+                // sign-out above has already happened and its Set-Cookie is not at risk, because
+                // nothing here throws out of result execution.
+                logger.LogWarning(ex,
+                    "Signing out of the identity provider failed; the local session was still ended.");
+                return Redirect(target);
+            }
         }
 
         // In development, just redirect to the specified URL or the signed-out page

--- a/src/Bastet/Controllers/AzureController.cs
+++ b/src/Bastet/Controllers/AzureController.cs
@@ -21,8 +21,7 @@ namespace Bastet.Controllers
             // Check environment variable
             if (!IsAzureImportEnabled())
             {
-                TempData["ErrorPageMessage"] = "Azure Import feature is not enabled";
-                return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 403 });
+                return this.RedirectToErrorPage(403, "Azure Import feature is not enabled");
             }
 
             // Get the subnet
@@ -33,8 +32,7 @@ namespace Bastet.Controllers
 
             if (subnet == null)
             {
-                TempData["ErrorPageMessage"] = $"Subnet with ID {id} could not be found.";
-                return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 404 });
+                return this.RedirectToErrorPage(404, $"Subnet with ID {id} could not be found.");
             }
 
             // Check if subnet has no children or host IPs and is not fully allocated
@@ -181,8 +179,7 @@ namespace Bastet.Controllers
         {
             if (!IsAzureImportEnabled())
             {
-                TempData["ErrorPageMessage"] = "Azure Import feature is not enabled";
-                return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 403 });
+                return this.RedirectToErrorPage(403, "Azure Import feature is not enabled");
             }
 
             BulkImportInitialViewModel viewModel = new() { IsFeatureEnabled = true };
@@ -289,8 +286,7 @@ namespace Bastet.Controllers
         {
             if (!IsAzureImportEnabled())
             {
-                TempData["ErrorPageMessage"] = "Azure Import feature is not enabled";
-                return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 403 });
+                return this.RedirectToErrorPage(403, "Azure Import feature is not enabled");
             }
 
             AzureReconcileInitialViewModel viewModel = new() { IsFeatureEnabled = true };

--- a/src/Bastet/Controllers/ErrorController.cs
+++ b/src/Bastet/Controllers/ErrorController.cs
@@ -14,8 +14,26 @@ namespace Bastet.Controllers;
 public class ErrorController : Controller
 {
     [Route("/Error/{statusCode}")]
-    public IActionResult HttpStatusCodeHandler(int statusCode)
+    public IActionResult HttpStatusCodeHandler()
     {
+        // Read straight off the route rather than bound as a parameter. UseStatusCodePagesWithReExecute
+        // re-executes the pipeline for the SAME request - same method, same body - having rewritten
+        // the path, and MVC's default composite value provider puts FormValueProviderFactory ahead of
+        // RouteValueProviderFactory. A form field named statusCode in the original POST body therefore
+        // outranked the route segment the middleware had just set, letting a caller relabel their own
+        // failed request: posting statusCode=404 to a request the framework answered 400 with put 404
+        // on the wire and in the request log.
+        //
+        // Binding also failed in the other direction. When the body cannot be read at all - a NUL byte
+        // in any form value, a malformed multipart boundary - FormPipeReader throws and binding is
+        // abandoned for every source, so the parameter arrived as 0 and the guard below turned an
+        // ordinary client mistake into 500 "Status Code: 0". The route value survives both, because it
+        // is what the middleware set and it does not depend on parsing the body.
+        int statusCode = RouteData.Values.TryGetValue("statusCode", out object? routeValue)
+                         && int.TryParse(routeValue as string, out int statusFromRoute)
+            ? statusFromRoute
+            : Response.StatusCode;
+
         // The message is read from TempData (set server-side by the redirecting action), never from
         // the query string - otherwise anyone could craft /Error/400?errorMessage=... and show
         // arbitrary text under this origin. Falls back to the per-status default below.

--- a/src/Bastet/Controllers/ErrorController.cs
+++ b/src/Bastet/Controllers/ErrorController.cs
@@ -37,7 +37,14 @@ public class ErrorController : Controller
         // The message is read from TempData (set server-side by the redirecting action), never from
         // the query string - otherwise anyone could craft /Error/400?errorMessage=... and show
         // arbitrary text under this origin. Falls back to the per-status default below.
-        string? errorMessage = TempData["ErrorPageMessage"] as string;
+        //
+        // Only the message belonging to *this* redirect is read. The query key is an opaque token
+        // minted by the redirecting action, not the text: a single shared slot meant whichever
+        // request reached this page first consumed whatever was pending, so an unrelated 4xx landing
+        // in the gap printed another request's diagnostic and the intended page lost it. A
+        // re-executed status page and a direct visit to /Error/{code} carry no token, so they read
+        // nothing and, just as importantly, clear nothing.
+        string? errorMessage = ErrorPageMessages.Take(TempData, Request.Query[ErrorPageMessages.TokenQueryKey]);
 
         // UseStatusCodePagesWithReExecute sets the status itself before re-executing, so a route
         // that matched nothing really did answer 404. A controller that *redirects* here does not:

--- a/src/Bastet/Controllers/ErrorPageMessages.cs
+++ b/src/Bastet/Controllers/ErrorPageMessages.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System.Text.Json;
+
+namespace Bastet.Controllers;
+
+/// <summary>
+/// Carries a diagnostic from an action that redirects to <c>/Error/{statusCode}</c> across to the
+/// error page, giving every redirect its own slot.
+/// </summary>
+/// <remarks>
+/// Round-10 J4. There used to be one <c>TempData["ErrorPageMessage"]</c> slot for the whole session,
+/// and <c>ErrorController</c> read it unconditionally - so whichever request reached the error page
+/// first took whatever was pending, and a TempData read consumes it. Three ways that went wrong,
+/// all reproduced:
+/// <list type="bullet">
+/// <item>an unrelated 4xx (a missing stylesheet, a stale antiforgery token) landing between the
+/// redirect and the browser following it printed a diagnostic about a request that browser never
+/// made, while the page it belonged to fell back to the generic text;</item>
+/// <item>two stale rows in two tabs crossed their messages - the most reachable path, and the one a
+/// re-execute-only guard does not close, because neither request is a re-execute;</item>
+/// <item>a 4xx re-execute with nothing pending still flushed the key, silently deleting a message
+/// rather than stealing it.</item>
+/// </list>
+/// A token in the redirect URL fixes all three: the error page reads only the entry the redirect that
+/// reached it created. The token is an opaque lookup key that is never rendered, so this does not
+/// reintroduce round 3's B6 - the message text still comes from TempData, set server-side, and is
+/// never taken from the URL.
+/// </remarks>
+public static class ErrorPageMessages
+{
+    private const string TempDataKey = "ErrorPageMessages";
+
+    /// <summary>Query-string key holding the token that identifies one pending message.</summary>
+    public const string TokenQueryKey = "m";
+
+    /// <summary>
+    /// How many undelivered messages to keep. A redirect the browser never follows - the user hits
+    /// Stop, closes the tab, the follow-up fails - leaves its entry behind, and TempData persists
+    /// anything unread. Without a cap those would accumulate in the cookie for the whole session.
+    /// The oldest is dropped first; losing an undelivered diagnostic costs nothing, because nothing
+    /// is going to ask for it.
+    /// </summary>
+    private const int MaxPending = 5;
+
+    private sealed record PendingMessage(string Token, string Message);
+
+    /// <summary>
+    /// Stashes <paramref name="message"/> and redirects to the error page for
+    /// <paramref name="statusCode"/>, tagging the redirect so only it can read the message back.
+    /// </summary>
+    public static RedirectToActionResult RedirectToErrorPage(
+        this Controller controller, int statusCode, string message)
+    {
+        List<PendingMessage> pending = Read(controller.TempData);
+        string token = Guid.NewGuid().ToString("N")[..12];
+
+        pending.Add(new PendingMessage(token, message));
+        if (pending.Count > MaxPending)
+        {
+            pending.RemoveRange(0, pending.Count - MaxPending);
+        }
+
+        Write(controller.TempData, pending);
+
+        return controller.RedirectToAction(
+            "HttpStatusCodeHandler", "Error", new { statusCode, m = token });
+    }
+
+    /// <summary>
+    /// Returns the message this request's token refers to, removing it so it is shown once, and
+    /// leaves every other pending message untouched.
+    /// </summary>
+    public static string? Take(ITempDataDictionary tempData, string? token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            // A re-executed 4xx or a direct visit to /Error/{code} carries no token. It must not
+            // read, and must not clear, a message queued for some other request.
+            return null;
+        }
+
+        List<PendingMessage> pending = Read(tempData);
+        PendingMessage? match = pending.Find(p => p.Token == token);
+        if (match is null)
+        {
+            return null;
+        }
+
+        pending.Remove(match);
+        Write(tempData, pending);
+        return match.Message;
+    }
+
+    private static List<PendingMessage> Read(ITempDataDictionary tempData)
+    {
+        // Peek rather than index: reading TempData consumes it, and the entries not being taken here
+        // still have a request to survive to.
+        if (tempData.Peek(TempDataKey) is not string serialized || serialized.Length == 0)
+        {
+            return [];
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<PendingMessage>>(serialized) ?? [];
+        }
+        catch (JsonException)
+        {
+            // Written by a previous version of this application, or truncated. A diagnostic is not
+            // worth failing a request that is already reporting an error.
+            return [];
+        }
+    }
+
+    private static void Write(ITempDataDictionary tempData, List<PendingMessage> pending)
+    {
+        if (pending.Count == 0)
+        {
+            tempData.Remove(TempDataKey);
+            return;
+        }
+
+        tempData[TempDataKey] = JsonSerializer.Serialize(pending);
+    }
+}

--- a/src/Bastet/Controllers/HostIpController.cs
+++ b/src/Bastet/Controllers/HostIpController.cs
@@ -567,8 +567,6 @@ public class HostIpController(
             {
                 // Subnet still exists
                 viewModel.SubnetName = subnet.Name;
-                viewModel.NetworkAddress = subnet.NetworkAddress;
-                viewModel.Cidr = subnet.Cidr;
             }
             else
             {
@@ -577,15 +575,11 @@ public class HostIpController(
                 if (deletedSubnet != null)
                 {
                     viewModel.SubnetName = $"{deletedSubnet.Name} (deleted)";
-                    viewModel.NetworkAddress = deletedSubnet.NetworkAddress;
-                    viewModel.Cidr = deletedSubnet.Cidr;
                 }
                 else
                 {
                     // No information available
                     viewModel.SubnetName = "Unknown";
-                    viewModel.NetworkAddress = "Unknown";
-                    viewModel.Cidr = 0;
                 }
             }
 

--- a/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
+++ b/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
@@ -3,6 +3,7 @@ using Bastet.Models.ViewModels;
 using Bastet.Services.Azure;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace Bastet.Controllers;
 
@@ -126,6 +127,13 @@ public partial class SubnetController : Controller
 
                     HashSet<int> alreadyArchived = [];
 
+                    // Read the tree once for the whole batch rather than twice per target. Every
+                    // target's subtree is archived from this one snapshot: subtrees are disjoint, so
+                    // rows removed by an earlier target are never named by a later one. Tracking, not
+                    // AsNoTracking - ArchiveSubnetSubtreeAsync removes these very instances, and a
+                    // detached duplicate throws once a target has descendants.
+                    List<Subnet> subnetTree = await context.Subnets.ToListAsync();
+
                     foreach (int subnetId in ordered)
                     {
                         if (alreadyArchived.Contains(subnetId))
@@ -140,21 +148,26 @@ public partial class SubnetController : Controller
                             continue;
                         }
 
-                        List<Subnet> descendants = await GetAllDescendantsOrdered(subnetId);
-                        (int archivedSubnets, int archivedHostIps) = await ArchiveSubnetSubtreeAsync(subnet);
+                        List<int> archivedIds = [];
+                        (int archivedSubnets, int archivedHostIps) =
+                            await ArchiveSubnetSubtreeAsync(subnet, subnetTree, archivedIds);
 
-                        foreach (Subnet descendant in descendants)
+                        // Covers the target itself as well as its descendants.
+                        foreach (int archivedId in archivedIds)
                         {
-                            alreadyArchived.Add(descendant.Id);
+                            alreadyArchived.Add(archivedId);
                         }
 
-                        alreadyArchived.Add(subnetId);
                         subnetsArchived += archivedSubnets;
                         hostIpsArchived += archivedHostIps;
                         targetsDeleted++;
-
-                        await context.SaveChangesAsync();
                     }
+
+                    // One save for the batch. It was per-target, which re-ran DetectChanges over
+                    // every tracked entity once per target while holding the global write lock; the
+                    // whole loop is a single transaction committed just below, so nothing between
+                    // iterations needs the rows flushed.
+                    await context.SaveChangesAsync();
 
                     await transaction.CommitAsync();
                     return null;

--- a/src/Bastet/Controllers/SubnetController.BulkAzure.cs
+++ b/src/Bastet/Controllers/SubnetController.BulkAzure.cs
@@ -51,6 +51,106 @@ public partial class SubnetController : Controller
         }
     }
 
+    /// <summary>
+    /// Compares the plan just re-derived at commit time against the outcome the preview showed the
+    /// operator, and describes every way they disagree.
+    /// </summary>
+    /// <remarks>
+    /// Round-10 J2. The commit posts the *selection*, not the plan, so the preview and commit request
+    /// bodies were byte-identical on the wire and nothing noticed when the re-derived plan differed.
+    /// A subnet created by another admin while the preview was on screen flipped the target from
+    /// AutoCreateTopLevel to ExactMatch, and the commit adopted it: stamped with the VNet's
+    /// AzureResourceId (which no view can clear), renamed if the rename box was ticked, and thereby
+    /// pulled into the reconcile wizard's deletion scope.
+    /// <para>
+    /// Nothing from the caller is echoed into the result. Divergences are described from the plan the
+    /// server just built, because <c>GlobalSanitizationFilter</c> does not descend into the nested
+    /// selection list and so nothing on the expectation has been sanitized. Where a selected prefix
+    /// produces no plan item at all there is no server-derived text to name it by, so it is
+    /// identified by its position in the submitted list.
+    /// </para>
+    /// </remarks>
+    private List<string> DescribeApprovedPlanDivergences(BulkImportSelectionDto selection, BulkImportPlanViewModel plan)
+    {
+        List<string> differences = [];
+        int unverified = 0;
+
+        for (int index = 0; index < selection.VNetPrefixes.Count; index++)
+        {
+            BulkImportSelectedVNetPrefixDto selected = selection.VNetPrefixes[index];
+            BulkImportExpectedTargetDto? expected = selected.Expected;
+
+            if (expected is null)
+            {
+                // A caller that did not preview has approved nothing, so there is nothing to compare
+                // against. Deliberately not refused: the endpoint is documented as a direct JSON API
+                // and refusing here would break it. Recorded instead, so an unverified commit is
+                // visible in the log rather than indistinguishable from a checked one.
+                unverified++;
+                continue;
+            }
+
+            BulkImportPlanItem? item = plan.Items.FirstOrDefault(i =>
+                string.Equals(i.VNetResourceId, selected.VNetResourceId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(i.VNetPrefix, selected.AddressPrefix, StringComparison.OrdinalIgnoreCase));
+
+            if (item is null)
+            {
+                differences.Add($"Selected prefix #{index + 1} no longer produces a target to import.");
+                continue;
+            }
+
+            // Server-derived and format-constrained, unlike the names round-tripped by the browser.
+            string label = $"{item.PrefixNetworkAddress}/{item.PrefixCidr}";
+
+            if (!Enum.TryParse(expected.TargetType, out BulkImportTargetType expectedTargetType)
+                || expectedTargetType != item.TargetType)
+            {
+                differences.Add($"{label}: the preview showed a different action; it now resolves to {item.TargetTypeName}.");
+            }
+
+            if (expected.ExistingTargetSubnetId != item.ExistingTargetSubnetId)
+            {
+                differences.Add(item.ExistingTargetSubnetId is null
+                    ? $"{label}: the preview matched an existing Bastet subnet; it no longer does."
+                    : $"{label}: it now targets existing Bastet subnet {item.ExistingTargetSubnetId}.");
+            }
+
+            if (expected.AutoCreateParentSubnetId != item.AutoCreateParentSubnetId)
+            {
+                differences.Add(item.AutoCreateParentSubnetId is null
+                    ? $"{label}: it would no longer be created under a parent subnet."
+                    : $"{label}: it would now be created under subnet {item.AutoCreateParentSubnetId}.");
+            }
+
+            if (expected.WillRename != item.WillRename)
+            {
+                differences.Add($"{label}: renaming the target changed to {item.WillRename}.");
+            }
+            else if (item.WillRename && !string.Equals(expected.NewName, item.NewName, StringComparison.Ordinal))
+            {
+                // The name itself is caller-supplied, so say that it differs without repeating it.
+                differences.Add($"{label}: the name the target would be renamed to has changed.");
+            }
+
+            if (expected.WillMarkFullyAllocated != item.WillMarkFullyAllocated)
+            {
+                differences.Add($"{label}: marking the target fully allocated changed to {item.WillMarkFullyAllocated}.");
+            }
+        }
+
+        if (unverified > 0)
+        {
+            logger.LogWarning(
+                "Bulk Azure import: {Unverified} of {Total} selected prefix(es) carried no previewed outcome, "
+                + "so the re-derived plan for them was not compared against anything the operator approved.",
+                unverified,
+                selection.VNetPrefixes.Count);
+        }
+
+        return differences;
+    }
+
     private async Task<IActionResult> BulkCreateFromAzurePlanCore(
         BulkImportSelectionDto selection,
         IAzureBulkImportPlanner planner,
@@ -60,6 +160,21 @@ public partial class SubnetController : Controller
         // Re-build the plan against the current Bastet tree right now
         IReadOnlyList<ExistingSubnetSnapshot> existing = await snapshotService.GetExistingSubnetsAsync();
         BulkImportPlanViewModel plan = planner.BuildPlan(selection, existing);
+
+        // Re-deriving the plan protects against committing a stale one, but on its own it also
+        // silently commits a *different* one when the tree moved under the operator. Refuse that,
+        // the way BulkDeleteStaleAzureSubnets already refuses a scan whose verdict has changed.
+        List<string> divergences = DescribeApprovedPlanDivergences(selection, plan);
+        if (divergences.Count > 0)
+        {
+            return Conflict(new
+            {
+                success = false,
+                error = "The plan changed since it was previewed, so nothing was imported. "
+                        + "Re-run the preview, review what it now says, and confirm again.",
+                differences = divergences
+            });
+        }
 
         if (!plan.CanCommit)
         {

--- a/src/Bastet/Controllers/SubnetController.Delete.cs
+++ b/src/Bastet/Controllers/SubnetController.Delete.cs
@@ -167,12 +167,25 @@ public partial class SubnetController : Controller
     /// archived atomically. Entities are queued deepest-first because the self-referencing FK is
     /// Restrict, so a parent cannot be removed before its children.
     /// </remarks>
+    /// <param name="subnet">The root of the subtree to archive.</param>
+    /// <param name="treeCache">
+    /// An already-loaded, <b>tracking</b> copy of the Subnets table - see
+    /// <see cref="GetAllDescendantsOrdered"/>. Lets a caller archiving several subtrees read the
+    /// table once rather than once per subtree.
+    /// </param>
+    /// <param name="archivedSubnetIds">
+    /// Receives the id of every subnet archived here, so a caller looping over targets can skip ones
+    /// already cascaded away without re-walking the tree to find out.
+    /// </param>
     /// <returns>How many subnets and host IP assignments were archived.</returns>
-    private async Task<(int SubnetsArchived, int HostIpsArchived)> ArchiveSubnetSubtreeAsync(Subnet subnet)
+    private async Task<(int SubnetsArchived, int HostIpsArchived)> ArchiveSubnetSubtreeAsync(
+        Subnet subnet, List<Subnet>? treeCache = null, List<int>? archivedSubnetIds = null)
     {
         // Deepest first, with the subnet itself processed last
-        List<Subnet> toDelete = await GetAllDescendantsOrdered(subnet.Id);
+        List<Subnet> toDelete = await GetAllDescendantsOrdered(subnet.Id, treeCache);
         toDelete.Add(subnet);
+
+        archivedSubnetIds?.AddRange(toDelete.Select(s => s.Id));
 
         string? deletedBy = userContextService.GetCurrentUsername();
         DateTime deletedAt = DateTime.UtcNow;

--- a/src/Bastet/Controllers/SubnetController.Delete.cs
+++ b/src/Bastet/Controllers/SubnetController.Delete.cs
@@ -19,8 +19,7 @@ public partial class SubnetController : Controller
 
         if (subnet == null)
         {
-            TempData["ErrorPageMessage"] = $"The subnet with ID {id} could not be found or may have been deleted.";
-            return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 404 });
+            return this.RedirectToErrorPage(404, $"The subnet with ID {id} could not be found or may have been deleted.");
         }
 
         // Count all descendants (not just direct children)
@@ -124,8 +123,7 @@ public partial class SubnetController : Controller
 
         if (subnet == null)
         {
-            TempData["ErrorPageMessage"] = $"The subnet with ID {id} could not be found or may have been deleted.";
-            return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 404 });
+            return this.RedirectToErrorPage(404, $"The subnet with ID {id} could not be found or may have been deleted.");
         }
 
         // Begin a transaction to ensure data consistency

--- a/src/Bastet/Controllers/SubnetController.Edit.cs
+++ b/src/Bastet/Controllers/SubnetController.Edit.cs
@@ -19,8 +19,7 @@ public partial class SubnetController : Controller
 
         if (subnet == null)
         {
-            TempData["ErrorPageMessage"] = $"The subnet with ID {id} could not be found or may have been deleted.";
-            return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 404 });
+            return this.RedirectToErrorPage(404, $"The subnet with ID {id} could not be found or may have been deleted.");
         }
 
         EditSubnetViewModel viewModel = new()
@@ -56,8 +55,7 @@ public partial class SubnetController : Controller
     {
         if (id != viewModel.Id)
         {
-            TempData["ErrorPageMessage"] = "The ID in the URL doesn't match the ID in the form data.";
-            return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 404 });
+            return this.RedirectToErrorPage(404, "The ID in the URL doesn't match the ID in the form data.");
         }
 
         if (ModelState.IsValid)
@@ -187,8 +185,7 @@ public partial class SubnetController : Controller
             {
                 if (!SubnetExists(id))
                 {
-                    TempData["ErrorPageMessage"] = "The subnet no longer exists. It may have been deleted by another user.";
-                    return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 404 });
+                    return this.RedirectToErrorPage(404, "The subnet no longer exists. It may have been deleted by another user.");
                 }
 
                 // Handle concurrency conflict - reload current data and show user-friendly message.
@@ -248,8 +245,7 @@ public partial class SubnetController : Controller
 
         if (origSubnet == null)
         {
-            TempData["ErrorPageMessage"] = $"The subnet with ID {id} could not be found or may have been deleted.";
-            return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 404 });
+            return this.RedirectToErrorPage(404, $"The subnet with ID {id} could not be found or may have been deleted.");
         }
 
         // Repopulate the display-only properties

--- a/src/Bastet/Controllers/SubnetController.Helpers.cs
+++ b/src/Bastet/Controllers/SubnetController.Helpers.cs
@@ -48,11 +48,26 @@ public partial class SubnetController : Controller
         return descendantCount;
     }
 
-    // Helper method to get all descendants ordered for deletion (deepest children first)
-    private async Task<List<Subnet>> GetAllDescendantsOrdered(int subnetId)
+    /// <summary>
+    /// Gets all descendants of <paramref name="subnetId"/> ordered for deletion (deepest first).
+    /// </summary>
+    /// <param name="subnetId">The subnet whose descendants are wanted.</param>
+    /// <param name="treeCache">
+    /// An already-loaded copy of the whole Subnets table, so a caller archiving several subtrees in
+    /// one transaction reads the table once instead of once per subtree. Subtrees are disjoint, so a
+    /// snapshot taken before the first archive still names every later target's descendants.
+    /// <para>
+    /// It MUST be a tracking read. <see cref="ArchiveSubnetSubtreeAsync"/> calls
+    /// <c>context.Subnets.Remove</c> on the instances this returns, while loading host IPs tracks a
+    /// fresh instance of every descendant; removing a detached duplicate throws "another instance
+    /// with the same key value is already being tracked". A flat, leaf-only workload never reaches
+    /// that path, so this cannot be left to a benchmark to catch.
+    /// </para>
+    /// </param>
+    private async Task<List<Subnet>> GetAllDescendantsOrdered(int subnetId, List<Subnet>? treeCache = null)
     {
         // Start with all subnets
-        List<Subnet> allSubnets = await context.Subnets.ToListAsync();
+        List<Subnet> allSubnets = treeCache ?? await context.Subnets.ToListAsync();
 
         // Create a dictionary for faster lookup
         Dictionary<int, Subnet> subnetDict = allSubnets.ToDictionary(s => s.Id);

--- a/src/Bastet/Controllers/SubnetController.Read.cs
+++ b/src/Bastet/Controllers/SubnetController.Read.cs
@@ -40,8 +40,7 @@ public partial class SubnetController : Controller
         if (subnet == null)
         {
             // Use our custom 404 page with helpful context
-            TempData["ErrorPageMessage"] = $"Subnet with ID {id} could not be found.";
-            return RedirectToAction("HttpStatusCodeHandler", "Error", new { statusCode = 404 });
+            return this.RedirectToErrorPage(404, $"Subnet with ID {id} could not be found.");
         }
 
         SubnetDetailsViewModel viewModel = new()

--- a/src/Bastet/Models/ViewModels/AllDeletedHostIpViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AllDeletedHostIpViewModels.cs
@@ -24,9 +24,17 @@ public class AllDeletedHostIpItemViewModel
 
     // Original subnet information
     public int OriginalSubnetId { get; set; }
+
+    /// <summary>
+    /// The original subnet's name, or "Unknown" when neither a live nor an archived subnet carries
+    /// the recorded id.
+    /// </summary>
+    /// <remarks>
+    /// No address range accompanies it. The prefix the subnet had when this address was archived is
+    /// not stored, and the current one is not a truthful substitute under a column headed "Original
+    /// Subnet" - see the comment in AllDeletedHostIps.cshtml.
+    /// </remarks>
     public string SubnetName { get; set; } = string.Empty;
-    public string NetworkAddress { get; set; } = string.Empty;
-    public int Cidr { get; set; }
 
     // Metadata
     public DateTime DeletedAt { get; set; }

--- a/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
@@ -184,6 +184,49 @@ namespace Bastet.Models.ViewModels
         /// Selected Azure subnets that fall under this VNet prefix
         /// </summary>
         public List<BulkImportSelectedSubnetDto> Subnets { get; set; } = [];
+
+        /// <summary>
+        /// What the preview told the operator would happen to this prefix, round-tripped so the
+        /// commit can refuse a plan that is no longer the plan they approved. Null when the caller
+        /// did not preview - see <see cref="BulkImportExpectedTargetDto"/>.
+        /// </summary>
+        public BulkImportExpectedTargetDto? Expected { get; set; }
+    }
+
+    /// <summary>
+    /// The outcome the preview displayed for one VNet prefix.
+    /// </summary>
+    /// <remarks>
+    /// The commit re-derives its plan against the tree as it is at commit time, which is what stops a
+    /// stale preview from writing stale decisions. But re-deriving also silently *changes* the
+    /// decision when the tree moved underneath the operator: a subnet created between preview and
+    /// commit turns "create a new top-level subnet" into "adopt that subnet", stamping it with the
+    /// VNet's Azure resource id - which no screen in the application can clear. Carrying the approved
+    /// outcome back lets the commit tell those apart and refuse the second.
+    /// <para>
+    /// Every field here is a bool, an int or a closed enum name except <see cref="NewName"/>. The
+    /// nested selection list is not visited by <c>GlobalSanitizationFilter</c>, so nothing on this
+    /// type is echoed back in the conflict response - divergences are described from the server's own
+    /// re-derived plan instead.
+    /// </para>
+    /// </remarks>
+    public class BulkImportExpectedTargetDto
+    {
+        /// <summary>
+        /// <see cref="BulkImportTargetType"/> by name. Compared by name rather than ordinal so
+        /// reordering the enum cannot silently turn a divergence into a match.
+        /// </summary>
+        public string? TargetType { get; set; }
+
+        public int? ExistingTargetSubnetId { get; set; }
+
+        public int? AutoCreateParentSubnetId { get; set; }
+
+        public bool WillRename { get; set; }
+
+        public string? NewName { get; set; }
+
+        public bool WillMarkFullyAllocated { get; set; }
     }
 
     /// <summary>

--- a/src/Bastet/Services/Azure/AzureReconciler.cs
+++ b/src/Bastet/Services/Azure/AzureReconciler.cs
@@ -77,6 +77,31 @@ namespace Bastet.Services.Azure
                     continue;
                 }
 
+                // Recognise the ID before scoping it. BelongsToSubscription is a StartsWith over
+                // "/subscriptions/{id}/", so a value that is not a parseable ARM ID at all - a typo,
+                // a truncation, a migrated string; AzureResourceId is free text and the app's own
+                // Admin API will write one - fails it for *every* subscription. Scoping first
+                // therefore sent those rows to notCovered and they never reached the
+                // UnrecognisedResourceId arm below that exists precisely for them: the scan reported
+                // them in no list at all, and where one sat beneath a stale ancestor the cascade
+                // guard withheld it saying the descendant "belongs to a different subscription",
+                // which is not true of a row that names no subscription and cannot be acted on,
+                // because rescanning any other subscription will never surface it either.
+                //
+                // Reported on every subscription's scan now rather than none, which is correct - it
+                // is in no subscription - and it lands in ReviewItems, which is never offered for
+                // deletion.
+                bool recognised = AzureResourceIdentity.IsAzureSubnet(snapshot.AzureResourceId)
+                                  || AzureResourceIdentity.IsAzureVNet(snapshot.AzureResourceId);
+
+                if (!recognised)
+                {
+                    plan.ReviewItems.Add(Item(snapshot, AzureReconcileStatus.UnrecognisedResourceId, true,
+                        "The recorded Azure resource ID names neither a VNet nor a subnet, so nothing "
+                        + "can be established about it. Correct or clear the link on this subnet."));
+                    continue;
+                }
+
                 // Only reconcile what this scan actually covers. A subnet belonging to another
                 // subscription is out of scope, not stale - but it still has to be protected from an
                 // ancestor's cascade, because an unasked question is not a deletion either.
@@ -86,26 +111,13 @@ namespace Bastet.Services.Azure
                     continue;
                 }
 
-                // Three-way, not two. An ID that is neither a VNet nor a subnet used to fall down
-                // the VNet branch, where absence from the listing reads as VNetDeleted - a claim
-                // nothing established, on the one path that removes data. It is reported for review
-                // instead, so the operator can correct the row rather than have it silently offered
-                // for archival.
-                AzureReconcileItem? item;
-                if (AzureResourceIdentity.IsAzureSubnet(snapshot.AzureResourceId))
-                {
-                    item = EvaluateSubnetLevel(snapshot, liveSubnetPrefixes);
-                }
-                else if (AzureResourceIdentity.IsAzureVNet(snapshot.AzureResourceId))
-                {
-                    item = EvaluateVNetLevel(snapshot, liveVNets);
-                }
-                else
-                {
-                    item = Item(snapshot, AzureReconcileStatus.UnrecognisedResourceId, true,
-                        "The recorded Azure resource ID names neither a VNet nor a subnet, so nothing "
-                        + "can be established about it. Correct or clear the link on this subnet.");
-                }
+                // Two-way: the unrecognised case is handled above, before scoping. An ID that is
+                // neither a VNet nor a subnet used to fall down the VNet branch, where absence from
+                // the listing reads as VNetDeleted - a claim nothing established, on the one path
+                // that removes data.
+                AzureReconcileItem? item = AzureResourceIdentity.IsAzureSubnet(snapshot.AzureResourceId)
+                    ? EvaluateSubnetLevel(snapshot, liveSubnetPrefixes)
+                    : EvaluateVNetLevel(snapshot, liveVNets);
 
                 if (item is null)
                 {

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -219,6 +219,12 @@
                         $.each(shownSubnets, function (sIdx, subnet) {
                             const subnetId = `bulk-subnet-${vIdx}-${pIdx}-${sIdx}`;
                             const $subnetDiv = $('<div class="form-check"></div>');
+                            // Declared here, ahead of the label and the reason below that both read
+                            // it. Referencing a `const` earlier in the block than its declaration is
+                            // a temporal dead zone, and Razor does not parse embedded script - so it
+                            // would build at 0 warnings and then throw inside this render loop,
+                            // leaving step 2 spinning with no checkboxes at all.
+                            const subnetBlockedByPrefix = subnet.isSelectable && !prefixInfo.isSelectable;
                             const $subnetCheckbox = $('<input type="checkbox" class="form-check-input bulk-subnet-checkbox">')
                                 .attr('id', subnetId)
                                 .attr('data-vnet-idx', vIdx)
@@ -233,10 +239,28 @@
                             const $subnetLabel = $('<label class="form-check-label"></label>')
                                 .attr('for', subnetId)
                                 .html(`${escapeHtml(subnet.name)} <span class="text-muted">${escapeHtml(subnet.addressPrefix)}</span>`
-                                    + availabilityBadge(subnet.statusName));
+                                    + availabilityBadge(subnet.statusName)
+                                    // Its own status is Available - it is only unselectable because
+                                    // its prefix is. Deliberately not the red "Cannot import" badge,
+                                    // which the legend defines as conflicting with something already
+                                    // in BASTET; that is untrue here and would trade one inaccurate
+                                    // legend entry for another.
+                                    + (subnetBlockedByPrefix
+                                        ? '<span class="badge bg-secondary ms-1">Blocked by VNet prefix</span>'
+                                        : ""));
                             $subnetDiv.append($subnetCheckbox).append($subnetLabel);
-                            if (!subnet.isSelectable) {
-                                $subnetDiv.append(reasonHtml(subnet.reason));
+
+                            // Unconditional. The old !isSelectable guard also swallowed the reason of
+                            // a *selectable* row, and AnnotateSubnet produces exactly one: the
+                            // encompassing subnet, whose "Covers the whole VNet prefix..." explains
+                            // why it marks the target fully allocated instead of being created.
+                            $subnetDiv.append(reasonHtml(subnet.reason));
+
+                            // Only when the row has nothing more specific to say, so a subnet with
+                            // its own conflict keeps that reason rather than this generic one.
+                            if (subnetBlockedByPrefix && !subnet.reason) {
+                                $subnetDiv.append(reasonHtml(
+                                    "Its VNet prefix cannot be imported, so this subnet cannot be either."));
                             }
                             $subList.append($subnetDiv);
                         });

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -453,6 +453,11 @@
                         $("#bulk-preview-error").removeClass("d-none");
                         return;
                     }
+                    // Record what this preview promised for each prefix, on the very object the
+                    // commit posts. The commit re-plans server-side and refuses anything that no
+                    // longer matches, so a subnet created by someone else while this screen is up
+                    // cannot be silently adopted instead of a new one being created.
+                    attachApprovedOutcomes(selection, result.plan);
                     renderPlan(result.plan);
                     $("#bulk-preview-content").removeClass("d-none");
                 },
@@ -473,6 +478,34 @@
                     }
                     $("#bulk-preview-loading").addClass("d-none");
                 }
+            });
+        }
+
+        // Copies each planned outcome onto the matching selected prefix, so the commit can send back
+        // what was approved. Only the plan's own decision fields are carried - the server describes
+        // any divergence from its own re-derived plan and never echoes these values.
+        function attachApprovedOutcomes(selection, plan) {
+            const planned = {};
+            $.each((plan && plan.items) || [], function (i, item) {
+                planned[item.vNetResourceId + "|" + item.vNetPrefix] = item;
+            });
+
+            $.each((selection && selection.vNetPrefixes) || [], function (i, prefix) {
+                const item = planned[prefix.vNetResourceId + "|" + prefix.addressPrefix];
+                if (!item) {
+                    // No plan item means nothing was approved for it; the server treats a missing
+                    // expectation as unverified rather than as agreement.
+                    prefix.expected = null;
+                    return;
+                }
+                prefix.expected = {
+                    targetType: item.targetTypeName,
+                    existingTargetSubnetId: typeof item.existingTargetSubnetId === "number" ? item.existingTargetSubnetId : null,
+                    autoCreateParentSubnetId: typeof item.autoCreateParentSubnetId === "number" ? item.autoCreateParentSubnetId : null,
+                    willRename: item.willRename === true,
+                    newName: typeof item.newName === "string" ? item.newName : null,
+                    willMarkFullyAllocated: item.willMarkFullyAllocated === true
+                };
             });
         }
 

--- a/src/Bastet/Views/Azure/Import/_ImportScripts.cshtml
+++ b/src/Bastet/Views/Azure/Import/_ImportScripts.cshtml
@@ -190,6 +190,15 @@
                     $("#vnet-selection").addClass("d-none");
                     $("#vnet-error").addClass("d-none");
                     $("#no-vnets").addClass("d-none");
+                    // The success branch empties the dropdown and re-appends the placeholder, which
+                    // resets the select's value without firing `change` - and the change handler is
+                    // the only thing that touches this button's disabled state. Re-entering step 2
+                    // therefore left "Next: Select Subnets" fully saturated and clickable over a
+                    // placeholder, and clicking it fell through the `if (selectedVNetId)` guard: no
+                    // request, no step change, no message. Same placement and reason as
+                    // loadSubnets' beforeSend below, so the wizard has one rule rather than two
+                    // that disagree, and it also covers the error and no-vnets branches.
+                    $("#select-vnet-btn").prop("disabled", true);
                 },
                 success: function(result) {
                     if (result.success) {

--- a/src/Bastet/Views/HostIp/AllDeletedHostIps.cshtml
+++ b/src/Bastet/Views/HostIp/AllDeletedHostIps.cshtml
@@ -60,9 +60,23 @@ else
                                 <td><code>@hostIp.OriginalIP</code></td>
                                 <td>@(string.IsNullOrEmpty(hostIp.Name) ? "-" : hostIp.Name)</td>
                                 <td>
+                                    @*
+                                        Deliberately no address range. This column is headed "Original
+                                        Subnet", but the only prefix available at render time is the
+                                        subnet's *current* one - the prefix as it stood when the
+                                        address was archived is not stored anywhere. Those differ
+                                        precisely when the subnet was narrowed after the address was
+                                        deleted, which is the one edit deleting it makes possible:
+                                        ValidateSubnetCidrChangeWithHostIps returns early when a
+                                        subnet has no live host IPs. The pairing then read as a
+                                        containment claim that was false and unconstructible -
+                                        10.150.0.200 shown inside 10.150.0.0/25 - because the live
+                                        listing renders the byte-identical string where containment
+                                        *is* guaranteed. The name and the link are enough to navigate.
+                                    *@
                                     @if (hostIp.SubnetName != "Unknown")
                                     {
-                                        <text>@hostIp.SubnetName (@hostIp.NetworkAddress/@hostIp.Cidr)</text>
+                                        <text>@hostIp.SubnetName</text>
                                     }
                                     else
                                     {

--- a/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
@@ -492,6 +492,78 @@ public class AzureReconcilerTests
     }
 
     /// <summary>
+    /// A link that is not a parseable ARM ID at all must be classified, not silently skipped.
+    /// </summary>
+    /// <remarks>
+    /// Round-10 J7. The subscription-scope test ran before the three-way recognition, and
+    /// BelongsToSubscription is a StartsWith over "/subscriptions/{id}/" - so a value that names no
+    /// subscription failed it for *every* subscription, went to notCovered, and never reached the
+    /// UnrecognisedResourceId arm that exists precisely for it. The row was then reported in no list
+    /// on any scan, and rescanning a different subscription could never surface it either.
+    /// <para>
+    /// The existing <c>UnrecognisedResourceId_IsReviewedNotOfferedForDeletion</c> theory uses only
+    /// IDs prefixed with the scanned subscription, so it pinned exactly the half that already worked.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData("not-an-arm-id")]
+    // Names the scanned subscription but has no trailing slash, so StartsWith("/subscriptions/{id}/")
+    // fails while the row's own text contradicts a "different subscription" verdict outright.
+    [InlineData($"/subscriptions/{SubId}")]
+    public void UnparseableResourceId_IsReviewed_NotSilentlySkipped(string resourceId)
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),
+            Linked(1, "broken-link", "10.90.0.0", 16, resourceId));
+
+        Assert.Empty(plan.Items);
+
+        AzureReconcileItem item = Assert.Single(plan.ReviewItems);
+        Assert.Equal(1, item.SubnetId);
+        Assert.Equal(AzureReconcileStatus.UnrecognisedResourceId, item.Status);
+    }
+
+    /// <summary>
+    /// And beneath a stale ancestor, the ancestor is still withheld - but not for a reason that is
+    /// false and cannot be acted on.
+    /// </summary>
+    /// <remarks>
+    /// Round-10 J7's second consequence. The cascade guard reported that the descendant "belongs to a
+    /// different subscription", which is untrue of a row naming no subscription, and unactionable
+    /// because the offending child was named nowhere in the response. The child now appears in
+    /// ReviewItems, so the operator is finally told which row to correct.
+    /// </remarks>
+    [Fact]
+    public void StaleAncestorOverUnparseableDescendant_IsWithheldWithoutBlamingASubscription()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.0.0.0/16"])),
+            Linked(1, "parent-stale", "10.90.0.0", 15, VNetId("vnet-gone"), descendants: 1, descendantIds: [2]),
+            Linked(2, "child-broken", "10.90.1.0", 24, "not-an-arm-id"));
+
+        // The row to correct is now named, where before it appeared in no list at all.
+        AzureReconcileItem review = Assert.Single(plan.ReviewItems);
+        Assert.Equal(2, review.SubnetId);
+        Assert.Equal(AzureReconcileStatus.UnrecognisedResourceId, review.Status);
+
+        // Not withheld on a claim about a subscription the row does not name.
+        Assert.DoesNotContain(plan.Warnings, w => w.Contains("different subscription"));
+
+        // Protection is unchanged, it just arrives by the review-item guard rather than the
+        // not-covered one: the ancestor is withheld once Azure confirms its VNet really is gone,
+        // which is the point at which the delete path asks.
+        _ = Assert.Single(plan.Items);
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>
+        {
+            [VNetId("vnet-gone")] = AzureResourceConfirmation.Deleted
+        });
+
+        Assert.Empty(plan.Items);
+        Assert.Contains(plan.Warnings, w => w.Contains("'parent-stale'"));
+    }
+
+    /// <summary>
     /// The mirror of the above: the guard must not withhold a target whose subtree holds no
     /// foreign-subscription row, or the reconciler stops doing its job.
     /// </summary>

--- a/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileScalingTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileScalingTests.cs
@@ -1,0 +1,238 @@
+using Bastet.Controllers;
+using Bastet.Data;
+using Bastet.Models;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Validation;
+using Bastet.Tests.TestHelpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Data.Common;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// Counts unfiltered reads of the Subnets table - the ones with no WHERE clause, which materialise
+/// the entire table however few rows the caller actually wants.
+/// </summary>
+internal sealed class WholeTableSubnetReadCounter : DbCommandInterceptor
+{
+    private int _count;
+
+    public int Count => Volatile.Read(ref _count);
+
+    private void Tally(DbCommand command)
+    {
+        string text = command.CommandText;
+        bool readsSubnets = text.Contains("FROM \"Subnets\"") || text.Contains("FROM [Subnets]");
+        if (readsSubnets && !text.Contains("WHERE"))
+        {
+            Interlocked.Increment(ref _count);
+        }
+    }
+
+    public override InterceptionResult<DbDataReader> ReaderExecuting(
+        DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+    {
+        Tally(command);
+        return result;
+    }
+
+    public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+        DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+        CancellationToken cancellationToken = default)
+    {
+        Tally(command);
+        return ValueTask.FromResult(result);
+    }
+}
+
+/// <summary>
+/// The reconcile bulk delete archives every selected subtree inside the global write lock, so its
+/// cost while holding that lock is what decides whether an unrelated user's write is merely delayed
+/// or actually refused.
+/// </summary>
+/// <remarks>
+/// Regression for round-10 J1. The archive path read the whole Subnets table twice per selected
+/// target - once in the loop and once inside <c>ArchiveSubnetSubtreeAsync</c> - so a request cost
+/// O(targets x table). With 200 targets against 66,000 subnets it held
+/// <c>Bastet:SubnetOperations</c> for ~57 s and a concurrent <c>POST /Subnet/Create</c> from a second
+/// process was refused after 30.3 s with the app's high-concurrency message.
+/// <para>
+/// The pin is deliberately a comparison rather than a fixed number: what must stay true is that the
+/// count does not grow with the number of targets. Asserting an exact count would fail on unrelated
+/// query changes while still permitting the defect to come back.
+/// </para>
+/// <para>
+/// The subtrees here are nested and carry host IPs on purpose. The cache threaded through the
+/// archive path must be a tracking read, and a flat, leaf-only workload cannot detect that: the
+/// per-subnet host-IP <c>Include</c> tracks a fresh instance of every descendant, so removing a
+/// detached duplicate throws "another instance with the same key value is already being tracked" -
+/// but only once a target actually has descendants.
+/// </para>
+/// </remarks>
+[Collection(AzureFeatureFlagCollection.Name)]
+public class SubnetControllerAzureReconcileScalingTests : IDisposable
+{
+    private const string SubId = "11111111-1111-1111-1111-111111111111";
+
+    public SubnetControllerAzureReconcileScalingTests() =>
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "true");
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", null);
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed record Outcome(int WholeTableReads, int SubnetsArchived, int HostIpsArchived, int SubnetsRemaining);
+
+    /// <summary>
+    /// Archives <paramref name="targetCount"/> stale VNet-linked subtrees, each a root with a child,
+    /// a grandchild and one host IP, alongside 200 unrelated subnets that are never selected.
+    /// </summary>
+    private static async Task<Outcome> ArchiveStaleTargetsAsync(int targetCount)
+    {
+        WholeTableSubnetReadCounter counter = new();
+
+        DbContextOptions<BastetDbContext> options = new DbContextOptionsBuilder<BastetDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .AddInterceptors(counter)
+            .Options;
+
+        using BastetDbContext context = new(options);
+        context.Database.OpenConnection();
+        context.Database.EnsureCreated();
+
+        IIpUtilityService ipUtilityService = new IpUtilityService();
+        SubnetController controller = new(
+            context,
+            ipUtilityService,
+            new SubnetValidationService(ipUtilityService),
+            new HostIpValidationService(ipUtilityService, context),
+            ControllerTestHelper.CreateMockUserContextService(),
+            ControllerTestHelper.CreateMockSubnetLockingService(),
+            NullLogger<SubnetController>.Instance);
+        ControllerTestHelper.SetupController(controller);
+        controller.Url = Mock.Of<IUrlHelper>();
+
+        int nextId = 1;
+        List<int> targets = [];
+
+        for (int v = 0; v < targetCount; v++)
+        {
+            int rootId = nextId++;
+            targets.Add(rootId);
+            context.Subnets.Add(new Subnet
+            {
+                Id = rootId,
+                Name = $"vnet-gone-{v}",
+                NetworkAddress = $"10.{v}.0.0",
+                Cidr = 16,
+                AzureResourceId = $"/subscriptions/{SubId}/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet-gone-{v}",
+                CreatedAt = DateTime.UtcNow
+            });
+
+            int childId = nextId++;
+            context.Subnets.Add(new Subnet
+            {
+                Id = childId,
+                Name = $"child-{v}",
+                NetworkAddress = $"10.{v}.1.0",
+                Cidr = 24,
+                ParentSubnetId = rootId,
+                CreatedAt = DateTime.UtcNow
+            });
+
+            int grandchildId = nextId++;
+            context.Subnets.Add(new Subnet
+            {
+                Id = grandchildId,
+                Name = $"grandchild-{v}",
+                NetworkAddress = $"10.{v}.1.0",
+                Cidr = 26,
+                ParentSubnetId = childId,
+                CreatedAt = DateTime.UtcNow
+            });
+
+            context.HostIpAssignments.Add(new HostIpAssignment
+            {
+                IP = $"10.{v}.1.5",
+                Name = $"host-{v}",
+                SubnetId = grandchildId,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        // Never selected and never archived - present so that an unfiltered read is materially more
+        // expensive than a targeted one, which is the whole point of the defect.
+        for (int pad = 0; pad < 200; pad++)
+        {
+            context.Subnets.Add(new Subnet
+            {
+                Id = nextId++,
+                Name = $"pad-{pad}",
+                NetworkAddress = $"172.{pad / 256}.{pad % 256}.0",
+                Cidr = 24,
+                CreatedAt = DateTime.UtcNow
+            });
+        }
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        IActionResult result = await controller.BulkDeleteStaleAzureSubnets(
+            new AzureReconcileDeleteDto
+            {
+                SubscriptionId = SubId,
+                SubnetIds = targets,
+                Confirmation = "approved"
+            },
+            new MockAzureService(),
+            new AzureReconciler(),
+            new AzureSubnetSnapshotService(context));
+
+        // An empty-but-successful Azure inventory means every VNet really is gone, so all of them
+        // are archived. Asserted here so a failure inside the loop is not read as a scaling result.
+        Assert.IsType<OkObjectResult>(result);
+
+        Outcome outcome = new(
+            counter.Count,
+            await context.DeletedSubnets.CountAsync(TestContext.Current.CancellationToken),
+            await context.DeletedHostIpAssignments.CountAsync(TestContext.Current.CancellationToken),
+            await context.Subnets.CountAsync(TestContext.Current.CancellationToken));
+
+        context.Database.CloseConnection();
+        return outcome;
+    }
+
+    [Fact]
+    public async Task BulkDeleteStaleAzureSubnets_WholeTableReads_DoNotGrowWithTargetCount()
+    {
+        Outcome two = await ArchiveStaleTargetsAsync(2);
+        Outcome eight = await ArchiveStaleTargetsAsync(8);
+
+        // Before the fix this was 1 + 2 per target: 5 reads for two targets and 17 for eight.
+        Assert.Equal(two.WholeTableReads, eight.WholeTableReads);
+
+        // And the extra targets really were archived, so the counts above compare like with like.
+        Assert.Equal(6, two.SubnetsArchived);
+        Assert.Equal(24, eight.SubnetsArchived);
+    }
+
+    [Fact]
+    public async Task BulkDeleteStaleAzureSubnets_NestedSubtreesWithHostIps_AreFullyArchived()
+    {
+        Outcome outcome = await ArchiveStaleTargetsAsync(8);
+
+        // Root, child and grandchild for each of the eight targets.
+        Assert.Equal(24, outcome.SubnetsArchived);
+        Assert.Equal(8, outcome.HostIpsArchived);
+
+        // The 200 unrelated subnets are untouched.
+        Assert.Equal(200, outcome.SubnetsRemaining);
+    }
+}

--- a/test/Bastet.Tests/Azure/SubnetControllerBulkAzureImportTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerBulkAzureImportTests.cs
@@ -1,0 +1,234 @@
+using Bastet.Controllers;
+using Bastet.Data;
+using Bastet.Models;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Security;
+using Bastet.Services.Validation;
+using Bastet.Tests.TestHelpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// The bulk Azure import commit re-derives its plan against the tree as it is at commit time. That
+/// stops a stale preview writing stale decisions, but it also means the plan actually executed can
+/// differ from the one the operator read and approved.
+/// </summary>
+/// <remarks>
+/// Regression for round-10 J2. The commit posts the selection, never the plan, so the preview and
+/// commit request bodies were byte-identical on the wire and nothing compared the two plans. A
+/// subnet created by a second admin while the preview was on screen flipped the target from
+/// AutoCreateTopLevel to ExactMatch, and the commit adopted that subnet: stamped it with the VNet's
+/// <c>AzureResourceId</c>, renamed it if the rename box was ticked, and pulled it into the reconcile
+/// wizard's deletion scope. None of that is reversible in the application - no view clears
+/// <c>AzureResourceId</c>, and the archive table does not carry it.
+/// </remarks>
+[Collection(AzureFeatureFlagCollection.Name)]
+public class SubnetControllerBulkAzureImportTests : IDisposable
+{
+    private const string SubId = "22222222-2222-2222-2222-222222222222";
+    private const string VNetId =
+        $"/subscriptions/{SubId}/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/rig-div";
+
+    private readonly BastetDbContext _context;
+    private readonly SubnetController _controller;
+    private readonly IAzureBulkImportPlanner _planner;
+    private readonly IAzureSubnetSnapshotService _snapshotService;
+
+    public SubnetControllerBulkAzureImportTests()
+    {
+        DbContextOptions<BastetDbContext> options = new DbContextOptionsBuilder<BastetDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        _context = new BastetDbContext(options);
+        _context.Database.OpenConnection();
+        _context.Database.EnsureCreated();
+
+        IIpUtilityService ipUtilityService = new IpUtilityService();
+        IInputSanitizationService sanitizationService = new InputSanitizationService();
+        _planner = new AzureBulkImportPlanner(ipUtilityService, sanitizationService);
+        _snapshotService = new AzureSubnetSnapshotService(_context);
+
+        _controller = new SubnetController(
+            _context,
+            ipUtilityService,
+            new SubnetValidationService(ipUtilityService),
+            new HostIpValidationService(ipUtilityService, _context),
+            ControllerTestHelper.CreateMockUserContextService(),
+            ControllerTestHelper.CreateMockSubnetLockingService(),
+            NullLogger<SubnetController>.Instance);
+        ControllerTestHelper.SetupController(_controller);
+        _controller.Url = Mock.Of<IUrlHelper>();
+
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "true");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", null);
+        _context.Database.CloseConnection();
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private Task<IActionResult> Commit(BulkImportSelectionDto selection) =>
+        _controller.BulkCreateFromAzurePlan(selection, _planner, _snapshotService, null);
+
+    /// <summary>
+    /// The selection the browser posts for one VNet prefix, carrying what the preview approved.
+    /// </summary>
+    private static BulkImportSelectionDto Selection(BulkImportExpectedTargetDto? expected, bool rename = false) =>
+        new()
+        {
+            SubscriptionId = SubId,
+            VNetPrefixes =
+            [
+                new BulkImportSelectedVNetPrefixDto
+                {
+                    VNetName = "rig-div",
+                    VNetResourceId = VNetId,
+                    AddressPrefix = "10.151.0.0/16",
+                    Subnets = [],
+                    Expected = expected
+                }
+            ],
+            RenameMatchedBastetSubnets = rename
+        };
+
+    /// <summary>
+    /// What the preview showed when nothing in Bastet covered the VNet prefix: a brand-new top-level
+    /// subnet would be created for it.
+    /// </summary>
+    private static BulkImportExpectedTargetDto ApprovedNewTopLevel() =>
+        new()
+        {
+            TargetType = nameof(BulkImportTargetType.AutoCreateTopLevel),
+            ExistingTargetSubnetId = null,
+            AutoCreateParentSubnetId = null,
+            WillRename = false,
+            NewName = null,
+            WillMarkFullyAllocated = false
+        };
+
+    /// <summary>
+    /// The second admin: an ordinary hand-made subnet on the same prefix, with no Azure link.
+    /// </summary>
+    private async Task InterleaveHandCreatedSubnetAsync() =>
+        await AddSubnetAsync("Finance-Prod-Reserved", "10.151.0.0", 16);
+
+    private async Task AddSubnetAsync(string name, string network, int cidr)
+    {
+        _context.Subnets.Add(new Subnet
+        {
+            Name = name,
+            NetworkAddress = network,
+            Cidr = cidr,
+            Description = "Reserved by the network team. Not an Azure VNet.",
+            CreatedAt = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task BulkCreateFromAzurePlan_TargetAdoptedAfterPreview_IsRefusedAndWritesNothing()
+    {
+        // Approved when the tree was empty: "create a new top-level subnet".
+        BulkImportSelectionDto selection = Selection(ApprovedNewTopLevel());
+
+        // ... and then someone else creates that very prefix by hand.
+        await InterleaveHandCreatedSubnetAsync();
+
+        IActionResult result = await Commit(selection);
+
+        _ = Assert.IsType<ConflictObjectResult>(result);
+
+        // The hand-made subnet is untouched: not linked to Azure, not renamed.
+        Subnet reserved = await _context.Subnets.SingleAsync(
+            s => s.Name == "Finance-Prod-Reserved", TestContext.Current.CancellationToken);
+        Assert.Null(reserved.AzureResourceId);
+
+        // And nothing new was created for the VNet.
+        Assert.Equal(1, await _context.Subnets.CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task BulkCreateFromAzurePlan_TargetAdoptedAfterPreview_ConflictNamesTheDivergence()
+    {
+        BulkImportSelectionDto selection = Selection(ApprovedNewTopLevel());
+        await InterleaveHandCreatedSubnetAsync();
+
+        ConflictObjectResult conflict = Assert.IsType<ConflictObjectResult>(await Commit(selection));
+
+        // The response has to say what changed, or the operator cannot tell this from a transient
+        // failure and will simply retry into the same adoption. Serialized rather than inspected
+        // field by field, so this also asserts on what actually reaches the browser.
+        string body = System.Text.Json.JsonSerializer.Serialize(conflict.Value);
+        Assert.Contains("10.151.0.0/16", body, StringComparison.Ordinal);
+        Assert.Contains(nameof(BulkImportTargetType.ExactMatch), body, StringComparison.Ordinal);
+
+        // The caller's own strings are never echoed back - the nested selection list is not visited
+        // by GlobalSanitizationFilter, so nothing on the expectation has been sanitized.
+        Assert.DoesNotContain("Reserved by the network team", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BulkCreateFromAzurePlan_PlanUnchangedSincePreview_StillCommits()
+    {
+        // The approved outcome and the re-derived one agree, which is the ordinary case; the guard
+        // must not stand in its way.
+        BulkImportSelectionDto selection = Selection(ApprovedNewTopLevel());
+
+        IActionResult result = await Commit(selection);
+
+        _ = Assert.IsType<OkObjectResult>(result);
+
+        Subnet created = await _context.Subnets.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("10.151.0.0", created.NetworkAddress);
+        Assert.Equal(VNetId, created.AzureResourceId);
+    }
+
+    [Fact]
+    public async Task BulkCreateFromAzurePlan_AdoptingASubnetThatWasApprovedForAdoption_StillCommits()
+    {
+        // The advertised adopt path: the operator previewed an ExactMatch onto an unlinked subnet
+        // and approved it. Refusing this would break the feature, so it must still go through.
+        await InterleaveHandCreatedSubnetAsync();
+        int existingId = (await _context.Subnets.SingleAsync(TestContext.Current.CancellationToken)).Id;
+
+        BulkImportSelectionDto selection = Selection(new BulkImportExpectedTargetDto
+        {
+            TargetType = nameof(BulkImportTargetType.ExactMatch),
+            ExistingTargetSubnetId = existingId,
+            AutoCreateParentSubnetId = null,
+            WillRename = false,
+            NewName = null,
+            WillMarkFullyAllocated = false
+        });
+
+        IActionResult result = await Commit(selection);
+
+        _ = Assert.IsType<OkObjectResult>(result);
+
+        Subnet adopted = await _context.Subnets.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(VNetId, adopted.AzureResourceId);
+    }
+
+    [Fact]
+    public async Task BulkCreateFromAzurePlan_NoApprovedOutcome_IsNotRefused()
+    {
+        // A direct JSON caller that never previewed has approved nothing, so there is nothing to
+        // compare against. Documented behaviour is preserved rather than broken; the commit records
+        // the unverified prefix in the log instead.
+        await InterleaveHandCreatedSubnetAsync();
+
+        IActionResult result = await Commit(Selection(expected: null));
+
+        _ = Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/test/Bastet.Tests/Security/AccountControllerLogoutTests.cs
+++ b/test/Bastet.Tests/Security/AccountControllerLogoutTests.cs
@@ -1,6 +1,9 @@
 using Bastet.Controllers;
 using Bastet.Tests.TestHelpers;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -18,13 +21,46 @@ public class AccountControllerLogoutTests
 {
     private const string SignedOutPath = "/Account/SignedOut";
 
+    /// <summary>
+    /// A controller under test together with what its sign-out actually did.
+    /// </summary>
+    /// <remarks>
+    /// Production sign-out no longer returns a <c>SignOutResult</c> for the framework to execute
+    /// later; it awaits <c>HttpContext.SignOutAsync</c> for each scheme itself. Round 9's I6 pins
+    /// read <c>SignOutResult.Properties.RedirectUri</c>, which was the only place the resolved target
+    /// was observable - so they now read it off the properties handed to the mocked
+    /// <see cref="IAuthenticationService"/> instead. Same assertion, same guarantee, one layer down.
+    /// </remarks>
+    private sealed class LogoutHarness
+    {
+        public required AccountController Controller { get; init; }
+
+        /// <summary>Properties passed to the OpenID Connect sign-out, or null if it never ran.</summary>
+        public AuthenticationProperties? OidcProperties { get; set; }
+
+        /// <summary>Properties passed to the cookie sign-out, or null if it never ran.</summary>
+        public AuthenticationProperties? CookieProperties { get; set; }
+
+        public bool CookieSignOutRan => CookieProperties is not null;
+    }
+
     private static AccountController CreateController(
-        bool isDevelopment, bool authenticated = false, bool signOutRegistered = true)
+        bool isDevelopment, bool authenticated = false, bool signOutRegistered = true) =>
+        CreateHarness(isDevelopment, authenticated, signOutRegistered).Controller;
+
+    private static LogoutHarness CreateHarness(
+        bool isDevelopment,
+        bool authenticated = false,
+        bool signOutRegistered = true,
+        Exception? oidcSignOutThrows = null)
     {
         Mock<Microsoft.AspNetCore.Hosting.IWebHostEnvironment> environment = new();
         environment.Setup(e => e.EnvironmentName).Returns(isDevelopment ? "Development" : "Production");
 
-        AccountController controller = new(environment.Object, ControllerTestHelper.CreateMockUserContextService());
+        AccountController controller = new(
+            environment.Object,
+            ControllerTestHelper.CreateMockUserContextService(),
+            NullLogger<AccountController>.Instance);
         ControllerTestHelper.SetupController(controller);
 
         // SignOutAsync resolves IAuthenticationService from RequestServices.
@@ -35,6 +71,8 @@ public class AccountControllerLogoutTests
         // not produce. Development registers only DevAuthScheme, and DevAuthHandler is not an
         // IAuthenticationSignOutHandler, so the real framework throws there. signOutRegistered:false
         // reproduces that, and is used only by the Development cases.
+        LogoutHarness harness = new() { Controller = controller };
+
         Mock<IAuthenticationService> authService = new();
         if (!signOutRegistered)
         {
@@ -43,6 +81,38 @@ public class AccountControllerLogoutTests
                     It.IsAny<HttpContext>(), It.IsAny<string?>(), It.IsAny<AuthenticationProperties?>()))
                 .ThrowsAsync(new InvalidOperationException(
                     "No sign-out authentication handlers are registered."));
+        }
+        else
+        {
+            authService
+                .Setup(a => a.SignOutAsync(
+                    It.IsAny<HttpContext>(),
+                    CookieAuthenticationDefaults.AuthenticationScheme,
+                    It.IsAny<AuthenticationProperties?>()))
+                .Callback<HttpContext, string?, AuthenticationProperties?>(
+                    (_, _, properties) => harness.CookieProperties = properties)
+                .Returns(Task.CompletedTask);
+
+            Moq.Language.Flow.ISetup<IAuthenticationService, Task> oidc = authService
+                .Setup(a => a.SignOutAsync(
+                    It.IsAny<HttpContext>(),
+                    OpenIdConnectDefaults.AuthenticationScheme,
+                    It.IsAny<AuthenticationProperties?>()));
+
+            if (oidcSignOutThrows is null)
+            {
+                oidc.Callback<HttpContext, string?, AuthenticationProperties?>(
+                        (_, _, properties) => harness.OidcProperties = properties)
+                    .Returns(Task.CompletedTask);
+            }
+            else
+            {
+                // The IdP is unreachable: OpenIdConnectHandler.SignOutAsync throws while fetching the
+                // discovery document.
+                oidc.Callback<HttpContext, string?, AuthenticationProperties?>(
+                        (_, _, properties) => harness.OidcProperties = properties)
+                    .ThrowsAsync(oidcSignOutThrows);
+            }
         }
 
         Mock<IServiceProvider> services = new();
@@ -62,7 +132,7 @@ public class AccountControllerLogoutTests
         urlHelper.Setup(u => u.Action(It.IsAny<UrlActionContext>())).Returns(SignedOutPath);
         controller.Url = urlHelper.Object;
 
-        return controller;
+        return harness;
     }
 
     [Theory]
@@ -72,23 +142,23 @@ public class AccountControllerLogoutTests
     [InlineData(null)]
     public async Task Logout_Production_NonLocalOrMissingReturnUrl_RedirectsToSignedOutPage(string? returnUrl)
     {
-        AccountController controller = CreateController(isDevelopment: false);
+        LogoutHarness harness = CreateHarness(isDevelopment: false);
 
-        IActionResult result = await controller.Logout(returnUrl);
+        IActionResult result = await harness.Controller.Logout(returnUrl);
 
-        SignOutResult signOut = Assert.IsType<SignOutResult>(result);
-        Assert.Equal(SignedOutPath, signOut.Properties?.RedirectUri);
+        _ = Assert.IsType<EmptyResult>(result);
+        Assert.Equal(SignedOutPath, harness.OidcProperties?.RedirectUri);
     }
 
     [Fact]
     public async Task Logout_Production_LocalReturnUrl_IsPreserved()
     {
-        AccountController controller = CreateController(isDevelopment: false);
+        LogoutHarness harness = CreateHarness(isDevelopment: false);
 
-        IActionResult result = await controller.Logout("/Subnet/Details/5");
+        IActionResult result = await harness.Controller.Logout("/Subnet/Details/5");
 
-        SignOutResult signOut = Assert.IsType<SignOutResult>(result);
-        Assert.Equal("/Subnet/Details/5", signOut.Properties?.RedirectUri);
+        _ = Assert.IsType<EmptyResult>(result);
+        Assert.Equal("/Subnet/Details/5", harness.OidcProperties?.RedirectUri);
     }
 
     /// <summary>
@@ -110,12 +180,61 @@ public class AccountControllerLogoutTests
     [InlineData("/\u2028next")]                            // line separator; char.IsControl misses it
     public async Task Logout_Production_ReturnUrlKestrelCannotWrite_RedirectsToSignedOutPage(string returnUrl)
     {
-        AccountController controller = CreateController(isDevelopment: false);
+        LogoutHarness harness = CreateHarness(isDevelopment: false);
 
-        IActionResult result = await controller.Logout(returnUrl);
+        IActionResult result = await harness.Controller.Logout(returnUrl);
 
-        SignOutResult signOut = Assert.IsType<SignOutResult>(result);
-        Assert.Equal(SignedOutPath, signOut.Properties?.RedirectUri);
+        _ = Assert.IsType<EmptyResult>(result);
+        Assert.Equal(SignedOutPath, harness.OidcProperties?.RedirectUri);
+    }
+
+    /// <summary>
+    /// An unreachable identity provider must not keep a privileged session alive.
+    /// </summary>
+    /// <remarks>
+    /// Round-10 J6. Sign-out used to return <c>SignOut(...)</c>, so both schemes ran during *result*
+    /// execution, after the action had returned. A Production process that started while the IdP was
+    /// down has never fetched the discovery document, so OpenIdConnectHandler.SignOutAsync threw
+    /// IDX20803 there - and because UseExceptionHandler calls Response.Clear(), every queued
+    /// Set-Cookie went with it. The user got a 500, the browser kept its ticket, and the cookie
+    /// handler went on validating it locally without ever contacting the IdP, for up to the one-hour
+    /// sliding expiry. Every other 500 in that window fails closed; this one failed open.
+    /// <para>
+    /// The local sign-out is now awaited first and separately, so it survives the remote leg failing.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task Logout_Production_IdentityProviderUnreachable_StillEndsTheLocalSession()
+    {
+        LogoutHarness harness = CreateHarness(
+            isDevelopment: false,
+            oidcSignOutThrows: new InvalidOperationException(
+                "IDX20803: Unable to obtain configuration from: '[PII is hidden]'."));
+
+        IActionResult result = await harness.Controller.Logout(returnUrl: null);
+
+        // The user lands on the signed-out page rather than a 500.
+        RedirectResult redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Equal(SignedOutPath, redirect.Url);
+
+        // And the local session was ended before the remote leg was attempted.
+        Assert.True(harness.CookieSignOutRan);
+        Assert.Equal(SignedOutPath, harness.CookieProperties?.RedirectUri);
+    }
+
+    /// <summary>
+    /// The cookie scheme's own LogoutPath is /Account/Logout - this very path - so signing out of it
+    /// without a RedirectUri makes HandleSignOutAsync take its redirect branch and write a
+    /// self-redirect. Harmless only by accident today, because both exits overwrite Location.
+    /// </summary>
+    [Fact]
+    public async Task Logout_Production_CookieSignOut_CarriesTheRedirectTarget()
+    {
+        LogoutHarness harness = CreateHarness(isDevelopment: false);
+
+        _ = await harness.Controller.Logout("/Subnet/Details/5");
+
+        Assert.Equal("/Subnet/Details/5", harness.CookieProperties?.RedirectUri);
     }
 
     /// <summary>The Development branch reads the same target, so it is fixed by the same guard.</summary>

--- a/test/Bastet.Tests/Security/ErrorControllerTests.cs
+++ b/test/Bastet.Tests/Security/ErrorControllerTests.cs
@@ -5,7 +5,9 @@ using Bastet.Services;
 using Bastet.Services.Validation;
 using Bastet.Tests.TestHelpers;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Globalization;
 
 namespace Bastet.Tests.Security;
 
@@ -24,12 +26,29 @@ public class ErrorControllerTests
         return controller;
     }
 
+    /// <summary>
+    /// Invokes the action the way routing does, with the status as a route value.
+    /// </summary>
+    /// <remarks>
+    /// It is deliberately not an action parameter. UseStatusCodePagesWithReExecute re-executes the
+    /// same request, body included, and the default composite value provider reads form values before
+    /// route values - so a form field named statusCode used to outrank the segment the middleware had
+    /// just set, and a caller could relabel their own failed request's status.
+    /// </remarks>
+    private static IActionResult Invoke(ErrorController controller, int statusCode)
+    {
+        controller.ControllerContext.RouteData = new RouteData();
+        controller.ControllerContext.RouteData.Values["statusCode"] =
+            statusCode.ToString(CultureInfo.InvariantCulture);
+        return controller.HttpStatusCodeHandler();
+    }
+
     [Fact]
     public void HttpStatusCodeHandler_NoTempData_UsesPerStatusDefault()
     {
         ErrorController controller = CreateController();
 
-        IActionResult result = controller.HttpStatusCodeHandler(404);
+        IActionResult result = Invoke(controller, 404);
 
         ViewResult view = Assert.IsType<ViewResult>(result);
         Assert.Equal("NotFound", view.ViewName);
@@ -43,7 +62,7 @@ public class ErrorControllerTests
         ErrorController controller = CreateController();
         controller.TempData["ErrorPageMessage"] = "Subnet with ID 5 could not be found.";
 
-        IActionResult result = controller.HttpStatusCodeHandler(404);
+        IActionResult result = Invoke(controller, 404);
 
         ViewResult view = Assert.IsType<ViewResult>(result);
         ErrorViewModel model = Assert.IsType<ErrorViewModel>(view.Model);
@@ -91,7 +110,7 @@ public class ErrorControllerTests
     {
         ErrorController controller = CreateController();
 
-        _ = controller.HttpStatusCodeHandler(statusCode);
+        _ = Invoke(controller, statusCode);
 
         Assert.Equal(statusCode, controller.Response.StatusCode);
     }
@@ -109,9 +128,37 @@ public class ErrorControllerTests
     {
         ErrorController controller = CreateController();
 
-        _ = controller.HttpStatusCodeHandler(statusCode);
+        _ = Invoke(controller, statusCode);
 
         Assert.Equal(500, controller.Response.StatusCode);
+    }
+
+    /// <summary>
+    /// When the route value is missing the status must come from the response the middleware already
+    /// set, not from a defaulted zero.
+    /// </summary>
+    /// <remarks>
+    /// Round-10 J3, the leg that <c>[FromRoute]</c> alone would not have closed. A NUL byte in any
+    /// form value - or a malformed multipart boundary - makes FormPipeReader throw, and MVC then
+    /// abandons binding for *every* source rather than just the form. A bound parameter arrived as 0,
+    /// which the out-of-range guard turned into 500 "Status Code: 0": an ordinary client mistake
+    /// reported as a server fault. Reading the route directly and falling back to the response status
+    /// keeps a 400 a 400.
+    /// </remarks>
+    [Fact]
+    public void HttpStatusCodeHandler_NoRouteValue_UsesTheStatusAlreadyOnTheResponse()
+    {
+        ErrorController controller = CreateController();
+        controller.ControllerContext.RouteData = new RouteData();
+        controller.Response.StatusCode = 400;
+
+        IActionResult result = controller.HttpStatusCodeHandler();
+
+        ViewResult view = Assert.IsType<ViewResult>(result);
+        Assert.Equal("BadRequest", view.ViewName);
+        Assert.Equal(400, controller.Response.StatusCode);
+        ErrorViewModel model = Assert.IsType<ErrorViewModel>(view.Model);
+        Assert.Equal(400, model.StatusCode);
     }
 
     [Fact]

--- a/test/Bastet.Tests/Security/ErrorControllerTests.cs
+++ b/test/Bastet.Tests/Security/ErrorControllerTests.cs
@@ -4,6 +4,7 @@ using Bastet.Models.ViewModels;
 using Bastet.Services;
 using Bastet.Services.Validation;
 using Bastet.Tests.TestHelpers;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -35,13 +36,23 @@ public class ErrorControllerTests
     /// route values - so a form field named statusCode used to outrank the segment the middleware had
     /// just set, and a caller could relabel their own failed request's status.
     /// </remarks>
-    private static IActionResult Invoke(ErrorController controller, int statusCode)
+    private static IActionResult Invoke(ErrorController controller, int statusCode, string? token = null)
     {
         controller.ControllerContext.RouteData = new RouteData();
         controller.ControllerContext.RouteData.Values["statusCode"] =
             statusCode.ToString(CultureInfo.InvariantCulture);
+        controller.Request.QueryString = token is null
+            ? QueryString.Empty
+            : QueryString.Create(ErrorPageMessages.TokenQueryKey, token);
         return controller.HttpStatusCodeHandler();
     }
+
+    /// <summary>
+    /// Queues a message the way a redirecting action does, returning the token that identifies it.
+    /// </summary>
+    private static string StashMessage(ErrorController controller, string message) =>
+        controller.RedirectToErrorPage(404, message)
+            .RouteValues?[ErrorPageMessages.TokenQueryKey]?.ToString() ?? string.Empty;
 
     [Fact]
     public void HttpStatusCodeHandler_NoTempData_UsesPerStatusDefault()
@@ -57,16 +68,42 @@ public class ErrorControllerTests
     }
 
     [Fact]
-    public void HttpStatusCodeHandler_TempDataMessage_IsShown()
+    public void HttpStatusCodeHandler_MessageForThisRedirect_IsShown()
     {
         ErrorController controller = CreateController();
-        controller.TempData["ErrorPageMessage"] = "Subnet with ID 5 could not be found.";
+        string token = StashMessage(controller, "Subnet with ID 5 could not be found.");
+
+        IActionResult result = Invoke(controller, 404, token);
+
+        ViewResult view = Assert.IsType<ViewResult>(result);
+        ErrorViewModel model = Assert.IsType<ErrorViewModel>(view.Model);
+        Assert.Equal("Subnet with ID 5 could not be found.", model.ErrorMessage);
+    }
+
+    /// <summary>
+    /// A message queued by some other request must not be shown here, and must not be consumed.
+    /// </summary>
+    /// <remarks>
+    /// Round-10 J4. Every request reaching this page used to read the one shared slot, so an
+    /// unrelated 4xx - a missing stylesheet, a stale antiforgery token, a second tab's stale row -
+    /// printed a diagnostic about a request the browser never made, and the page it belonged to fell
+    /// back to the generic text. A re-executed status page carries no token at all.
+    /// </remarks>
+    [Fact]
+    public void HttpStatusCodeHandler_MessageForAnotherRedirect_IsNeitherShownNorConsumed()
+    {
+        ErrorController controller = CreateController();
+        string otherToken = StashMessage(controller, "The subnet with ID 999 could not be found.");
 
         IActionResult result = Invoke(controller, 404);
 
         ViewResult view = Assert.IsType<ViewResult>(result);
         ErrorViewModel model = Assert.IsType<ErrorViewModel>(view.Model);
-        Assert.Equal("Subnet with ID 5 could not be found.", model.ErrorMessage);
+        Assert.Equal("The resource you requested could not be found.", model.ErrorMessage);
+
+        // Still there for the request it was meant for.
+        Assert.Equal("The subnet with ID 999 could not be found.",
+            ErrorPageMessages.Take(controller.TempData, otherToken));
     }
 
     [Fact]
@@ -88,7 +125,12 @@ public class ErrorControllerTests
         Assert.Equal("HttpStatusCodeHandler", redirect.ActionName);
         Assert.Equal("Error", redirect.ControllerName);
         Assert.Equal(404, redirect.RouteValues?["statusCode"]);
-        Assert.Contains("999", controller.TempData["ErrorPageMessage"]?.ToString() ?? "");
+
+        // Keyed to this redirect rather than dropped in a single shared slot, so a concurrent 4xx
+        // elsewhere in the session can neither show it nor consume it.
+        string? token = redirect.RouteValues?[ErrorPageMessages.TokenQueryKey]?.ToString();
+        Assert.False(string.IsNullOrEmpty(token));
+        Assert.Contains("999", ErrorPageMessages.Take(controller.TempData, token) ?? "");
     }
 
     /// <summary>

--- a/test/Bastet.Tests/SubnetManagement/SubnetControllerCidrEditTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetControllerCidrEditTests.cs
@@ -192,8 +192,10 @@ public class SubnetControllerCidrEditTests : IDisposable
         Assert.NotNull(statusCode);
         Assert.Equal(404, statusCode);
 
-        // The custom message now travels via TempData, not the (forgeable) query string.
-        string errorMessageStr = _controller.TempData["ErrorPageMessage"]?.ToString() ?? string.Empty;
+        // The custom message travels via TempData, not the (forgeable) query string, and is keyed
+        // to this redirect so a concurrent 4xx elsewhere in the session cannot take it.
+        string errorMessageStr = ErrorPageMessages.Take(
+            _controller.TempData, redirectResult.RouteValues?["m"]?.ToString()) ?? string.Empty;
         Assert.Contains($"{nonExistentId}", errorMessageStr);
     }
 
@@ -921,8 +923,10 @@ public class SubnetControllerCidrEditTests : IDisposable
         Assert.NotNull(statusCode);
         Assert.Equal(404, statusCode);
 
-        // The custom message now travels via TempData, not the (forgeable) query string.
-        string errorMessageStr = _controller.TempData["ErrorPageMessage"]?.ToString() ?? string.Empty;
+        // The custom message travels via TempData, not the (forgeable) query string, and is keyed
+        // to this redirect so a concurrent 4xx elsewhere in the session cannot take it.
+        string errorMessageStr = ErrorPageMessages.Take(
+            _controller.TempData, redirectResult.RouteValues?["m"]?.ToString()) ?? string.Empty;
         Assert.Contains($"{nonExistentId}", errorMessageStr);
     }
 }


### PR DESCRIPTION
### Improvements
- **Bulk Azure import now explains every row it greys out** — subnets sitting under a VNet prefix that cannot be imported showed no badge and no reason at all, while the row directly above them, disabled by the same rule, carried both

### Bug Fixes
- Signing out could **leave you signed in** — when the identity provider was unreachable as the process started, `/Account/Logout` answered 500 and silently discarded the session-cookie deletion, so a privileged session kept running until it expired. The local session is now ended before the provider is contacted, and an unreachable provider only costs you the redirect
- A bulk Azure import could **adopt a subnet another admin created while you were reading the plan** — the commit re-derived the plan and executed it without checking it still matched what you approved, permanently stamping that subnet with the VNet's Azure resource id, which no page can clear. A plan that no longer matches is now refused with `409 Conflict`, listing exactly what changed
- Deleting stale Azure subnets in bulk could **refuse other people's saves across the whole deployment** — the reconcile delete re-read the entire subnet table twice per selected target while holding the global write lock, so a large selection blocked every other write for the best part of a minute. It now reads the tree once per request
- A reconcile scan **silently ignored subnets whose Azure link was malformed**, listing them nowhere, and where one sat beneath a stale parent it refused the cleanup while blaming "a different subscription" — untrue of a link that names no subscription at all. Such rows are now reported for review, naming the row to correct
- The error page could be made to **report a different HTTP status than the one that actually occurred**: a form field named `statusCode` outranked the value the framework had set. A malformed form body — a stray NUL byte, a truncated upload — also turned an ordinary `400` into a `500`
- An error message could **appear on an unrelated page** — any other `4xx` in the session took the diagnostic meant for a different request, and the page it belonged to fell back to generic text. Each message is now tied to the redirect that created it
- The single-VNet import wizard's **Next button stayed lit but did nothing** after going back to Subscriptions and forward again
- Archived host IPs were **shown inside a subnet range that never contained them** — the "Original Subnet" column printed the subnet's *current* range, which can change after an address is archived, so the pairing read as a containment claim that was false
