### PR TITLE
Audit 11 Cleanup

### DIFF
--- a/docs/AUDIT-FINDINGS-11.md
+++ b/docs/AUDIT-FINDINGS-11.md
@@ -73,127 +73,45 @@ is recorded in the finding.
 
 # Medium
 
-## K1 - Bulk import wizard leaves the Commit step reachable across a re-preview, bypassing round 10's approved-plan (J2) check and silently adopting a subnet the operator never selected
+_K1 is fixed and committed, exactly as proposed: `invalidatePlan()` is now the first statement in
+`#bulk-go-preview-btn`'s click handler. Ordering is load-bearing twice and is preserved — it nulls
+`lastSelection`, so it precedes the reassignment, and it re-disables `#step3-tab`, so it precedes
+`activateTab("step3")`. Step 4 is now reachable only through `#bulk-go-commit-btn`, which `renderPlan`
+enables only when `plan.canCommit`, i.e. only from a plan that was actually rendered._
 
-`[x1]` &nbsp;|&nbsp; **Severity: medium** &nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
-`src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:410`
+_Reproduced first on an unfixed publish of `09cee3d` on its own port and catalog, driven headless
+against real ARM. **Before:** one click of *Continue to Commit* left `step4-tab disabled: False` for the
+page's life; after an aborted re-preview both the pill click and the confirm click were **accepted**,
+the commit body carried **`expected: [null, null]`** — no expectation at all, so J2's check could not
+fire — and the import succeeded with *"linked 1 existing target(s) to Azure"*. The out-of-band row
+`created-by-another-admin` came back stamped
+`AzureResourceId=/subscriptions/.../virtualNetworks/rig-vnet-visible-2`, which no screen in the
+application can clear. **After:** `step4-tab disabled: True`, Playwright **refuses** both clicks, **no
+POST is issued at all**, and the row keeps an empty `AzureResourceId`. Leg C (the click landing while
+the second preview is still in flight — the silent leg, with no log line) closes identically._
 
-### The defect
+_Two non-regression legs measured on the same build. The **J2 control** — same race, no re-preview —
+still stamps `expected` and still answers **409 "The plan changed since it was previewed"**, so the
+guard this finding is about is untouched. A **benign re-preview that succeeds** still re-opens step 4
+through *Continue to Commit* and commits normally (2 targets, 3 child subnets), so the fix does not
+strand an operator who simply previewed twice. Zero `pageerror`s across every run; `invalidatePlan` is
+a hoisted `function` declaration, so this is not the round-10 J9 temporal-dead-zone shape._
 
-`#bulk-go-preview-btn`'s click handler (`:410-415`) is exactly:
+_No test ships with this. It is view-embedded JavaScript with no unit-testable seam — the position
+round 10 took for J5 and J9 — and the browser runs above are the verification. Suite unchanged at
+**730**._
 
-```js
-const selection = buildSelectionFromUI();
-lastSelection = selection;
-activateTab("step3");
-loadPreview(selection);
-```
+_Rejections, both on the verifier's measurement. The **cheaper interim was not taken**: calling
+`invalidatePlan()` from `loadPreview`'s error handler and `!result.success` branch closes legs A and B
+but leaves **leg C** open, and leg C is the one that stamps an expectation from a plan the operator
+never saw with no warning line at all — it closes the loud legs and leaves the silent one. And this was
+**not** "fixed" server-side by refusing a null `Expected`: `SubnetController.BulkAzure.cs:85-90` records
+that as a deliberate round-10 decision so the documented direct JSON API keeps working._
 
-It never calls `invalidatePlan()` (`:29-33`), which is the **only** writer that re-adds `disabled` to
-`#step3-tab` / `#step4-tab` and disables `#bulk-go-commit-btn`. Its four callers are the subscription
-change (`:100`), `loadVNets`' `beforeSend` (`:126`), the selection-change handler (`:332`) and the
-rename switch (`:336`) - not the preview button. `activateTab` only un-disables the tab it is handed.
-`#bulk-confirm-commit-btn` carries no `disabled` attribute in markup (`_StepCommit.cshtml:30`).
-
-So **one** click of *Continue to Commit* un-disables the step-4 pill for the rest of the page's life,
-and every later re-preview leaves it live while `lastSelection` has already been replaced by a fresh
-object that `attachApprovedOutcomes` (`:508-533`, which runs only inside `loadPreview`'s `success`
-handler after `result.success`) has not stamped. `DescribeApprovedPlanDivergences`
-(`SubnetController.BulkAzure.cs:83-91`) treats a null `Expected` as an *unverified* commit, logs a
-warning, and lets it through - a deliberate round-10 decision so the documented direct JSON API keeps
-working.
-
-The other two wizards do re-lock: `#rec-scan-btn` calls `invalidateScan()` before `runScan()`
-(`_ReconcileScripts.cshtml:140`), and `loadSubnets`/`loadVNets` reset their forward buttons in
-`beforeSend` (`_ImportScripts.cshtml:201`, `:264-265`).
-
-### Failure scenario
-
-App credentialed as SP_A. (1) Tick VNet `rig-vnet-visible-2` prefix `10.111.0.0/16` plus its Azure
-subnet `rig-sn-vis2-core`; the preview renders **"New top-level create rig-vnet-visible-2
-(10.111.0.0/16)"**. (2) Click *Continue to Commit* - step 4 is now permanently unlocked. (3) Click the
-step-2 pill, change nothing, click *Go to Preview* again. (4) That preview does not render. (5)
-Another admin creates `10.111.0.0/16` in Bastet in the meantime. (6) Click the still-enabled step-4
-pill, click *Confirm Import*.
-
-**Wrong output:** the commit succeeds. The banner reads *"Created 0 VNet target(s), 1 child subnet(s),
-... linked 1 existing target(s) to Azure"*. The unrelated subnet `created-by-another-admin`
-(`10.111.0.0/16`) is stamped with
-`AzureResourceId = /subscriptions/.../virtualNetworks/rig-vnet-visible-2` and the Azure child is
-created underneath it. That is verbatim the outcome J2 exists to refuse - and it is unrecoverable
-through the UI: no unlink view exists, `EditSubnetViewModel` does not carry `AzureResourceId`, a CIDR
-edit then throws, and the row plus its whole subtree is pulled into the reconcile wizard's deletion
-scope.
-
-### Reproduction
-
-Three legs, all on a pristine `09cee3d` publish, driven headless by Playwright against real ARM:
-
-- **Leg A - re-preview aborted (network blip).** `step4-tab disabled: False`, pill click ACCEPTED,
-  confirm ACCEPTED. Posted body carried **no `expected` key anywhere**. Server log:
-  `warn: Bulk Azure import: 1 of 1 selected prefix(es) carried no previewed outcome, so the re-derived
-  plan for them was not compared against anything the operator approved.` DB after:
-  `created-by-another-admin | 10.111.0.0 | 16 | .../virtualNetworks/rig-vnet-visible-2` plus the child.
-- **Leg B - no network manipulation at all.** The second preview answered with the byte-identical body
-  `AzureController.BulkImportPreview`'s own catch block emits (`:276`,
-  `{"success":false,"error":"Failed to build the import preview. Details have been logged."}`). Same
-  outcome. This kills the objection that the leg needs an artificial transport failure - any exception
-  in `GetExistingSubnetsAsync`/`BuildPlan` reaches it.
-- **Leg C - in-flight, no failure.** The operator clicks the still-lit step-4 pill while preview #2 is
-  in flight; the preview lands behind them and stamps
-  `"expected":{"targetType":"ExactMatch","existingTargetSubnetId":1,...}` from a plan they never saw.
-  Commit adopts with **no 409 and no warning line at all** - completely silent, and therefore worse
-  than leg A.
-
-**The control is what makes this a bypass rather than a re-file of J2.** Same fixture, same
-out-of-band insert while the operator sits on step 4, but *without* the second preview: the posted
-body carries `"expected":{"targetType":"AutoCreateTopLevel",...}` and the server answers
-`409 Commit failed: The plan changed since it was previewed, so nothing was imported.` DB after:
-`created-by-another-admin` with an **empty** `AzureResourceId`. J2 works; the re-preview turns it off.
-
-### Fix
-
-In `_BulkScripts.cshtml:410`, call `invalidatePlan()` first. Ordering is load-bearing twice over -
-`invalidatePlan()` nulls `lastSelection`, so it must precede the reassignment, and it re-disables
-`#step3-tab`, so it must precede `activateTab("step3")`:
-
-```js
-$("#bulk-go-preview-btn").on("click", function () {
-    const selection = buildSelectionFromUI();
-    invalidatePlan();          // re-locks #step3-tab/#step4-tab and #bulk-go-commit-btn
-    lastSelection = selection;
-    activateTab("step3");      // re-opens step 3 only
-    loadPreview(selection);
-});
-```
-
-Step 4 then becomes reachable only via `#bulk-go-commit-btn`, which `renderPlan` enables only when
-`plan.canCommit` - i.e. only from a plan that was actually rendered.
-
-**Built and measured, not reasoned.** `dotnet build -c Release --no-incremental` -> 0 warnings, 0
-errors; published and driven with the identical scripts. All three legs close: `step4-tab disabled =
-True`, `pointer-events: none`, both the pill click and the confirm click refused by Playwright, **no
-POST issued**, and the out-of-band row keeps an empty `AzureResourceId`. `invalidatePlan` is a hoisted
-`function` declaration, so this is not the round-10 J9 temporal-dead-zone shape; Chromium logged zero
-`pageerror`s across four scripted runs. Two non-regression checks both pass: the ordinary
-single-preview commit still writes correctly with `expected` stamped, and a re-preview that
-**succeeds** still re-opens step 4 through *Continue to Commit* and commits - the fix does not strand
-the operator after a benign re-preview. Zero C# impact; view-embedded JS with no unit-testable seam
-(the position round 10 took for J5/J9), so it must be driven in a browser rather than unit-tested.
-
-### Fix corrections
-
-- **The cheaper interim is worse than the finding admits.** Calling `invalidatePlan()` from
-  `loadPreview`'s `error` handler and `!result.success` branch (mirroring `showScanError` in
-  `_ReconcileScripts.cshtml:199`) closes legs A and B but leaves **leg C** open - and leg C is the one
-  that stamps an expectation from an unseen plan with **no log line at all**. The interim closes the
-  loud legs and leaves the silent one. **Take the click-handler version only.**
-- **Do not "fix" this server-side by refusing a null `Expected`.** `SubnetController.BulkAzure.cs:85-90`
-  documents that as a deliberate round-10 decision to keep the direct JSON API working.
-- **Residue, not a defect in the fix:** on the patched build `#bulk-confirm-commit-btn` still reads
-  `disabled: False` after a failed re-preview. It is unreachable because the step-4 pane is never
-  activated, so nothing follows from it - but a belt-and-braces variant would also
-  `prop("disabled", true)` that button inside `invalidatePlan()`.
+_Residue, deliberately not changed: `#bulk-confirm-commit-btn` still reads `disabled: False` after a
+failed re-preview. Nothing follows from it because the step-4 pane is never activated — measured, the
+click is refused — and adding `prop("disabled", true)` for it inside `invalidatePlan()` is
+belt-and-braces beyond the defect. Noted here so the next round does not re-derive it._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-11.md
+++ b/docs/AUDIT-FINDINGS-11.md
@@ -1,17 +1,74 @@
 # Bastet - Round-11 Audit Findings
 
-| | Value |
-|---|---|
-| Round | **11** (finding letter **K** - findings are `K1` ... `K5`) |
-| Branch | `audit/round-11` |
-| HEAD | `09cee3d` - *"Audit 10 Cleanup (#155)"* |
-| Build | **0 warnings, 0 errors** |
-| Tests | **730 passed**, 0 failed, 0 skipped |
-| Date | 2026-08-01 |
+| | Audit | After reconciliation |
+|---|---|---|
+| Round | **11** (finding letter **K** - findings are `K1` ... `K5`) | |
+| Branch | `audit/round-11` | one commit per finding |
+| HEAD | `09cee3d` - *"Audit 10 Cleanup (#155)"* | |
+| Build | **0 warnings, 0 errors** | **0 warnings, 0 errors** (clean rebuild, `bin`/`obj` deleted) |
+| Tests | **730 passed**, 0 failed, 0 skipped | **738 passed**, 0 failed, 0 skipped (+8) |
+| Working tree | clean at start and at finish | clean |
+| Date | 2026-08-01 | 2026-08-01 |
 
-Every line number below was re-derived against the working tree at `09cee3d` by at least one verifier,
-and every surviving finding was reproduced against a live rig - real SQL Server, the real application,
-a real browser, and two Azure service principals with disjoint RBAC over two resource groups.
+Every line number in the original findings was re-derived against the working tree at `09cee3d` by at
+least one verifier, and every surviving finding was reproduced against a live rig. The struck entries
+below cite the **post-fix** lines.
+
+**All five findings were fixed - none was refuted on re-verification.** Each was reproduced against an
+unfixed publish before being fixed and re-measured after, one commit per finding, each carrying its own
+struck entry. Four of the five (`K1`-`K4`) sit on the J2 bulk-import surface round 10 introduced.
+
+**Three of the five proposed fixes were corrected on evidence**, and one correction was found here
+rather than by the audit:
+
+- **`K3` needed more than the null guard.** With the dereference guarded, a null list *element* still
+  produced a **409** rather than the promised 400: the planner returns no items when it records a
+  global error, so the valid prefix beside the null one was described as "no longer produces a target"
+  - a divergence manufactured by the malformed body. The divergence check now yields when
+  `plan.GlobalErrors` is non-empty, which preserves round 10's 409-before-400 ordering wherever both
+  are meaningful.
+- **`K5`'s proposed label was wrong for a `/32`** and was replaced with one that discriminates: RFC
+  3021 covers 31-bit point-to-point prefixes and says nothing about `/32`, which has no broadcast
+  because it is a single host.
+- **`K4`'s and `K2`'s cheaper interims were both declined**, and `K4`'s dependency on `K2` was
+  honoured rather than noted - numeric order meant `K2` shipped first, so `K4`'s new divergence message
+  was verified actually rendering rather than being dead text.
+
+### Final verification sweep
+
+- **Clean rebuild** with `bin`/`obj` deleted: 0 warnings, 0 errors. **Full suite: 738 passed**, 0
+  failed, 0 skipped (730 -> 738, +8; no test was deleted or disabled).
+- **Real app against real SQL Server 2022**, every major area asserted on **content**, not status
+  codes: **22 of 22 passed** - subnet list/details/create/edit/delete, host IPs and their edit form,
+  per-subnet and global deleted-host-IP listings, deleted subnets, the purge confirmation, all three
+  Azure wizards, roles, access-denied, the error pages, and `K5`'s `/31` label beside a `/24` control.
+  Security headers still ride on a normal 200.
+- **Log read and classified:** zero `fail:` lines and zero exceptions. Four warnings, both classes
+  expected and neither introduced by this round: three EF `MultipleCollectionIncludeWarning`
+  advisories from the two-collection `Include` in the delete path (present at `09cee3d`), and one
+  DataProtection "no XML encryptor configured", which is a local-rig artefact with no certificate
+  configured.
+- **Both Azure surfaces driven end to end against live ARM** with two service principals holding
+  **disjoint RBAC at resource-group scope** (each `Owner` on its own group, `AuthorizationFailed` on
+  the other - verified before anything was measured). Discovery, bulk preview and commit, the
+  approved-plan 409 in three separate shapes, reconcile scan and reconcile delete commit all
+  exercised. Both counter-tests pass, so the reconciler **discriminates** rather than merely blocking:
+  a resource the credential cannot see was **withheld** with a warning naming it, while a genuinely
+  deleted resource was still **offered and deleted** - and the unreadable row survived that delete.
+
+### Deliberately not done
+
+- **`K1`'s belt-and-braces variant** - also disabling `#bulk-confirm-commit-btn` inside
+  `invalidatePlan()`. The button is unreachable because its pane is never activated, measured, so
+  nothing follows from it.
+- **`K2` does not fix `#bulk-back-to-preview-btn`**, which still repaints the stale plan after a 409.
+  The error panel now tells the truth; the button beside it still shows a plan contradicting it. It is
+  on the watch list.
+- **The three interims the findings proposed** were each declined with a recorded reason: `K1`'s
+  leaves the silent leg open, `K2`'s ships the same array twice on the wire, `K4`'s deletes deliberate
+  naming behaviour and closes nothing structurally.
+- **No test ships for `K1` or `K2`.** Both are view-embedded JavaScript with no unit-testable seam -
+  the position round 10 took for J5 and J9 - and both were driven in real headless Chromium instead.
 
 ---
 

--- a/docs/AUDIT-FINDINGS-11.md
+++ b/docs/AUDIT-FINDINGS-11.md
@@ -150,125 +150,42 @@ Always rebuild before believing a browser measurement of a `.cshtml` change._
 
 ---
 
-## K3 - J2's approved-plan divergence check dereferences a caller-supplied collection, turning two malformed bulk-import bodies from a modelled 400 into an unhandled 500
+_K3 is fixed and committed. `DescribeApprovedPlanDivergences` now copies `selection.VNetPrefixes ?? []`
+into a local, skips a null element with a comment rather than counting it, and the third dereference
+inside the `LogWarning` reads the local. The guard is in place rather than reordered, exactly as the
+finding argued: the 409 is deliberately raised before the `CanCommit` 400, and moving it after would
+report "this plan cannot be committed" in place of "the plan changed since you approved it" whenever
+both apply. A null entry is **not** counted as `unverified` — it is a malformed request, not an
+unchecked one, and the planner already names it._
 
-`[x2]` &nbsp;|&nbsp; **Severity: low** &nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
-`src/Bastet/Controllers/SubnetController.BulkAzure.cs:78`
+_**One thing the finding did not anticipate, found by the test rather than by reading.** With the null
+dereference guarded, body (B) still did not produce the promised 400 — it produced a **409**. When the
+planner records a global error it returns no items, so the *valid* prefix alongside the null one is
+described as "no longer produces a target to import": a divergence manufactured by the malformed body
+rather than by the tree moving. The divergence check is therefore skipped when
+`plan.GlobalErrors.Count > 0`, so the planner's own message reaches the caller. Round 10's
+409-before-400 ordering is preserved wherever both are meaningful — a plan failing only on per-item
+errors is still reported as diverged first._
 
-### The defect
+_Measured live on two publishes. **Before:** `{"vNetPrefixes":null}`, `{"vNetPrefixes":[null]}` and
+`{"vNetPrefixes":[<valid>,null]}` all returned **HTTP 500** with
+`System.NullReferenceException ... at DescribeApprovedPlanDivergences`. **After:** all three return
+**400** with the planner's own wording — *"No VNet address prefixes were selected."* for (A) and
+*"A selected VNet prefix was empty."* for (B). Both controls are byte-identical either side: an empty
+list still 400s, and a valid selection with no `Expected` still returns `200 createdTargets:1`._
 
-`DescribeApprovedPlanDivergences` walks `selection.VNetPrefixes` (`:78`), indexes it and reads
-`selected.Expected` (`:80-81`), and reads `.Count` again inside a `LogWarning` (`:148`) - all before
-any null guard. The DTO declares `List<BulkImportSelectedVNetPrefixDto> VNetPrefixes { get; set; } = []`
-(`AzureBulkImportViewModels.cs:244`), but **System.Text.Json overwrites that initialiser with null
-when the body carries an explicit null** - the same trap this codebase already documents and guards at
-`SubnetController.AzureReconcile.cs:46-50` for the sibling endpoint.
+_Because the ordering changed, J2's own path was re-verified rather than assumed: a valid selection
+whose plan genuinely diverged still answers **409** with identical `differences` wording, and K2's
+rendering still shows both sentences._
 
-The call site at `:167` sits **outside** `BulkCreateFromAzurePlanCore`'s transaction `try` (which opens
-after the `CanCommit` check), and the public action's own `try` catches only `TimeoutException`, so
-nothing intercepts it.
+_Two regression tests added (`SubnetControllerBulkAzureImportTests`), 730 → **732**. Both confirmed
+failing against the unfixed code with the defect's own signature — `System.NullReferenceException`,
+not an unrelated assertion._
 
-### Failure scenario
-
-`POST /Subnet/BulkCreateFromAzurePlan` (RequireAdminRole, antiforgery token supplied) with either:
-
-- **(A)** `{"subscriptionId":"<sub>","vNetPrefixes":null}`
-- **(B)** `{"subscriptionId":"<sub>","vNetPrefixes":[{...valid prefix...},null]}`
-
-**Expected** (and pre-round-10 actual): HTTP 400 with the planner's own wording - *"No VNet address
-prefixes were selected."* for (A), *"A selected VNet prefix was empty."* for (B).
-`AzureBulkImportPlanner.BuildPlan` explicitly guards both shapes (`:37`, `:50`) and records a global
-error, and the pre-existing `if (!plan.CanCommit)` arm turns that into a modelled 400.
-
-**Actual:** HTTP 500, unhandled `NullReferenceException`. For the documented direct JSON API the
-response stops being JSON - an HTML error page in Production, a stack trace in Development. For the
-browser wizard the `$.ajax` error handler's `JSON.parse` fails and `showCommitError` falls back to the
-literal string *"Server error: 500"* (`_BulkScripts.cshtml:680-683`), so the operator loses the
-planner's actual message. Nothing is written - the crash pre-empts a refusal, not a write. The global
-subnet lock is released correctly (verified: the next normal commit returned 200 in 0.026 s, and
-`sys.dm_tran_locks` shows 0 application locks).
-
-**Reachability:** not from the wizard (`buildSelectionFromUI` never emits a null entry). Reachable
-from the documented direct JSON API - which this method's own comment at `:83-86` says must keep
-working - and from any crafted Admin request.
-
-### Reproduction
-
-Pristine `09cee3d` publish, token scraped from `/Azure/BulkImport`:
-
-```
-{"vNetPrefixes":null}                    -> HTTP 500
-  System.NullReferenceException: Object reference not set to an instance of an object.
-     at Bastet.Controllers.SubnetController.DescribeApprovedPlanDivergences(...)
-        in .../SubnetController.BulkAzure.cs:line 78
-{"vNetPrefixes":[null]}                  -> HTTP 500, same exception, line 81
-{"vNetPrefixes":[<valid 10.110.0.0/16>,null]} -> HTTP 500, same exception, line 81
-{"vNetPrefixes":[]}            (control) -> HTTP 400 {"success":false,"globalErrors":["No VNet address
-                                            prefixes were selected."],"itemErrors":[]}
-/Azure/BulkImportPreview, same bodies    -> HTTP 200 with globalErrors (preview is unaffected)
-```
-
-**Regression pinned to J2:** `git show dcc15ab:src/Bastet/Controllers/SubnetController.BulkAzure.cs`
-goes straight from `planner.BuildPlan(...)` to `if (!plan.CanCommit)`; `DescribeApprovedPlanDivergences`
-did not exist, and there is no other dereference of `VNetPrefixes` anywhere in `Controllers/`.
-Building and running the parent commit confirmed both bodies produce the modelled 400 there.
-
-### Fix
-
-Null-guard the walk **in place** rather than reordering the checks - the 409 is deliberately raised
-before the `CanCommit` `BadRequest` (round-10 J2), and moving it after would report *"this plan cannot
-be committed"* in place of *"the plan changed since you approved it"* whenever both apply.
-
-```csharp
-// System.Text.Json overwrites the DTO's collection initialiser with null when the body
-// carries an explicit null, and a list element can itself be null - AzureBulkImportPlanner
-// guards both (:37, :50) and records a global error. This walk runs before the CanCommit
-// check that reports those errors, so it has to survive them.
-List<BulkImportSelectedVNetPrefixDto> selectedPrefixes = selection.VNetPrefixes ?? [];
-
-for (int index = 0; index < selectedPrefixes.Count; index++)
-{
-    BulkImportSelectedVNetPrefixDto? selected = selectedPrefixes[index];
-    if (selected is null)
-    {
-        // Already reported by the planner as a global error; nothing to compare.
-        continue;
-    }
-
-    BulkImportExpectedTargetDto? expected = selected.Expected;
-```
-
-and change the third dereference at `:148` (`selection.VNetPrefixes.Count` inside the `LogWarning`) to
-`selectedPrefixes.Count`.
-
-**Do NOT count a null entry as `unverified++`** - it is not an unverified commit, it is a malformed
-one, and the planner already names it. Doing so would also log an "unverified commit" for a request
-about to be refused as malformed.
-
-**Built and measured:** 0 warnings / 0 errors (the `?? []` on a non-nullable-declared property does
-**not** trip nullable analysis, which is where this could have failed the repo's warnings bar);
-**730 passed, 0 failed**; all three malformed bodies answer 400 with the planner's own wording; and
-both paths it sits in front of are byte-identical to the unpatched build - a valid selection with no
-`Expected` still returns `200 createdTargets:1`, and a valid selection with a wrong `Expected` still
-returns J2's 409 with identical `differences` wording.
-
-### Fix corrections
-
-- **The cheaper interim is partial and should not be mistaken for the fix.** Adding the sibling
-  endpoint's guard to the public action, immediately after the existing `selection is null` check at
-  `:36-39` -
-
-  ```csharp
-  if (selection.VNetPrefixes is null or { Count: 0 })
-  {
-      return BadRequest(new { success = false, error = "No VNet address prefixes were selected." });
-  }
-  ```
-
-  mirroring `SubnetController.AzureReconcile.cs:50` - closes body **(A)** only. Body **(B)**, a null
-  element inside a non-empty list, still 500s.
-- **Apply by content, not by line number.** The `:75-81` and `:148` citations are correct at `09cee3d`
-  but shift once the comment block is inserted.
+_The cheaper interim was **not** taken. Adding the sibling endpoint's
+`selection.VNetPrefixes is null or { Count: 0 }` guard to the public action closes body (A) only; a
+null element inside a non-empty list still threw. Applied by content rather than by line number, as
+the finding advised, since the inserted comment block shifts the cited lines._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-11.md
+++ b/docs/AUDIT-FINDINGS-11.md
@@ -117,99 +117,36 @@ belt-and-braces beyond the defect. Noted here so the next round does not re-deri
 
 # Low
 
-## K2 - The bulk import 409's divergence list is computed, serialised to the browser, and discarded - the un-fixed twin of the reconcile wizard's `warnings` rendering
+_K2 is fixed and committed with the client-side version: `showCommitError` now renders
+`payload.differences` as `<li>`s after the `itemErrors` block, using `.text()` to match the two blocks
+either side. This is the same treatment the reconcile wizard's `showCommitError` already gives its
+409's `warnings`._
 
-`[x2]` &nbsp;|&nbsp; **Severity: low** &nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
-`src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:691`
+_Measured before and after against two publishes on separate ports and catalogs, with the colliding
+subnet created through `/Subnet/Create` from a second cookie jar while the plan was on screen.
+**Before:** the server answered 409 with
+`differences: ["10.110.0.0/16: the preview showed a different action; it now resolves to ExactMatch.",
+"10.110.0.0/16: it now targets existing Bastet subnet N."]` and the rendered
+`#bulk-commit-error-list` was **empty** — every sentence the server built was dropped. **After:** the
+identical 409 renders both sentences as list items beneath the generic message. Zero `pageerror`s in
+both runs, and the refusal itself is unchanged, so nothing was written either way._
 
-### The defect
+_The cheaper interim was **not** taken. Emitting `globalErrors = divergences` server-side alongside
+`differences` does render, and it avoids touching a `.cshtml` — a real consideration given round 10
+lost two fixes to view-embedded JS — but it ships the same array twice on the wire and fixes only this
+one 409 rather than the client's inability to render a `differences` body at all. The client fix was
+verified in a browser, which is the mitigation the interim was trying to avoid needing._
 
-Round 10's J2 added `DescribeApprovedPlanDivergences` (`SubnetController.BulkAzure.cs:73-152`). When
-the re-derived plan disagrees with what the operator approved, `BulkCreateFromAzurePlanCore` answers
-409 with `{success, error, differences:[...]}` (`:167-176`). The only consumer of that body is
-`commitImport`'s `error` handler (`:680-684`), which calls `showCommitError(payload)`.
-`showCommitError` (`:691-711`) renders `payload.error` (`:695`), `payload.globalErrors` (`:697-699`)
-and `payload.itemErrors` (`:700-708`) - and the 409 carries neither of the last two. **Every sentence
-the server built is dropped on the floor.** `grep -rn 'differences' src/Bastet/Views
-src/Bastet/wwwroot` returns nothing.
+_Not closed by this change, and deliberately left: `#bulk-back-to-preview-btn` still repaints the
+stale plan after a 409, so the button beside the now-truthful error panel still shows a plan that
+contradicts it. That is a separate defect on the same screen and is recorded in the watch list rather
+than fixed here. Suite unchanged at **730** — no test asserts on this view's DOM, and the block is
+purely additive._
 
-The reconcile wizard's `showCommitError` (`Views/Azure/Reconcile/_ReconcileScripts.cshtml:453-475`)
-was extended to render `payload.warnings` for precisely this reason, with the comment *"The 409
-carries no globalErrors - the reason a row was withheld travels in warnings, and without this the
-operator sees only 'no longer reported as deleted'"*. This is that same fix, not applied to the bulk
-wizard.
-
-### Failure scenario
-
-Empty Bastet tree. Bulk-import wizard, tick VNet `rig-vnet-visible` prefix `10.110.0.0/16` plus both
-Azure subnets; the preview says *"New top-level create rig-vnet-visible (10.110.0.0/16)"*. A second
-admin then creates `10.110.0.0/16` by hand. Pressing *Confirm Import* gives a 409 whose body says the
-commit would have **adopted someone else's subnet rather than creating one** - the exact outcome J2
-exists to surface. What renders is only the generic sentence and an empty `<ul>`.
-
-The refusal itself is correct and nothing is written, so this is a lost-diagnostic defect, not data
-loss.
-
-### Reproduction
-
-Real headless Chromium against a pristine `09cee3d` publish, with the colliding subnet created through
-`/Subnet/Create` in a second tab:
-
-```
----- SERVER 409 BODY ----
-{"success":false,"error":"The plan changed since it was previewed, so nothing was imported. Re-run the
- preview, review what it now says, and confirm again.","differences":["10.110.0.0/16: the preview
- showed a different action; it now resolves to ExactMatch.","10.110.0.0/16: it now targets existing
- Bastet subnet 1."]}
-
----- WHAT THE OPERATOR SEES ----
-error-message span: 'The plan changed since it was previewed, so nothing was imported. Re-run the
- preview, review what it now says, and confirm again.'
-error list items: []
-```
-
-**The information is nowhere else on screen** - this was the hunt that was expected to kill the
-finding and made it worse instead. Driving the recovery path the error message itself prescribes
-("Re-run the preview, review what it now says"), clicking `#bulk-back-to-preview-btn` - the only other
-button on the commit step - repaints nothing and leaves step 3 showing the **stale** plan, *"New
-top-level create rig-vnet-visible (10.110.0.0/16)"*, which flatly contradicts the refusal that just
-fired. Only going back to step 2 and pressing *Preview* again re-derives, and even then the delta the
-server had already computed is not shown.
-
-### Fix
-
-In `showCommitError` (`_BulkScripts.cshtml:691`), after the `globalErrors` block:
-
-```js
-if (payload && payload.differences && payload.differences.length > 0) {
-    $.each(payload.differences, function (i, d) { $list.append($('<li></li>').text(d)); });
-}
-```
-
-`.text()`, not `.html()`, matching the two blocks either side.
-
-**Built, published and driven.** Patched build renders both divergence sentences as `<li>`s,
-`pageerrors: []`, and a clean happy-path import still shows its success banner with the error panel
-hidden. `dotnet test` on the patched copy: **730 passed, 0 failed**. No TDZ hazard - `$list` is
-declared at `:696` and the insertion is below it. No sibling call site is missed: `showCommitError`
-has exactly two callers (`:677` and `:683`), the block is purely additive, and the other two
-`Conflict(...)` sites in `SubnetController.BulkAzure.cs` (`:255`, `:293`) carry only `error` and
-already render correctly.
-
-### Fix corrections
-
-- **Cheaper interim - sound but strictly inferior.** In `BulkCreateFromAzurePlanCore`
-  (`SubnetController.BulkAzure.cs:171-176`) also emit the list under the key the client already
-  renders: `globalErrors = divergences` beside `differences = divergences`. One line of server code,
-  no `.cshtml` edit (which matters - round 10 lost two fixes to view-embedded JS that builds at 0
-  warnings and throws at runtime), keeps the documented `differences` key for the direct JSON API, and
-  needs no browser verification. The shipped pin
-  `BulkCreateFromAzurePlan_TargetAdoptedAfterPreview_ConflictNamesTheDivergence` still passes with a
-  duplicated list. It ships the same array twice on the wire and fixes only this one 409 rather than
-  the client's inability to render a `differences` body at all - **prefer the client fix**.
-- **Not closed by either version:** `#bulk-back-to-preview-btn` still repaints the stale plan after a
-  409. The fix makes the error panel tell the truth; the button next to it still shows a plan
-  contradicting it.
+_One process note worth carrying forward: Razor views are compiled into the assembly, so a
+`dotnet run --no-build` restart serves the previous view. The first "after" run reported an empty list
+because it was still serving the pre-fix build; rebuilding and re-running produced the result above.
+Always rebuild before believing a browser measurement of a `.cshtml` change._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-11.md
+++ b/docs/AUDIT-FINDINGS-11.md
@@ -228,97 +228,38 @@ not compared: both are selection-derived and cannot move, so comparing them woul
 
 # Info
 
-## K5 - Subnet Details prints a broadcast address for `/31` and `/32`, contradicting the app's own RFC 3021 rule and a host IP listed on the same page
+_K5 is fixed and committed. `SubnetController.Read.cs` computes `BroadcastAddress` only below `/31`,
+and `_NetworkInformation.cshtml` renders a label that **discriminates the two cases** rather than the
+single one the finding proposed._
 
-`[x1]` &nbsp;|&nbsp; **Severity: info** (filed low; corrected down on measurement - see below)
-&nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
-`src/Bastet/Controllers/SubnetController.Read.cs:63`
+_The proposed `"None (RFC 3021)"` label was rejected on the verifier's correction and confirmed here:
+RFC 3021 is about 31-bit point-to-point prefixes and says nothing about `/32`, which has no broadcast
+because it is a single host — the distinction the app's own comment in `HostIpValidationService`
+already draws. Labelling both would have replaced one false statement with a differently false one.
+The view now prints *"None (RFC 3021 point-to-point)"* for a `/31` and *"None (single host)"* for a
+`/32`, which also stops `string.Empty` doing duty as a display sentinel._
 
-### The defect
+_Measured on two publishes against the same catalog, with every row created through the ordinary Create
+and HostIp forms. **Before:** `/31 10.211.0.0` printed *"Broadcast Address 10.211.0.1"* while also
+reporting *Usable 2* and listing `10.211.0.1` as an assigned host IP on the same page; `/32
+10.212.0.0` printed its own network address as the broadcast. **After:** the two render as
+*"None (RFC 3021 point-to-point)"* and *"None (single host)"*. The `/30` control is byte-identical
+either side — still `10.213.0.3`, and assigning it as a host IP is still refused with *"Cannot assign
+the broadcast address as a host IP"*, so the guard did not reach below `/31`._
 
-`SubnetController.Read.cs:63` sets `BroadcastAddress = ipUtilityService.CalculateBroadcastAddress(...)`
-with no CIDR test. `HostIpValidationService.ValidateNewHostIp:70` applies the network/broadcast
-reservation only when `subnet.Cidr < 31`, so both `/31` addresses and the single `/32` address are
-legitimately assignable, and `IpUtilityService.CalculateUsableIpAddresses:105-110` documents `/31` as
-2 usable and `/32` as 1.
+_Four regression tests added (`SubnetDetailsBroadcastAddressTests`), 734 → **738**: two pinning that
+`/31` and `/32` carry no broadcast address, and two controls pinning that `/30` and `/24` still do.
+The first two were confirmed failing against unfixed code with the defect's own values — `/32`
+returning `10.212.0.0`, its own network address._
 
-### Failure scenario
-
-Create `10.211.0.0/31` and assign both addresses as host IPs (the app accepts them). `GET
-/Subnet/Details/{id}` then renders, **in one document**: *"Broadcast Address 10.211.0.1"*, *"Usable IP
-Addresses 2"*, and a Host IP Assignments row *"10.211.0.1 p2p-b"*. The page labels an assigned, legally
-assignable host address as the subnet's broadcast address. For a `/32` (`10.212.0.0/32`) it prints
-*"Broadcast Address 10.212.0.0"* - the subnet's only address, also assignable and assigned, so the
-Network Address and Broadcast Address rows print the identical string.
-
-Control: on a `/30`, `POST /HostIp/Create` for the broadcast address is refused (*"Cannot assign the
-broadcast address as a host IP"*, no row written) and the page correctly prints it as the broadcast.
-
-### Reproduction
-
-Driven through the real Create and HostIp forms (no direct SQL writes):
-
-```
-HOSTIP subnet=1 ip=10.211.0.0 -> 302 ; ip=10.211.0.1 -> 302 ; subnet=2 ip=10.212.0.0 -> 302
-HOSTIP subnet=3 ip=10.213.0.3 -> 200 (refused: "Cannot assign the broadcast address as a host IP")
-
-/Subnet/Details/1  /31  Subnet Mask 255.255.255.254  Broadcast Address 10.211.0.1  Total 2  Usable 2
-                   ...Host IP Assignments: 10.211.0.0 p2p-a | 10.211.0.1 p2p-b
-/Subnet/Details/2  /32  Subnet Mask 255.255.255.255  Broadcast Address 10.212.0.0  Total 1  Usable 1
-/Subnet/Details/3  /30  Broadcast Address 10.213.0.3  Total 4  Usable 2          (correct, control)
-```
-
-Nothing is written wrong and nothing is blocked - the harm is entirely a misread, which is why the
-severity was corrected from low to info. The two verifiers disagreed here: one held low on the
-precedent of round 5's E13 (an RFC-3021 display contradiction on the same page, filed low), the other
-corrected to info on the precedent of round 10's J8 (a page stating a wrong network fact about a row
-on the same screen, filed info) after measuring that no operator action is refused or misdirected.
-**Info stands.** What is genuinely defensible, and was verified, is the self-contradiction: one card
-says Total 2 / Usable 2 and then names one of those two the broadcast, and the card below names it as
-an assignment.
-
-### Fix
-
-At `SubnetController.Read.cs:63`, compute it only below `/31`:
-
-```csharp
-BroadcastAddress = subnet.Cidr < 31
-    ? ipUtilityService.CalculateBroadcastAddress(subnet.NetworkAddress, subnet.Cidr)
-    : string.Empty,
-```
-
-and render the empty case in `src/Bastet/Views/Subnet/Details/_NetworkInformation.cshtml:19`.
-`SubnetDetailsViewModel.BroadcastAddress` (`SubnetViewModels.cs:101`) has exactly one consumer - that
-one `<dd>` - and no test in `test/` mentions the view model, so nothing else moves.
-
-**Built and driven side by side** against the same catalog: 0 warnings / 0 errors, **730 passed**, the
-`/31` and `/32` flip while the `/30` is byte-identical. The Razor `@(...)` expression is compiled at
-build, so this is not the J9 shape.
-
-**Cheaper interim, no controller change:** gate the two lines in `_NetworkInformation.cshtml:18-19` on
-`@if (Model.Cidr < 31)`, which the view can do because `Model.Cidr` is already on the view model. It
-leaves the value computed and unused **and silently drops the row from the definition list**, so the
-card loses a label rather than answering the question - the controller-side version is preferable.
-
-### Fix corrections
-
-- **The proposed label is wrong for a `/32`.** RFC 3021 is *"Using 31-Bit Prefixes on IPv4
-  Point-to-Point Links"* and says nothing about `/32`; a `/32` has no broadcast because it is a single
-  host - exactly the distinction the app's own comment at `HostIpValidationService.cs:65-69` already
-  draws. Rendering `"None (RFC 3021)"` for a `/32` replaces one false statement with a differently
-  false one. Discriminate on `Model.Cidr`, e.g.
-  `@(Model.Cidr == 31 ? "None (RFC 3021 point-to-point)" : Model.Cidr == 32 ? "None (single host)" : Model.BroadcastAddress)`,
-  which also removes the reliance on `string.Empty` as an out-of-band sentinel.
-- **The finding's claim that `Read.cs:63` is "the one call site with no guard" is false**, and this
-  matters because it is the reason the fix must not be generalised. Four other call sites are also
-  unguarded: `HostIpController.cs:104`, `:140`, `:182` - all benign, because they build the
-  `SubnetRange` string and `"10.211.0.0 - 10.211.0.1"` is the correct range for a `/31` (verified in
-  the rendered Create page) - and `HostIpValidationService.cs:161`, which is **permanently-accepted
-  item 5** and out of scope.
-- **Do NOT "fix" this inside `IpUtilityService.CalculateBroadcastAddress`.**
-  `HostIpValidationService.cs:327` deliberately calls it for `newCidr < 31` only,
-  `SubnetPropertyCalculationTests` pins its current `/31` and `/32` return values, and it would break
-  the three `HostIpController` range strings.
+_Two things deliberately not done, both on the verifier's corrections. The **cheaper interim** — gating
+the two lines in the view on `@if (Model.Cidr < 31)` — was not taken: it silently drops the row from
+the definition list, so the card loses a label rather than answering the question. And the guard was
+**not** pushed into `IpUtilityService.CalculateBroadcastAddress`: `SubnetPropertyCalculationTests`
+pins its current `/31` and `/32` return values, `HostIpValidationService` deliberately calls it for
+`newCidr < 31` only, and three `HostIpController` range strings depend on today's behaviour — the
+finding's claim that `Read.cs` was "the one call site with no guard" is false, and those four other
+sites are correct as they are._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-11.md
+++ b/docs/AUDIT-FINDINGS-11.md
@@ -1,0 +1,732 @@
+# Bastet - Round-11 Audit Findings
+
+| | Value |
+|---|---|
+| Round | **11** (finding letter **K** - findings are `K1` ... `K5`) |
+| Branch | `audit/round-11` |
+| HEAD | `09cee3d` - *"Audit 10 Cleanup (#155)"* |
+| Build | **0 warnings, 0 errors** |
+| Tests | **730 passed**, 0 failed, 0 skipped |
+| Date | 2026-08-01 |
+
+Every line number below was re-derived against the working tree at `09cee3d` by at least one verifier,
+and every surviving finding was reproduced against a live rig - real SQL Server, the real application,
+a real browser, and two Azure service principals with disjoint RBAC over two resource groups.
+
+---
+
+## Verdict
+
+**Read `K1` first.** It is the only finding above `low`, and it is a hole in round 10's own J2 guard:
+the bulk-import wizard leaves the **Commit** step clickable across a re-preview, so an operator can
+confirm an import whose plan was never rendered. The commit then adopts a subnet the operator never
+selected - stamping it with an `AzureResourceId` that **no screen in the application can clear** - and
+J2's approved-plan check does not fire, because the wizard posted either no expectation at all or one
+stamped from a plan that landed behind the operator's back. Verified against a control on the same
+build: without the re-preview the identical race is correctly refused with a 409 and nothing is
+written. The fix is one line - `invalidatePlan()` in the `#bulk-go-preview-btn` handler - and it was
+built, published and driven in a real browser, closing all three legs with no regression to the happy
+path.
+
+Everything else is small. Three `low` findings all sit on the same J2/bulk-import surface: the 409's
+`differences` list is computed and then discarded by the client (`K2`), two malformed JSON bodies turn
+a modelled 400 into an unhandled 500 (`K3`), and the approved-plan expectation carries no child-subnet
+information so children can be written under names the preview never showed (`K4`). One `info`
+finding is a display contradiction on `/Subnet/Details` for `/31` and `/32` (`K5`).
+
+**This was a quiet round.** 40 raw findings collapsed to 19 candidates and only 5 survived; 14 were
+killed, most of them for the same reason - a true mechanical observation with no reachable wrong
+output behind it (dead code, unpinned tests, comment inaccuracies, hypothetical future maintainers).
+Nothing critical or high was found. No data-loss, privilege-escalation or cross-tenant defect
+survived verification, and the two Azure service principals with disjoint RBAC produced no new
+isolation failure.
+
+Two corrections to proposed fixes are worth as much as the findings themselves, and both are recorded
+in place: **`K4`'s cheaper interim should not be taken** (it deletes deliberate naming behaviour and
+closes nothing structurally), and **`K4`'s new divergence message is dead text until `K2` is fixed** -
+`showCommitError` never renders `differences`, so the operator is told a plan changed without being
+told how. Fix `K2` in the same change as `K4`.
+
+## How this audit ran
+
+**20 finders over 8 beats.** Each beat was covered twice independently - **pass A** working code-first
+(read the diff and the call graph, then go looking for the behaviour) and **pass B** working
+behaviour-first (drive the running application, then go looking for the code) - plus a **deeper third
+sweep** on the four highest-yield beats: `security`, `azure`, `regression` and `regression-tests`.
+
+**40 raw findings merged to 19 candidates** (5 tagged `[x2]`, 14 tagged `[x1]`).
+
+- **`[x2]`** means two independent passes found the same defect. Merging was on the defect, not the
+  wording: same root cause, same citation, same one-line fix.
+- **`[x1]`** means only one pass found it. Those got a **second verifier on a reachability lens** -
+  "can an actual request, job, or user action reach this in a real deployment?" - and where the two
+  verifiers disagreed, a **third broke the tie**. Three candidates went to a tie-break; all three
+  died there.
+
+**Every candidate went to at least one verifier prompted to refute it**, not to confirm it, and to
+reproduce it against the live rig rather than reason about it. **5 survived, 14 were refuted, and all
+5 survivors were reproduced live.** Four of the five had their proposed fix built, published on a
+separate port and catalog, and driven end to end; three of those fix builds produced a correction that
+is recorded in the finding.
+
+---
+
+# Medium
+
+## K1 - Bulk import wizard leaves the Commit step reachable across a re-preview, bypassing round 10's approved-plan (J2) check and silently adopting a subnet the operator never selected
+
+`[x1]` &nbsp;|&nbsp; **Severity: medium** &nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
+`src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:410`
+
+### The defect
+
+`#bulk-go-preview-btn`'s click handler (`:410-415`) is exactly:
+
+```js
+const selection = buildSelectionFromUI();
+lastSelection = selection;
+activateTab("step3");
+loadPreview(selection);
+```
+
+It never calls `invalidatePlan()` (`:29-33`), which is the **only** writer that re-adds `disabled` to
+`#step3-tab` / `#step4-tab` and disables `#bulk-go-commit-btn`. Its four callers are the subscription
+change (`:100`), `loadVNets`' `beforeSend` (`:126`), the selection-change handler (`:332`) and the
+rename switch (`:336`) - not the preview button. `activateTab` only un-disables the tab it is handed.
+`#bulk-confirm-commit-btn` carries no `disabled` attribute in markup (`_StepCommit.cshtml:30`).
+
+So **one** click of *Continue to Commit* un-disables the step-4 pill for the rest of the page's life,
+and every later re-preview leaves it live while `lastSelection` has already been replaced by a fresh
+object that `attachApprovedOutcomes` (`:508-533`, which runs only inside `loadPreview`'s `success`
+handler after `result.success`) has not stamped. `DescribeApprovedPlanDivergences`
+(`SubnetController.BulkAzure.cs:83-91`) treats a null `Expected` as an *unverified* commit, logs a
+warning, and lets it through - a deliberate round-10 decision so the documented direct JSON API keeps
+working.
+
+The other two wizards do re-lock: `#rec-scan-btn` calls `invalidateScan()` before `runScan()`
+(`_ReconcileScripts.cshtml:140`), and `loadSubnets`/`loadVNets` reset their forward buttons in
+`beforeSend` (`_ImportScripts.cshtml:201`, `:264-265`).
+
+### Failure scenario
+
+App credentialed as SP_A. (1) Tick VNet `rig-vnet-visible-2` prefix `10.111.0.0/16` plus its Azure
+subnet `rig-sn-vis2-core`; the preview renders **"New top-level create rig-vnet-visible-2
+(10.111.0.0/16)"**. (2) Click *Continue to Commit* - step 4 is now permanently unlocked. (3) Click the
+step-2 pill, change nothing, click *Go to Preview* again. (4) That preview does not render. (5)
+Another admin creates `10.111.0.0/16` in Bastet in the meantime. (6) Click the still-enabled step-4
+pill, click *Confirm Import*.
+
+**Wrong output:** the commit succeeds. The banner reads *"Created 0 VNet target(s), 1 child subnet(s),
+... linked 1 existing target(s) to Azure"*. The unrelated subnet `created-by-another-admin`
+(`10.111.0.0/16`) is stamped with
+`AzureResourceId = /subscriptions/.../virtualNetworks/rig-vnet-visible-2` and the Azure child is
+created underneath it. That is verbatim the outcome J2 exists to refuse - and it is unrecoverable
+through the UI: no unlink view exists, `EditSubnetViewModel` does not carry `AzureResourceId`, a CIDR
+edit then throws, and the row plus its whole subtree is pulled into the reconcile wizard's deletion
+scope.
+
+### Reproduction
+
+Three legs, all on a pristine `09cee3d` publish, driven headless by Playwright against real ARM:
+
+- **Leg A - re-preview aborted (network blip).** `step4-tab disabled: False`, pill click ACCEPTED,
+  confirm ACCEPTED. Posted body carried **no `expected` key anywhere**. Server log:
+  `warn: Bulk Azure import: 1 of 1 selected prefix(es) carried no previewed outcome, so the re-derived
+  plan for them was not compared against anything the operator approved.` DB after:
+  `created-by-another-admin | 10.111.0.0 | 16 | .../virtualNetworks/rig-vnet-visible-2` plus the child.
+- **Leg B - no network manipulation at all.** The second preview answered with the byte-identical body
+  `AzureController.BulkImportPreview`'s own catch block emits (`:276`,
+  `{"success":false,"error":"Failed to build the import preview. Details have been logged."}`). Same
+  outcome. This kills the objection that the leg needs an artificial transport failure - any exception
+  in `GetExistingSubnetsAsync`/`BuildPlan` reaches it.
+- **Leg C - in-flight, no failure.** The operator clicks the still-lit step-4 pill while preview #2 is
+  in flight; the preview lands behind them and stamps
+  `"expected":{"targetType":"ExactMatch","existingTargetSubnetId":1,...}` from a plan they never saw.
+  Commit adopts with **no 409 and no warning line at all** - completely silent, and therefore worse
+  than leg A.
+
+**The control is what makes this a bypass rather than a re-file of J2.** Same fixture, same
+out-of-band insert while the operator sits on step 4, but *without* the second preview: the posted
+body carries `"expected":{"targetType":"AutoCreateTopLevel",...}` and the server answers
+`409 Commit failed: The plan changed since it was previewed, so nothing was imported.` DB after:
+`created-by-another-admin` with an **empty** `AzureResourceId`. J2 works; the re-preview turns it off.
+
+### Fix
+
+In `_BulkScripts.cshtml:410`, call `invalidatePlan()` first. Ordering is load-bearing twice over -
+`invalidatePlan()` nulls `lastSelection`, so it must precede the reassignment, and it re-disables
+`#step3-tab`, so it must precede `activateTab("step3")`:
+
+```js
+$("#bulk-go-preview-btn").on("click", function () {
+    const selection = buildSelectionFromUI();
+    invalidatePlan();          // re-locks #step3-tab/#step4-tab and #bulk-go-commit-btn
+    lastSelection = selection;
+    activateTab("step3");      // re-opens step 3 only
+    loadPreview(selection);
+});
+```
+
+Step 4 then becomes reachable only via `#bulk-go-commit-btn`, which `renderPlan` enables only when
+`plan.canCommit` - i.e. only from a plan that was actually rendered.
+
+**Built and measured, not reasoned.** `dotnet build -c Release --no-incremental` -> 0 warnings, 0
+errors; published and driven with the identical scripts. All three legs close: `step4-tab disabled =
+True`, `pointer-events: none`, both the pill click and the confirm click refused by Playwright, **no
+POST issued**, and the out-of-band row keeps an empty `AzureResourceId`. `invalidatePlan` is a hoisted
+`function` declaration, so this is not the round-10 J9 temporal-dead-zone shape; Chromium logged zero
+`pageerror`s across four scripted runs. Two non-regression checks both pass: the ordinary
+single-preview commit still writes correctly with `expected` stamped, and a re-preview that
+**succeeds** still re-opens step 4 through *Continue to Commit* and commits - the fix does not strand
+the operator after a benign re-preview. Zero C# impact; view-embedded JS with no unit-testable seam
+(the position round 10 took for J5/J9), so it must be driven in a browser rather than unit-tested.
+
+### Fix corrections
+
+- **The cheaper interim is worse than the finding admits.** Calling `invalidatePlan()` from
+  `loadPreview`'s `error` handler and `!result.success` branch (mirroring `showScanError` in
+  `_ReconcileScripts.cshtml:199`) closes legs A and B but leaves **leg C** open - and leg C is the one
+  that stamps an expectation from an unseen plan with **no log line at all**. The interim closes the
+  loud legs and leaves the silent one. **Take the click-handler version only.**
+- **Do not "fix" this server-side by refusing a null `Expected`.** `SubnetController.BulkAzure.cs:85-90`
+  documents that as a deliberate round-10 decision to keep the direct JSON API working.
+- **Residue, not a defect in the fix:** on the patched build `#bulk-confirm-commit-btn` still reads
+  `disabled: False` after a failed re-preview. It is unreachable because the step-4 pane is never
+  activated, so nothing follows from it - but a belt-and-braces variant would also
+  `prop("disabled", true)` that button inside `invalidatePlan()`.
+
+---
+
+# Low
+
+## K2 - The bulk import 409's divergence list is computed, serialised to the browser, and discarded - the un-fixed twin of the reconcile wizard's `warnings` rendering
+
+`[x2]` &nbsp;|&nbsp; **Severity: low** &nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
+`src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:691`
+
+### The defect
+
+Round 10's J2 added `DescribeApprovedPlanDivergences` (`SubnetController.BulkAzure.cs:73-152`). When
+the re-derived plan disagrees with what the operator approved, `BulkCreateFromAzurePlanCore` answers
+409 with `{success, error, differences:[...]}` (`:167-176`). The only consumer of that body is
+`commitImport`'s `error` handler (`:680-684`), which calls `showCommitError(payload)`.
+`showCommitError` (`:691-711`) renders `payload.error` (`:695`), `payload.globalErrors` (`:697-699`)
+and `payload.itemErrors` (`:700-708`) - and the 409 carries neither of the last two. **Every sentence
+the server built is dropped on the floor.** `grep -rn 'differences' src/Bastet/Views
+src/Bastet/wwwroot` returns nothing.
+
+The reconcile wizard's `showCommitError` (`Views/Azure/Reconcile/_ReconcileScripts.cshtml:453-475`)
+was extended to render `payload.warnings` for precisely this reason, with the comment *"The 409
+carries no globalErrors - the reason a row was withheld travels in warnings, and without this the
+operator sees only 'no longer reported as deleted'"*. This is that same fix, not applied to the bulk
+wizard.
+
+### Failure scenario
+
+Empty Bastet tree. Bulk-import wizard, tick VNet `rig-vnet-visible` prefix `10.110.0.0/16` plus both
+Azure subnets; the preview says *"New top-level create rig-vnet-visible (10.110.0.0/16)"*. A second
+admin then creates `10.110.0.0/16` by hand. Pressing *Confirm Import* gives a 409 whose body says the
+commit would have **adopted someone else's subnet rather than creating one** - the exact outcome J2
+exists to surface. What renders is only the generic sentence and an empty `<ul>`.
+
+The refusal itself is correct and nothing is written, so this is a lost-diagnostic defect, not data
+loss.
+
+### Reproduction
+
+Real headless Chromium against a pristine `09cee3d` publish, with the colliding subnet created through
+`/Subnet/Create` in a second tab:
+
+```
+---- SERVER 409 BODY ----
+{"success":false,"error":"The plan changed since it was previewed, so nothing was imported. Re-run the
+ preview, review what it now says, and confirm again.","differences":["10.110.0.0/16: the preview
+ showed a different action; it now resolves to ExactMatch.","10.110.0.0/16: it now targets existing
+ Bastet subnet 1."]}
+
+---- WHAT THE OPERATOR SEES ----
+error-message span: 'The plan changed since it was previewed, so nothing was imported. Re-run the
+ preview, review what it now says, and confirm again.'
+error list items: []
+```
+
+**The information is nowhere else on screen** - this was the hunt that was expected to kill the
+finding and made it worse instead. Driving the recovery path the error message itself prescribes
+("Re-run the preview, review what it now says"), clicking `#bulk-back-to-preview-btn` - the only other
+button on the commit step - repaints nothing and leaves step 3 showing the **stale** plan, *"New
+top-level create rig-vnet-visible (10.110.0.0/16)"*, which flatly contradicts the refusal that just
+fired. Only going back to step 2 and pressing *Preview* again re-derives, and even then the delta the
+server had already computed is not shown.
+
+### Fix
+
+In `showCommitError` (`_BulkScripts.cshtml:691`), after the `globalErrors` block:
+
+```js
+if (payload && payload.differences && payload.differences.length > 0) {
+    $.each(payload.differences, function (i, d) { $list.append($('<li></li>').text(d)); });
+}
+```
+
+`.text()`, not `.html()`, matching the two blocks either side.
+
+**Built, published and driven.** Patched build renders both divergence sentences as `<li>`s,
+`pageerrors: []`, and a clean happy-path import still shows its success banner with the error panel
+hidden. `dotnet test` on the patched copy: **730 passed, 0 failed**. No TDZ hazard - `$list` is
+declared at `:696` and the insertion is below it. No sibling call site is missed: `showCommitError`
+has exactly two callers (`:677` and `:683`), the block is purely additive, and the other two
+`Conflict(...)` sites in `SubnetController.BulkAzure.cs` (`:255`, `:293`) carry only `error` and
+already render correctly.
+
+### Fix corrections
+
+- **Cheaper interim - sound but strictly inferior.** In `BulkCreateFromAzurePlanCore`
+  (`SubnetController.BulkAzure.cs:171-176`) also emit the list under the key the client already
+  renders: `globalErrors = divergences` beside `differences = divergences`. One line of server code,
+  no `.cshtml` edit (which matters - round 10 lost two fixes to view-embedded JS that builds at 0
+  warnings and throws at runtime), keeps the documented `differences` key for the direct JSON API, and
+  needs no browser verification. The shipped pin
+  `BulkCreateFromAzurePlan_TargetAdoptedAfterPreview_ConflictNamesTheDivergence` still passes with a
+  duplicated list. It ships the same array twice on the wire and fixes only this one 409 rather than
+  the client's inability to render a `differences` body at all - **prefer the client fix**.
+- **Not closed by either version:** `#bulk-back-to-preview-btn` still repaints the stale plan after a
+  409. The fix makes the error panel tell the truth; the button next to it still shows a plan
+  contradicting it.
+
+---
+
+## K3 - J2's approved-plan divergence check dereferences a caller-supplied collection, turning two malformed bulk-import bodies from a modelled 400 into an unhandled 500
+
+`[x2]` &nbsp;|&nbsp; **Severity: low** &nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
+`src/Bastet/Controllers/SubnetController.BulkAzure.cs:78`
+
+### The defect
+
+`DescribeApprovedPlanDivergences` walks `selection.VNetPrefixes` (`:78`), indexes it and reads
+`selected.Expected` (`:80-81`), and reads `.Count` again inside a `LogWarning` (`:148`) - all before
+any null guard. The DTO declares `List<BulkImportSelectedVNetPrefixDto> VNetPrefixes { get; set; } = []`
+(`AzureBulkImportViewModels.cs:244`), but **System.Text.Json overwrites that initialiser with null
+when the body carries an explicit null** - the same trap this codebase already documents and guards at
+`SubnetController.AzureReconcile.cs:46-50` for the sibling endpoint.
+
+The call site at `:167` sits **outside** `BulkCreateFromAzurePlanCore`'s transaction `try` (which opens
+after the `CanCommit` check), and the public action's own `try` catches only `TimeoutException`, so
+nothing intercepts it.
+
+### Failure scenario
+
+`POST /Subnet/BulkCreateFromAzurePlan` (RequireAdminRole, antiforgery token supplied) with either:
+
+- **(A)** `{"subscriptionId":"<sub>","vNetPrefixes":null}`
+- **(B)** `{"subscriptionId":"<sub>","vNetPrefixes":[{...valid prefix...},null]}`
+
+**Expected** (and pre-round-10 actual): HTTP 400 with the planner's own wording - *"No VNet address
+prefixes were selected."* for (A), *"A selected VNet prefix was empty."* for (B).
+`AzureBulkImportPlanner.BuildPlan` explicitly guards both shapes (`:37`, `:50`) and records a global
+error, and the pre-existing `if (!plan.CanCommit)` arm turns that into a modelled 400.
+
+**Actual:** HTTP 500, unhandled `NullReferenceException`. For the documented direct JSON API the
+response stops being JSON - an HTML error page in Production, a stack trace in Development. For the
+browser wizard the `$.ajax` error handler's `JSON.parse` fails and `showCommitError` falls back to the
+literal string *"Server error: 500"* (`_BulkScripts.cshtml:680-683`), so the operator loses the
+planner's actual message. Nothing is written - the crash pre-empts a refusal, not a write. The global
+subnet lock is released correctly (verified: the next normal commit returned 200 in 0.026 s, and
+`sys.dm_tran_locks` shows 0 application locks).
+
+**Reachability:** not from the wizard (`buildSelectionFromUI` never emits a null entry). Reachable
+from the documented direct JSON API - which this method's own comment at `:83-86` says must keep
+working - and from any crafted Admin request.
+
+### Reproduction
+
+Pristine `09cee3d` publish, token scraped from `/Azure/BulkImport`:
+
+```
+{"vNetPrefixes":null}                    -> HTTP 500
+  System.NullReferenceException: Object reference not set to an instance of an object.
+     at Bastet.Controllers.SubnetController.DescribeApprovedPlanDivergences(...)
+        in .../SubnetController.BulkAzure.cs:line 78
+{"vNetPrefixes":[null]}                  -> HTTP 500, same exception, line 81
+{"vNetPrefixes":[<valid 10.110.0.0/16>,null]} -> HTTP 500, same exception, line 81
+{"vNetPrefixes":[]}            (control) -> HTTP 400 {"success":false,"globalErrors":["No VNet address
+                                            prefixes were selected."],"itemErrors":[]}
+/Azure/BulkImportPreview, same bodies    -> HTTP 200 with globalErrors (preview is unaffected)
+```
+
+**Regression pinned to J2:** `git show dcc15ab:src/Bastet/Controllers/SubnetController.BulkAzure.cs`
+goes straight from `planner.BuildPlan(...)` to `if (!plan.CanCommit)`; `DescribeApprovedPlanDivergences`
+did not exist, and there is no other dereference of `VNetPrefixes` anywhere in `Controllers/`.
+Building and running the parent commit confirmed both bodies produce the modelled 400 there.
+
+### Fix
+
+Null-guard the walk **in place** rather than reordering the checks - the 409 is deliberately raised
+before the `CanCommit` `BadRequest` (round-10 J2), and moving it after would report *"this plan cannot
+be committed"* in place of *"the plan changed since you approved it"* whenever both apply.
+
+```csharp
+// System.Text.Json overwrites the DTO's collection initialiser with null when the body
+// carries an explicit null, and a list element can itself be null - AzureBulkImportPlanner
+// guards both (:37, :50) and records a global error. This walk runs before the CanCommit
+// check that reports those errors, so it has to survive them.
+List<BulkImportSelectedVNetPrefixDto> selectedPrefixes = selection.VNetPrefixes ?? [];
+
+for (int index = 0; index < selectedPrefixes.Count; index++)
+{
+    BulkImportSelectedVNetPrefixDto? selected = selectedPrefixes[index];
+    if (selected is null)
+    {
+        // Already reported by the planner as a global error; nothing to compare.
+        continue;
+    }
+
+    BulkImportExpectedTargetDto? expected = selected.Expected;
+```
+
+and change the third dereference at `:148` (`selection.VNetPrefixes.Count` inside the `LogWarning`) to
+`selectedPrefixes.Count`.
+
+**Do NOT count a null entry as `unverified++`** - it is not an unverified commit, it is a malformed
+one, and the planner already names it. Doing so would also log an "unverified commit" for a request
+about to be refused as malformed.
+
+**Built and measured:** 0 warnings / 0 errors (the `?? []` on a non-nullable-declared property does
+**not** trip nullable analysis, which is where this could have failed the repo's warnings bar);
+**730 passed, 0 failed**; all three malformed bodies answer 400 with the planner's own wording; and
+both paths it sits in front of are byte-identical to the unpatched build - a valid selection with no
+`Expected` still returns `200 createdTargets:1`, and a valid selection with a wrong `Expected` still
+returns J2's 409 with identical `differences` wording.
+
+### Fix corrections
+
+- **The cheaper interim is partial and should not be mistaken for the fix.** Adding the sibling
+  endpoint's guard to the public action, immediately after the existing `selection is null` check at
+  `:36-39` -
+
+  ```csharp
+  if (selection.VNetPrefixes is null or { Count: 0 })
+  {
+      return BadRequest(new { success = false, error = "No VNet address prefixes were selected." });
+  }
+  ```
+
+  mirroring `SubnetController.AzureReconcile.cs:50` - closes body **(A)** only. Body **(B)**, a null
+  element inside a non-empty list, still 500s.
+- **Apply by content, not by line number.** The `:75-81` and `:148` citations are correct at `09cee3d`
+  but shift once the comment block is inserted.
+
+---
+
+## K4 - The approved-plan expectation carries no child-subnet information, so the commit can create imported children under names the preview never showed and no 409 fires
+
+`[x1]` &nbsp;|&nbsp; **Severity: low** &nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
+`src/Bastet/Controllers/SubnetController.BulkAzure.cs:136`
+
+### The defect
+
+`BulkImportExpectedTargetDto` (`Models/ViewModels/AzureBulkImportViewModels.cs:213-230`) carries only
+`TargetType`, `ExistingTargetSubnetId`, `AutoCreateParentSubnetId`, `WillRename`, `NewName` and
+`WillMarkFullyAllocated`, and `DescribeApprovedPlanDivergences` (`:93-140`) compares exactly those six.
+**`BulkImportPlanItem.ChildSubnets` - the rows the commit actually writes - is compared against
+nothing.**
+
+Child names are not selection-only. `AzureBulkImportPlanner.BuildPlanItem` seeds `usedNames` from the
+**existing tree** (`usedNames.Add(targetExistingName)` at `:491-493`, where `targetExistingName` is
+`exact.Name`), so `DisambiguateName`'s output moves when another admin renames the matched Bastet
+subnet. Every other tree-dependent way the target can move (a different id, a flipped `TargetType`, a
+flipped `WillRename`) is already caught by the existing six checks; child naming is the one that is
+not.
+
+### Failure scenario
+
+Bastet holds subnet 13, `rig-ktdown-web`, at `10.172.0.0/16`. The operator previews importing Azure
+VNet `rig-ktdown-v2` (`10.172.0.0/16`, subnets `rig-ktdown-web` `10.172.1.0/24` and `rig-ktdown-db`
+`10.172.2.0/24`). The preview promises children `["rig-ktdown-web (rig-ktdown-v2)", "rig-ktdown-db"]` -
+the first disambiguated because it collides with the target's own name. Another admin renames subnet
+13 to `renamed-by-someone-else` through the ordinary Edit page. The operator confirms.
+
+Every compared field is unchanged (`ExactMatch` / 13 / null / `WillRename=false` /
+`WillMarkFullyAllocated=false`), so **no divergence is reported, the commit returns 200, and the child
+is written as `rig-ktdown-web`** - a name the operator never approved and never saw.
+
+The same mechanism runs in reverse and is if anything sharper: with the preview approving
+`["rig-sn-vis-app","rig-sn-vis-data"]` and the target then renamed **to** `rig-sn-vis-app`, the commit
+writes the child as `rig-sn-vis-app (rig-vnet-visible)` - a string that appeared nowhere on the preview
+screen.
+
+Consequence is confined to `Name`: address space, parentage, `AzureResourceId` and the child count are
+all selection-derived and still server-validated, disambiguation still runs at commit so the written
+names stay internally consistent, reconcile keys on `AzureResourceId` rather than `Name`, and `Name` is
+freely editable afterwards. That is why this is low.
+
+### Reproduction
+
+Driven both through the real wizard in headless Chromium and through the documented JSON endpoints,
+against real Azure VNets:
+
+```
+B. WHAT THE OPERATOR SEES ON STEP 3:
+   Exact match Bastet subnet "rig-sn-vis-app" (10.110.0.0/16)
+   Child Azure subnets:
+    Create rig-sn-vis-app (rig-vnet-visible) 10.110.1.0/24 (was "rig-sn-vis-app")
+    Create rig-sn-vis-data 10.110.2.0/24
+C. second admin renamed subnet 1
+D. POSTED expected: {"targetType":"ExactMatch","existingTargetSubnetId":1,"autoCreateParentSubnetId":
+   null,"willRename":false,"newName":null,"willMarkFullyAllocated":false}   <-- no child information
+E. COMMIT RESPONSE: 200 {"success":true,...,"createdChildSubnets":2,"linkedTargets":1,...}
+
+=== FINAL TREE ===
+1|renamed-by-someone-else|10.110.0.0|16|NULL
+2|rig-sn-vis-app|10.110.1.0|24|1        <-- screen said "rig-sn-vis-app (rig-vnet-visible)"
+3|rig-sn-vis-data|10.110.2.0|24|1
+```
+
+No 409, no warning. A control run with no concurrent rename writes exactly the previewed names, so the
+rename is the sole cause.
+
+### Fix
+
+Add the planned children to the expectation and compare them:
+
+- give `BulkImportExpectedTargetDto` a `public List<string>? ChildNames { get; set; }`;
+- have `attachApprovedOutcomes` stamp `childNames: (item.childSubnets || []).map(function (c) { return c.name; })`;
+- in `DescribeApprovedPlanDivergences`, **after the `WillMarkFullyAllocated` check at `:136-139`**, add
+  a guarded comparison:
+
+  ```csharp
+  expected.ChildNames is not null
+      && !expected.ChildNames.SequenceEqual(item.ChildSubnets.Select(c => c.Name), StringComparer.Ordinal)
+  ```
+
+  reporting `$"{label}: the child subnet names have changed."` **without repeating either list** - the
+  same rule the existing `NewName` check at `:130-134` follows, because the names are
+  caller-influenced.
+
+The `expected.ChildNames is not null` guard preserves the optional/unverified contract round 10 chose
+for the direct JSON API. Do **not** compare `OriginalAzureName` or the child address prefixes: those
+come from the selection and cannot move, so comparing them adds no coverage.
+
+**Built and driven.** 0 warnings / 0 errors, **730 passed** (existing tests construct the DTO without
+the new field, get null, and are skipped by the guard). Against the rename race the patched build
+answers `409 ... "differences":["10.110.0.0/16: the child subnet names have changed."]` and writes
+nothing; the unmutated control still commits 200 with byte-identical rows; zero page JS errors, so
+this is not another J9-shaped build-clean/runtime-throw. There is no sibling call site to miss -
+`DescribeApprovedPlanDivergences` has exactly one caller (`:167`) and `attachApprovedOutcomes` exactly
+one (`loadPreview`'s success handler). Child order follows the posted selection, the same object at
+preview and commit, so ordering cannot drift into a spurious 409.
+
+### Fix corrections
+
+- **The new message is dead text until `K2` is fixed.** `showCommitError` never renders
+  `differences`; measured on the patched build, the panel showed only the generic *"The plan changed
+  since it was previewed..."* sentence with an empty `#bulk-commit-error-list`. The write is correctly
+  refused, so the hole is closed - but **fix `K2` in the same change**, or the operator is told a plan
+  changed without being told how.
+- **Use `(item.childSubnets || []).map(...)`, not the bare form.** `ChildSubnets` is a non-nullable
+  `List<>` so the bare form works today, but this is a preview success handler: a `TypeError` there
+  leaves step 3 blank with the commit button live on a stale plan - the round-10 J9 shape. The guard
+  costs one token. Match house style with `function (c) { return c.name; }`; the file uses no arrow
+  functions.
+- **Do NOT take the cheaper interim.** It was proposed as: seed `usedNames` in `BuildPlanItem` only
+  from the post-rename name, i.e. drop `usedNames.Add(targetExistingName)` at `:491-493`. It does work
+  mechanically (it builds, keeps 730 green, no shipped test pins child-vs-target disambiguation, and
+  the remaining seeds are selection-derived so `ChildSubnets` becomes a pure function of the
+  selection) - but it pays for a verification gap by deleting deliberate product behaviour that the
+  code comment at `:490` exists to explain, and it lets a child be created with the exact name of its
+  own parent. It also fixes nothing structurally: the expectation still carries no child information,
+  so the next tree-dependent input to child planning reopens the same hole silently. **Take the
+  `ChildNames` version only.**
+- The finding's own citation of `:93` points at the plan-item lookup, not the comparison block; the
+  insertion point is `:136-139`.
+
+---
+
+# Info
+
+## K5 - Subnet Details prints a broadcast address for `/31` and `/32`, contradicting the app's own RFC 3021 rule and a host IP listed on the same page
+
+`[x1]` &nbsp;|&nbsp; **Severity: info** (filed low; corrected down on measurement - see below)
+&nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
+`src/Bastet/Controllers/SubnetController.Read.cs:63`
+
+### The defect
+
+`SubnetController.Read.cs:63` sets `BroadcastAddress = ipUtilityService.CalculateBroadcastAddress(...)`
+with no CIDR test. `HostIpValidationService.ValidateNewHostIp:70` applies the network/broadcast
+reservation only when `subnet.Cidr < 31`, so both `/31` addresses and the single `/32` address are
+legitimately assignable, and `IpUtilityService.CalculateUsableIpAddresses:105-110` documents `/31` as
+2 usable and `/32` as 1.
+
+### Failure scenario
+
+Create `10.211.0.0/31` and assign both addresses as host IPs (the app accepts them). `GET
+/Subnet/Details/{id}` then renders, **in one document**: *"Broadcast Address 10.211.0.1"*, *"Usable IP
+Addresses 2"*, and a Host IP Assignments row *"10.211.0.1 p2p-b"*. The page labels an assigned, legally
+assignable host address as the subnet's broadcast address. For a `/32` (`10.212.0.0/32`) it prints
+*"Broadcast Address 10.212.0.0"* - the subnet's only address, also assignable and assigned, so the
+Network Address and Broadcast Address rows print the identical string.
+
+Control: on a `/30`, `POST /HostIp/Create` for the broadcast address is refused (*"Cannot assign the
+broadcast address as a host IP"*, no row written) and the page correctly prints it as the broadcast.
+
+### Reproduction
+
+Driven through the real Create and HostIp forms (no direct SQL writes):
+
+```
+HOSTIP subnet=1 ip=10.211.0.0 -> 302 ; ip=10.211.0.1 -> 302 ; subnet=2 ip=10.212.0.0 -> 302
+HOSTIP subnet=3 ip=10.213.0.3 -> 200 (refused: "Cannot assign the broadcast address as a host IP")
+
+/Subnet/Details/1  /31  Subnet Mask 255.255.255.254  Broadcast Address 10.211.0.1  Total 2  Usable 2
+                   ...Host IP Assignments: 10.211.0.0 p2p-a | 10.211.0.1 p2p-b
+/Subnet/Details/2  /32  Subnet Mask 255.255.255.255  Broadcast Address 10.212.0.0  Total 1  Usable 1
+/Subnet/Details/3  /30  Broadcast Address 10.213.0.3  Total 4  Usable 2          (correct, control)
+```
+
+Nothing is written wrong and nothing is blocked - the harm is entirely a misread, which is why the
+severity was corrected from low to info. The two verifiers disagreed here: one held low on the
+precedent of round 5's E13 (an RFC-3021 display contradiction on the same page, filed low), the other
+corrected to info on the precedent of round 10's J8 (a page stating a wrong network fact about a row
+on the same screen, filed info) after measuring that no operator action is refused or misdirected.
+**Info stands.** What is genuinely defensible, and was verified, is the self-contradiction: one card
+says Total 2 / Usable 2 and then names one of those two the broadcast, and the card below names it as
+an assignment.
+
+### Fix
+
+At `SubnetController.Read.cs:63`, compute it only below `/31`:
+
+```csharp
+BroadcastAddress = subnet.Cidr < 31
+    ? ipUtilityService.CalculateBroadcastAddress(subnet.NetworkAddress, subnet.Cidr)
+    : string.Empty,
+```
+
+and render the empty case in `src/Bastet/Views/Subnet/Details/_NetworkInformation.cshtml:19`.
+`SubnetDetailsViewModel.BroadcastAddress` (`SubnetViewModels.cs:101`) has exactly one consumer - that
+one `<dd>` - and no test in `test/` mentions the view model, so nothing else moves.
+
+**Built and driven side by side** against the same catalog: 0 warnings / 0 errors, **730 passed**, the
+`/31` and `/32` flip while the `/30` is byte-identical. The Razor `@(...)` expression is compiled at
+build, so this is not the J9 shape.
+
+**Cheaper interim, no controller change:** gate the two lines in `_NetworkInformation.cshtml:18-19` on
+`@if (Model.Cidr < 31)`, which the view can do because `Model.Cidr` is already on the view model. It
+leaves the value computed and unused **and silently drops the row from the definition list**, so the
+card loses a label rather than answering the question - the controller-side version is preferable.
+
+### Fix corrections
+
+- **The proposed label is wrong for a `/32`.** RFC 3021 is *"Using 31-Bit Prefixes on IPv4
+  Point-to-Point Links"* and says nothing about `/32`; a `/32` has no broadcast because it is a single
+  host - exactly the distinction the app's own comment at `HostIpValidationService.cs:65-69` already
+  draws. Rendering `"None (RFC 3021)"` for a `/32` replaces one false statement with a differently
+  false one. Discriminate on `Model.Cidr`, e.g.
+  `@(Model.Cidr == 31 ? "None (RFC 3021 point-to-point)" : Model.Cidr == 32 ? "None (single host)" : Model.BroadcastAddress)`,
+  which also removes the reliance on `string.Empty` as an out-of-band sentinel.
+- **The finding's claim that `Read.cs:63` is "the one call site with no guard" is false**, and this
+  matters because it is the reason the fix must not be generalised. Four other call sites are also
+  unguarded: `HostIpController.cs:104`, `:140`, `:182` - all benign, because they build the
+  `SubnetRange` string and `"10.211.0.0 - 10.211.0.1"` is the correct range for a `/31` (verified in
+  the rendered Create page) - and `HostIpValidationService.cs:161`, which is **permanently-accepted
+  item 5** and out of scope.
+- **Do NOT "fix" this inside `IpUtilityService.CalculateBroadcastAddress`.**
+  `HostIpValidationService.cs:327` deliberately calls it for `newCidr < 31` only,
+  `SubnetPropertyCalculationTests` pins its current `/31` and `/32` return values, and it would break
+  the three `HostIpController` range strings.
+
+---
+
+# Refuted
+
+Reported by a finder, killed by the verifier.
+
+| Candidate | Severity as reported | Citation | Why it was killed |
+|---|---|---|---|
+| The J4 pending-message queue is a read-modify-write over a cookie, so two concurrent error redirects destroy each other's entry `[x1]` | info | `src/Bastet/Controllers/ErrorPageMessages.cs:55-64` | **Tie-break; the mechanism claim is false by measurement.** The loss reproduces easily (10/10 with two tabs in one context), but the cited line is not the cause: rebuilding with the queue removed entirely - one `TempData["EPM_"+token]` key, no list, no cap - loses messages at the same rate (9/10), because `CookieTempDataProvider` serialises the **entire** TempData dictionary into one cookie, so the second `Set-Cookie` replaces everything regardless of read-modify-write. The title states a causal claim that measurement falsifies, and no change confined to `ErrorPageMessages.cs` removes it. It is a framework-wide property of the app's TempData use, and J4's site is the one place it has been made *harmless*: across 20 tab-loads there was zero cross-talk, only the designed generic fallback, correct 404 status, nothing written. The untreated pre-J4 path (`AzureController.cs:41` + `_TempDataAlerts.cshtml`) renders the **wrong** message 9/10 under the identical race. The residual strand (the `MaxPending` doc comment) is comment accuracy, and is literally true sequentially. |
+| The J2 test's "caller's strings are never echoed" assertion tests a string that was never in the request, so it cannot fail `[x2]` | info | `test/Bastet.Tests/Azure/SubnetControllerBulkAzureImportTests.cs:177` | **Automatic refutation: test coverage.** The finding's own evidence concedes "production is correct today; it is only unpinned" - the entire claimed consequence is a hypothetical future edit by a hypothetical author. Two further kills on measurement: every consumer of this endpoint's error payload renders with jQuery `.text()` (`_BulkScripts.cshtml:541`, `:695`, `:698`, `:704`) and `differences` is read by no view at all, so even the *existing* `VNetName` echo reaches the DOM as a text node - the boundary being guarded has no measured consequence behind it. And the invariant it asks to pin is round 10's chosen mitigation for **permanently-accepted item 3** (`GlobalSanitizationFilter` skipping nested collections); asking for a test that pins that choice is not a new defect. What survives is one sentence of comment at `:175-176` that describes something the line below does not test. |
+| J1's scaling regression test does not fail when the per-target `SaveChangesAsync` - the dominant half of the fix - is put back `[x2]` | info | `test/Bastet.Tests/Azure/SubnetControllerAzureReconcileScalingTests.cs:219` | **Every factual claim is true and none of them is a defect in Bastet.** Reproduced: reverting only that half leaves all 730 green, and the test really is blind to it. But at HEAD the production code is **correct** - the batch save is present, and no operator can observe anything wrong. The finding's scenario opens "In a copy of the tree I reverted exactly one production hunk"; the defect is manufactured in the reporter's private copy and its consequence is entirely future-tense. That is a test-coverage gap and hits two automatic refutations at once. The secondary complaint (the test's `<remarks>` overstate what it bounds) is a doc-comment overstatement on a test. |
+| `AzureBulkImportPlanner.TruncateForName` has had no caller since round 4 extracted `SubnetNaming.WithSuffix` `[x2]` | info | `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:774` | **Automatic refutation: not a runtime defect, and what remains is naming.** A private static method with zero call sites is unreachable in every execution - no input, request, or click causes it to run, so there is no wrong output to exhibit. The finding's stated harm is a hypothetical maintainer confusing it with `TruncateAndSanitizeName`. The one load-bearing embellishment is also factually wrong: they are not "eight lines" apart - `TruncateAndSanitizeName` ends at `:724` and two full methods stand between them, putting them 57 lines apart, so the adjacency that made the trap plausible is not there. The codebase has already ruled on this class: the live watch-list entry on round 8's H6 residue says *"Defence in depth - do not tidy it away."* |
+| A plain-HTTP `BASTET_OIDC_AUTHORITY` passes startup and then answers every routed request with a bodiless HTTP 500 carrying none of the four security headers `[x1]` | info | `src/Bastet/Program.cs:210` | **Mechanism reproduces exactly; all three consequence limbs collapse.** (1) The headline limb is nil-consequence and is the shape round 10 already refuted verbatim: the response is `Content-Length: 0` with no body - nothing to MIME-sniff, no document to frame, no navigation to leak a referrer from, and nothing disclosed. (2) "Kills the error page and every anonymous page" is real but not *incremental*: the control shows the deployment is totally dead either way - with an ordinary unreachable HTTPS authority nobody can sign in and every routed page is 500 too - so the entire measured delta is a rendered ServerError page plus two account pages on an installation where no user can reach a single page of data. The plain-HTTP case is in fact the **louder** failure, 100% from the first request, with the framework naming the exact remediation. (3) "A liveness probe reports the deployment healthy" has no basis here: there is no `MapHealthChecks`, no `/health`, and no `HEALTHCHECK` in the Dockerfile. What is left is an operator misconfiguration that ASP.NET Core's own guardrail refuses, plus a configuration-surface feature request (expose `RequireHttpsMetadata`, fail at startup). |
+| A `/32` subnet offers "Add Child Subnet", an action every CIDR value is refused for `[x1]` | info | `src/Bastet/Views/Subnet/Details/_ChildSubnets.cshtml:6` | **Tie-break; verbatim re-raise plus a false premise.** `AUDIT-FINDINGS-7.md:876` is row 1 of round 7's refuted table: same file, same line, same claim, same severity band, killed for F10. The kill reason then reproduces now, and the load-bearing premise ("the two buttons on one page disagree about whether the action exists") is **false**: a fully-covered `/30` renders the identical "Add Child Subnet" link, has all 8 possible child POSTs refused (the complete space), and renders no Unallocated Ranges card at all - so there is no second button to disagree with, and the proposed `Cidr < 32` gate would not fire. The two controls are not peers: the per-range Create button is capacity-derived by construction, the header link is navigation that is capacity-gated nowhere. The proposed fix also does not close the dead end - `SubnetController.Create.cs:17-25` still offers the `/32` in the parent dropdown of a plain `GET /Subnet/Create`. Consequence measured at nil: ordinary 200 re-renders with an inline reason, `SELECT COUNT(*) FROM Subnets` unchanged after 9 attempted creations. |
+| Error page prints "Status Code: 200" on a response it sends as 500 when the route segment is not a number `[x1]` | info | `src/Bastet/Controllers/ErrorController.cs:62` | **Tie-break; both load-bearing claims fail.** (1) The "J3 leg" is not what produces the output: `/Error/200` is byte-identical to `/Error/abc` (wire 500, body "Status Code: 200"), and "200" parses, so that request never touches the fallback J3 added. `/Error/0` and `/Error/-1` disagree the same way. The finding requested `/Error/200` in its own loop and omitted the row. `git show ff285cf` has the clamp and the unclamped assignment byte-identical, so J3 changed only *which* wrong number prints for a non-numeric segment. The behaviour is twice-recorded as intended (`AUDIT-FINDINGS-7.md:76-77`, `AUDIT-FINDINGS-10.md:272-273`) and pinned by `HttpStatusCodeHandler_OutOfRangeStatus_FallsBackTo500` with `InlineData(200)`, `(302)`, `(0)`, `(99999)`. (2) The stated harm never happens: all eleven `RedirectToErrorPage` sites pass literal 403/404, `UseStatusCodePagesWithReExecute` always writes a framework int, `UseExceptionHandler("/Error")` hits the hardcoded-500 action, and no view links to `/Error/`. Six genuine failure paths driven live all have page-number == wire-status. The only way in is a human hand-typing an out-of-range `/Error/N`, on which request nothing failed - and the page's own `h1` says "Error" anyway. |
+| J1's `archivedSubnetIds` hunk is unpinned: breaking it writes a duplicate archive row for every nested selected target `[x1]` | low | `src/Bastet/Controllers/SubnetController.Delete.cs:186` | **Automatic refutation, twice.** (1) No runtime defect: at HEAD the shipped code is correct, independently reproduced with the exact shape the finding says is unexercised - operator ticks a target *and* one of its own descendants, both Azure-linked and stale; the plan offers both and the result is 2 archive rows, no duplicate. The "specific wrong output" exists only in a build where someone has first replaced `AddRange(toDelete.Select(...))` with `Add(subnet.Id)`. (2) Missing test coverage: strip the mutation and what remains is "all 730 tests still pass" with a proposed fix that is literally "add one case". Nothing in `src/` changes. The mechanism narrative is true - `FindAsync` returns the tracked Deleted-state instance so the `subnet is null` skip at `AzureReconcile.cs:145` is now dead - but that makes `alreadyArchived` correct **and** load-bearing, not defective. |
+| Reconcile plan router still tests for a status its two evaluators can no longer produce - dead arm left by round 10's J7 `[x1]` | info | `src/Bastet/Services/Azure/AzureReconciler.cs:133` | **No runtime defect, a settled watch-list item, and the proposed fix inverts the safety it claims to protect.** The arm really is unreachable (a `throw` wired into `:132` never fires across 730 tests nor a live ARM scan carrying two unrecognisable resource IDs), but the harm clause is verbatim counterfactual. It re-raises the recorded H6-residue watch-list entry - *"Defence in depth - do not tidy it away."* Most importantly: `or UnrecognisedResourceId` is the **fail-safe** half of a two-way router. `plan.ReviewItems` is never offered for archival; `plan.Items` is. Under the proposed fix the `else` at `:137` sends any such row straight into `plan.Items` - a row offered for archival with nothing established about it, which is the literal harm the finding says it is guarding against - and silently degrades the withholding set at `:256-264`. The inline comment at `:114-117` already tells the next reader the thing the finding says they will not be told. |
+| `BatchCreateChildSubnets`' JSON-API branch writes a TempData success banner nobody consumes, overwriting a message a real redirect had queued `[x1]` | info | `src/Bastet/Controllers/SubnetController.Azure.cs:429` | **Tie-break; reachable code path, unreachable wrong output.** The clobber reproduces byte for byte, but the shared cookie jar is the harness, not a client: with the operator's browser as one jar and the API script as another - which is what "a script calls the documented JSON API" means - the operator's banner comes back intact and the stray message sits unread in the script's jar, in a client that renders no HTML. No browser reaches the JSON branch through the app: the only `isAzureImport` in `Views/` is `_SubnetList.cshtml:26`, hardcoded `true`, and `wwwroot` never references the endpoint. Even forced, a real browser follows the 302 synchronously so the operator's message is already rendered; the pending-message window needs a client that posts an HTML form, declines its redirect, posts JSON, then requests HTML - reachable only via devtools JS an admin writes against their own session, cosmetically damaging only themselves, and not cross-site triggerable. Same asymmetry-as-evidence shape round 8 killed on this very method. |
+| Both Azure wizard landing view models carry an `IsFeatureEnabled` flag that is written true and read by nothing `[x1]` | info | `src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs:139` | **Consequence measured at exactly zero.** A/B on one port and one catalog: with the property present the two landing pages are 54674 and 38799 bytes; with both properties and both initialisers deleted they are 54674 and 38799 bytes, byte-identical after normalising the antiforgery token. A property whose complete removal changes not one byte of any response it can participate in has no observable behaviour to be wrong about. The stated harm is explicitly counterfactual ("a maintainer adding a 'feature disabled' panel would naturally branch on it") - the branch is not unreachable, it does not exist. The one reading with teeth also fails: neither type is bound by any POST and no view emits the flag, so it is not operator-tamperable; and the real gate is confirmed live (with the feature off both actions 302 to `/Error/403` and the view is never reached). Round 5's refuted table already killed `IsFeatureEnabled` on this reasoning. Corrections: it is one property per class, not several, and the wizards have sixteen view files, not eleven. |
+| Reconcile and bulk-import DTOs ship two dead fields to every client: `isVNetLevel`, and the raw enum ordinal `status` alongside `statusName` `[x1]` | info | `src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs:85` | **Dies on consequence, and half of it is a recorded kill.** Driving the whole path from a real entry point against a build with **both** fields stripped from the wire produced a byte-identical rendered row, zero JS errors, 730/730 either way. The harm needs two stacked hypotheticals - a future enum value inserted mid-list *and* a future client reading `status` - and neither exists: the only clients switch on `statusName`, the only `.status` hits in `Views/` are the two `xhr.status` lines the finding itself names, and there is no documented external HTTP API to postulate a third-party consumer for. `AUDIT-FINDINGS-5.md:633` already killed `IsVNetLevel` by name ("Worst case its own scenario names is one extra `true` in a JSON row the browser discards"), along with four sibling members. One overstatement corrected: `Status` is load-bearing server-side (`AzureReconciler.cs:132`, `:192`, `AzureController.cs:374`); only its JSON projection is redundant, and a redundant superset is not a defect. |
+| `IInputSanitizationService.SanitizeString` is registered, implemented, unit-tested and never called, and its `allowHtml` branch does not do what its comment claims `[x1]` | info | `src/Bastet/Services/Security/IInputSanitizationService.cs:14` | **Every claim is true - confirmed at IL level - and it still fails reachability.** An exhaustive scan of the shipped assembly (4395 method bodies, 129332 instructions, every call token resolved) finds **zero** call sites, stronger than grep because it also rules out async state machines, lambdas and local functions; dispatch cannot reach it, since `GlobalSanitizationFilter` goes through `SanitizationAttributeBase.Sanitize` and all four overrides call the other members. The comment really is false (`SanitizeString("<p>Paragraph</p>", true)` returns `&lt;p&gt;Paragraph&lt;/p&gt;`) and the `allowHtml:true` arm really is the weaker filter. But the in-edge set is provably empty - not a hard-to-hit branch, no edge at all - so no request produces a wrong byte, no row is corrupted and no XSS is admitted. The consequence chain terminates in a comment that misleads a reader, and the latent-XSS reading needs two future decisions (route untrusted markup through that arm, then render with `Html.Raw`), neither present. |
+| The archived-host-IP page's role check is tautological: its `else` branch cannot be reached `[x1]` | info | `src/Bastet/Services/UserContextService.cs:36` | **Automatic refutation: not a runtime defect.** The citations are accurate and the reachability conclusion is right - the full live matrix produced 403 with the view never executing, and only a rewritten `DevAuthHandler` reached the `else`. But the scenario names no wrong output and no wrong state, and its stated "why it matters" is verbatim *"the pattern a maintainer would copy"*. Consequence measured, not assumed: the surviving arm is the correct link for 100% of reachable principals and the dead arm's target is gated by the same policy, so it is a no-op alternative, not a mis-designed fallback. Two factual corrections, neither rescuing it: **"the two predicates are the same set" is false** - they differ on the authenticated-identity precondition, and the `else` was rendered live by exploiting exactly that gap, so the finding is right for the wrong reason; and `DevAuthHandler.cs:26-32` issues **one** role claim (`Admin`), not all four - the other three come from the inheritance switch at `UserContextService.cs:53-60`. |
+
+---
+
+# Watch list
+
+Not findings. Things a later round should know before it re-derives them.
+
+**Bulk-import / J2 surface**
+
+- **`AzureResourceId` can never be cleared through the UI.** It is written by the two import paths and
+  by nothing else, no unlink view exists, `EditSubnetViewModel` does not carry it, and a CIDR edit on a
+  stamped row then throws. This is what makes `K1`'s end state unrecoverable and is the reason both J2
+  and `K1` are priced above cosmetic. A "clear Azure link" action would retire a whole class of finding.
+- **`#bulk-back-to-preview-btn` repaints a stale plan after a 409.** Measured: after the refusal, the
+  only other button on the commit step returns the operator to step 3 still showing the superseded
+  plan, which contradicts the refusal that just fired. `K2`'s fix makes the error panel truthful and
+  does not touch this.
+- **The in-flight window is real.** Bulk preview latency up to **7,247 ms** was observed against live
+  ARM, which is why `K1`'s leg C - an impatient click on an already-lit pill - is unremarkable rather
+  than exotic.
+- **`#bulk-confirm-commit-btn` is enabled in markup** (`_StepCommit.cshtml:30`) and is disabled only
+  while a commit is in flight. It relies entirely on its pane being unreachable.
+- **Nested DTO fields arrive unsanitized.** Permanently-accepted item 3 (`GlobalSanitizationFilter`
+  skipping nested `System.*` collections) covers J2's `Expected` and will equally cover `K4`'s new
+  `ChildNames`. Round 10's chosen mitigation is "echo nothing back"; anyone making a divergence message
+  concrete must keep that rule.
+
+**TempData / flash messages**
+
+- **Ordinary `TempData` flash messages cross-talk between browser tabs.** Measured while refuting the
+  J4 candidate: the untreated pre-J4 path (`AzureController.cs:41` rendered by
+  `_TempDataAlerts.cshtml`) shows one tab the **wrong** message 9 times in 10 under a two-tab race,
+  across roughly 30 call sites. `CookieTempDataProvider` serialises the whole dictionary into one
+  cookie, so this is structural and no per-site fix removes it. J4's tokenised site is the one place it
+  has been made harmless. This is the honest version of a claim two candidates aimed at the wrong file.
+
+**Broadcast address / RFC 3021**
+
+- `CalculateBroadcastAddress` has four other unguarded callers besides `K5`'s.
+  `HostIpController.cs:104`, `:140`, `:182` are **benign** (range endpoints, correct at `/31` and
+  `/32`). `HostIpValidationService.cs:161` is **permanently-accepted item 5**. Do not "unify" the
+  guard into `IpUtilityService` - `SubnetPropertyCalculationTests` pins the current return values and
+  the three range strings would break.
+
+**Dead but deliberate - do not tidy**
+
+- `AzureReconciler.cs:132-133`'s `or UnrecognisedResourceId` arm is unreachable **and fail-safe**.
+  Removing it converts a fail-safe default into a fail-open one, sending unrecognised rows into the
+  archivable `plan.Items`. Leave it; the comment at `:114-117` already explains why.
+- `AzureBulkImportPlanner.TruncateForName` (`:774`) has had no caller since round 4, and
+  `IInputSanitizationService.SanitizeString` has no call site in the shipped assembly at all - proven
+  at IL level, not by grep. Both are inert. `SanitizeString`'s `allowHtml: true` arm is the **weaker**
+  filter despite its permissive name, and its comment ("keep basic HTML") is false - both arms end in
+  `EncodeHtml`. If anyone ever wires a rich-text field, fix the comment first.
+
+**Deliberate behaviours that keep getting re-filed**
+
+- `/Error/N` for any `N` outside 400-599 answers **500 while printing `N`**. Deliberate, documented in
+  rounds 7 and 10, and pinned by `HttpStatusCodeHandler_OutOfRangeStatus_FallsBackTo500`.
+- "Add Child Subnet" is capacity-gated **nowhere** - it renders identically on a `/32` and on a fully
+  covered `/30`, and both refuse every possible child. Killed for F10 in round 7 and again this round.
+
+**Rig hygiene**
+
+- Two agents this round bound ports that were free at probe time and taken by bind time, and in both
+  cases the probe then silently hit **another agent's application**. One such collision wrote three
+  rows (`renamed-by-someone-else` 10.110.0.0/16 plus two children) into catalog `bastet_vc3r` that
+  were never cleaned up. Check `ss -ltn` immediately before bind, and re-check which PID owns the port
+  after start, before believing any measurement.
+- The repository working tree was observed **dirty mid-round** by one verifier - another agent's
+  untracked `ZzC13ProbeTests.cs`, an untracked `Bastet/` directory, and a modified tracked
+  `SubnetControllerAzureReconcileScalingTests.cs`. It was clean again afterwards, but round 10's note
+  stands: verify `git status --porcelain` is empty immediately before any commit.

--- a/docs/AUDIT-FINDINGS-11.md
+++ b/docs/AUDIT-FINDINGS-11.md
@@ -189,127 +189,40 @@ the finding advised, since the inserted comment block shifts the cited lines._
 
 ---
 
-## K4 - The approved-plan expectation carries no child-subnet information, so the commit can create imported children under names the preview never showed and no 409 fires
+_K4 is fixed and committed with the `ChildNames` version. `BulkImportExpectedTargetDto` gained
+`List<string>? ChildNames`, `attachApprovedOutcomes` stamps
+`(item.childSubnets || []).map(function (c) { return c.name; })` — the defensive `|| []` and the
+`function` form both taken as advised, since this runs in a preview success handler where a TypeError
+would leave step 3 blank with the commit button live — and `DescribeApprovedPlanDivergences` compares
+the list after the `WillMarkFullyAllocated` check, guarded on null so a caller that never previewed
+keeps the optional contract. Neither list is repeated in the message, following the same rule the
+`NewName` check uses, because these names are caller-influenced and nothing here is sanitized._
 
-`[x1]` &nbsp;|&nbsp; **Severity: low** &nbsp;|&nbsp; **Confidence: confirmed** &nbsp;|&nbsp;
-`src/Bastet/Controllers/SubnetController.BulkAzure.cs:136`
+_Measured in a real browser against real ARM, before and after, with the target renamed through the
+ordinary Edit page while the plan sat on screen. The preview displayed
+*"Create rig-sn-vis-app (rig-vnet-visible) 10.110.1.0/24 (was rig-sn-vis-app)"* in both runs.
+**Before:** the commit returned **200** with `differences: null` and the child was written — under the
+bare `rig-sn-vis-app`, a string that appeared nowhere on the preview screen. **After:** the identical
+race returns **409** with
+`differences: ["10.110.0.0/16: the child subnet names have changed."]`, and nothing is written._
 
-### The defect
+_**The finding's warning that this message would be dead text was acted on rather than noted.** K2 was
+fixed first, in numeric order, so the same run shows the sentence actually rendered in
+`#bulk-commit-error-list` rather than an empty list beneath the generic refusal. Zero `pageerror`s in
+both runs._
 
-`BulkImportExpectedTargetDto` (`Models/ViewModels/AzureBulkImportViewModels.cs:213-230`) carries only
-`TargetType`, `ExistingTargetSubnetId`, `AutoCreateParentSubnetId`, `WillRename`, `NewName` and
-`WillMarkFullyAllocated`, and `DescribeApprovedPlanDivergences` (`:93-140`) compares exactly those six.
-**`BulkImportPlanItem.ChildSubnets` - the rows the commit actually writes - is compared against
-nothing.**
+_Two regression tests added, 732 → **734**: the rename race, and a pin that a caller supplying no
+child names is still not refused. The rename test was confirmed failing with **only** the comparison
+hunk reverted — `OkObjectResult` where `ConflictObjectResult` was expected, i.e. the commit going
+through and writing the moved name — so it fails for the defect's own reason, not a compile error._
 
-Child names are not selection-only. `AzureBulkImportPlanner.BuildPlanItem` seeds `usedNames` from the
-**existing tree** (`usedNames.Add(targetExistingName)` at `:491-493`, where `targetExistingName` is
-`exact.Name`), so `DisambiguateName`'s output moves when another admin renames the matched Bastet
-subnet. Every other tree-dependent way the target can move (a different id, a flipped `TargetType`, a
-flipped `WillRename`) is already caught by the existing six checks; child naming is the one that is
-not.
-
-### Failure scenario
-
-Bastet holds subnet 13, `rig-ktdown-web`, at `10.172.0.0/16`. The operator previews importing Azure
-VNet `rig-ktdown-v2` (`10.172.0.0/16`, subnets `rig-ktdown-web` `10.172.1.0/24` and `rig-ktdown-db`
-`10.172.2.0/24`). The preview promises children `["rig-ktdown-web (rig-ktdown-v2)", "rig-ktdown-db"]` -
-the first disambiguated because it collides with the target's own name. Another admin renames subnet
-13 to `renamed-by-someone-else` through the ordinary Edit page. The operator confirms.
-
-Every compared field is unchanged (`ExactMatch` / 13 / null / `WillRename=false` /
-`WillMarkFullyAllocated=false`), so **no divergence is reported, the commit returns 200, and the child
-is written as `rig-ktdown-web`** - a name the operator never approved and never saw.
-
-The same mechanism runs in reverse and is if anything sharper: with the preview approving
-`["rig-sn-vis-app","rig-sn-vis-data"]` and the target then renamed **to** `rig-sn-vis-app`, the commit
-writes the child as `rig-sn-vis-app (rig-vnet-visible)` - a string that appeared nowhere on the preview
-screen.
-
-Consequence is confined to `Name`: address space, parentage, `AzureResourceId` and the child count are
-all selection-derived and still server-validated, disambiguation still runs at commit so the written
-names stay internally consistent, reconcile keys on `AzureResourceId` rather than `Name`, and `Name` is
-freely editable afterwards. That is why this is low.
-
-### Reproduction
-
-Driven both through the real wizard in headless Chromium and through the documented JSON endpoints,
-against real Azure VNets:
-
-```
-B. WHAT THE OPERATOR SEES ON STEP 3:
-   Exact match Bastet subnet "rig-sn-vis-app" (10.110.0.0/16)
-   Child Azure subnets:
-    Create rig-sn-vis-app (rig-vnet-visible) 10.110.1.0/24 (was "rig-sn-vis-app")
-    Create rig-sn-vis-data 10.110.2.0/24
-C. second admin renamed subnet 1
-D. POSTED expected: {"targetType":"ExactMatch","existingTargetSubnetId":1,"autoCreateParentSubnetId":
-   null,"willRename":false,"newName":null,"willMarkFullyAllocated":false}   <-- no child information
-E. COMMIT RESPONSE: 200 {"success":true,...,"createdChildSubnets":2,"linkedTargets":1,...}
-
-=== FINAL TREE ===
-1|renamed-by-someone-else|10.110.0.0|16|NULL
-2|rig-sn-vis-app|10.110.1.0|24|1        <-- screen said "rig-sn-vis-app (rig-vnet-visible)"
-3|rig-sn-vis-data|10.110.2.0|24|1
-```
-
-No 409, no warning. A control run with no concurrent rename writes exactly the previewed names, so the
-rename is the sole cause.
-
-### Fix
-
-Add the planned children to the expectation and compare them:
-
-- give `BulkImportExpectedTargetDto` a `public List<string>? ChildNames { get; set; }`;
-- have `attachApprovedOutcomes` stamp `childNames: (item.childSubnets || []).map(function (c) { return c.name; })`;
-- in `DescribeApprovedPlanDivergences`, **after the `WillMarkFullyAllocated` check at `:136-139`**, add
-  a guarded comparison:
-
-  ```csharp
-  expected.ChildNames is not null
-      && !expected.ChildNames.SequenceEqual(item.ChildSubnets.Select(c => c.Name), StringComparer.Ordinal)
-  ```
-
-  reporting `$"{label}: the child subnet names have changed."` **without repeating either list** - the
-  same rule the existing `NewName` check at `:130-134` follows, because the names are
-  caller-influenced.
-
-The `expected.ChildNames is not null` guard preserves the optional/unverified contract round 10 chose
-for the direct JSON API. Do **not** compare `OriginalAzureName` or the child address prefixes: those
-come from the selection and cannot move, so comparing them adds no coverage.
-
-**Built and driven.** 0 warnings / 0 errors, **730 passed** (existing tests construct the DTO without
-the new field, get null, and are skipped by the guard). Against the rename race the patched build
-answers `409 ... "differences":["10.110.0.0/16: the child subnet names have changed."]` and writes
-nothing; the unmutated control still commits 200 with byte-identical rows; zero page JS errors, so
-this is not another J9-shaped build-clean/runtime-throw. There is no sibling call site to miss -
-`DescribeApprovedPlanDivergences` has exactly one caller (`:167`) and `attachApprovedOutcomes` exactly
-one (`loadPreview`'s success handler). Child order follows the posted selection, the same object at
-preview and commit, so ordering cannot drift into a spurious 409.
-
-### Fix corrections
-
-- **The new message is dead text until `K2` is fixed.** `showCommitError` never renders
-  `differences`; measured on the patched build, the panel showed only the generic *"The plan changed
-  since it was previewed..."* sentence with an empty `#bulk-commit-error-list`. The write is correctly
-  refused, so the hole is closed - but **fix `K2` in the same change**, or the operator is told a plan
-  changed without being told how.
-- **Use `(item.childSubnets || []).map(...)`, not the bare form.** `ChildSubnets` is a non-nullable
-  `List<>` so the bare form works today, but this is a preview success handler: a `TypeError` there
-  leaves step 3 blank with the commit button live on a stale plan - the round-10 J9 shape. The guard
-  costs one token. Match house style with `function (c) { return c.name; }`; the file uses no arrow
-  functions.
-- **Do NOT take the cheaper interim.** It was proposed as: seed `usedNames` in `BuildPlanItem` only
-  from the post-rename name, i.e. drop `usedNames.Add(targetExistingName)` at `:491-493`. It does work
-  mechanically (it builds, keeps 730 green, no shipped test pins child-vs-target disambiguation, and
-  the remaining seeds are selection-derived so `ChildSubnets` becomes a pure function of the
-  selection) - but it pays for a verification gap by deleting deliberate product behaviour that the
-  code comment at `:490` exists to explain, and it lets a child be created with the exact name of its
-  own parent. It also fixes nothing structurally: the expectation still carries no child information,
-  so the next tree-dependent input to child planning reopens the same hole silently. **Take the
-  `ChildNames` version only.**
-- The finding's own citation of `:93` points at the plan-item lookup, not the comparison block; the
-  insertion point is `:136-139`.
+_The cheaper interim was **not** taken, and its rejection is confirmed. Dropping
+`usedNames.Add(targetExistingName)` from `BuildPlanItem` does work mechanically, but it pays for a
+verification gap by deleting deliberate product behaviour the comment beside it exists to explain, it
+lets a child be created with the exact name of its own parent, and it fixes nothing structurally — the
+expectation would still carry no child information, so the next tree-dependent input to child planning
+reopens the same hole silently. `OriginalAzureName` and the child address prefixes are deliberately
+not compared: both are selection-derived and cannot move, so comparing them would add no coverage._
 
 ---
 

--- a/src/Bastet/Controllers/SubnetController.BulkAzure.cs
+++ b/src/Bastet/Controllers/SubnetController.BulkAzure.cs
@@ -75,9 +75,27 @@ public partial class SubnetController : Controller
         List<string> differences = [];
         int unverified = 0;
 
-        for (int index = 0; index < selection.VNetPrefixes.Count; index++)
+        // System.Text.Json overwrites the DTO's collection initialiser with null when the body
+        // carries an explicit null, and a list element can itself be null. AzureBulkImportPlanner
+        // guards both shapes and records a global error - but this walk runs before the CanCommit
+        // check that turns those into a modelled 400, so it has to survive them. Without this the
+        // two shapes threw from outside the transaction's try, where the action catches only
+        // TimeoutException: the documented JSON API stopped answering JSON and the wizard showed
+        // "Server error: 500" in place of the planner's own message.
+        List<BulkImportSelectedVNetPrefixDto> selectedPrefixes = selection.VNetPrefixes ?? [];
+
+        for (int index = 0; index < selectedPrefixes.Count; index++)
         {
-            BulkImportSelectedVNetPrefixDto selected = selection.VNetPrefixes[index];
+            BulkImportSelectedVNetPrefixDto? selected = selectedPrefixes[index];
+
+            if (selected is null)
+            {
+                // Already reported by the planner as a global error. Deliberately not counted as an
+                // unverified commit: it is a malformed request, not an unchecked one, and logging it
+                // as unverified would describe a request that is about to be refused outright.
+                continue;
+            }
+
             BulkImportExpectedTargetDto? expected = selected.Expected;
 
             if (expected is null)
@@ -145,7 +163,7 @@ public partial class SubnetController : Controller
                 "Bulk Azure import: {Unverified} of {Total} selected prefix(es) carried no previewed outcome, "
                 + "so the re-derived plan for them was not compared against anything the operator approved.",
                 unverified,
-                selection.VNetPrefixes.Count);
+                selectedPrefixes.Count);
         }
 
         return differences;
@@ -164,7 +182,17 @@ public partial class SubnetController : Controller
         // Re-deriving the plan protects against committing a stale one, but on its own it also
         // silently commits a *different* one when the tree moved under the operator. Refuse that,
         // the way BulkDeleteStaleAzureSubnets already refuses a scan whose verdict has changed.
-        List<string> divergences = DescribeApprovedPlanDivergences(selection, plan);
+        //
+        // Skipped when the planner recorded a global error, because then it produced no items and
+        // every selected prefix would be described as "no longer produces a target to import" - a
+        // divergence manufactured by the malformed body rather than by the tree moving. The
+        // planner's own message is the useful answer there, and the BadRequest below carries it.
+        // The 409-before-400 ordering still holds wherever both are meaningful: a plan that fails
+        // only on per-item errors is still reported as diverged first.
+        List<string> divergences = plan.GlobalErrors.Count > 0
+            ? []
+            : DescribeApprovedPlanDivergences(selection, plan);
+
         if (divergences.Count > 0)
         {
             return Conflict(new

--- a/src/Bastet/Controllers/SubnetController.BulkAzure.cs
+++ b/src/Bastet/Controllers/SubnetController.BulkAzure.cs
@@ -155,6 +155,19 @@ public partial class SubnetController : Controller
             {
                 differences.Add($"{label}: marking the target fully allocated changed to {item.WillMarkFullyAllocated}.");
             }
+
+            // The children are what the commit actually writes, and their names are not
+            // selection-only: BuildPlanItem seeds disambiguation from the existing tree, so a
+            // concurrent rename of the matched subnet moves them while every field above stays
+            // equal. Guarded on null so a caller that did not preview keeps the optional contract.
+            // Neither list is repeated in the message - the same rule the NewName check follows,
+            // because these names are caller-influenced and nothing here has been sanitized.
+            if (expected.ChildNames is not null
+                && !expected.ChildNames.SequenceEqual(
+                    item.ChildSubnets.Select(c => c.Name), StringComparer.Ordinal))
+            {
+                differences.Add($"{label}: the child subnet names have changed.");
+            }
         }
 
         if (unverified > 0)

--- a/src/Bastet/Controllers/SubnetController.Read.cs
+++ b/src/Bastet/Controllers/SubnetController.Read.cs
@@ -60,7 +60,14 @@ public partial class SubnetController : Controller
             IsFullyAllocated = subnet.IsFullyAllocated,
             // Calculate subnet properties
             SubnetMask = ipUtilityService.CalculateSubnetMask(subnet.Cidr),
-            BroadcastAddress = ipUtilityService.CalculateBroadcastAddress(subnet.NetworkAddress, subnet.Cidr),
+            // Only below /31. A /31 has no broadcast address (RFC 3021 gives both addresses to the
+            // link) and a /32 is a single host, and this application agrees: HostIpValidationService
+            // applies the network/broadcast reservation only when Cidr < 31, so both /31 addresses
+            // and the single /32 address are assignable - and were being assigned while this card
+            // named one of them the broadcast, on the same page that listed it as a host IP.
+            BroadcastAddress = subnet.Cidr < 31
+                ? ipUtilityService.CalculateBroadcastAddress(subnet.NetworkAddress, subnet.Cidr)
+                : string.Empty,
             TotalIpAddresses = ipUtilityService.CalculateTotalIpAddresses(subnet.Cidr),
             UsableIpAddresses = ipUtilityService.CalculateUsableIpAddresses(subnet.Cidr),
             // Include children, ordered by network address

--- a/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureBulkImportViewModels.cs
@@ -227,6 +227,23 @@ namespace Bastet.Models.ViewModels
         public string? NewName { get; set; }
 
         public bool WillMarkFullyAllocated { get; set; }
+
+        /// <summary>
+        /// The child subnet names the preview displayed, in the order it displayed them.
+        /// </summary>
+        /// <remarks>
+        /// Child names are not selection-only, which is why they need carrying back.
+        /// <c>BuildPlanItem</c> seeds its disambiguation set from the <b>existing tree</b>, so a
+        /// concurrent rename of the matched Bastet subnet moves <c>DisambiguateName</c>'s output and
+        /// the commit writes a child under a name that was never on screen. Every other
+        /// tree-dependent way the target can move is already covered by the fields above; this was
+        /// the one that was not.
+        /// <para>
+        /// Null when the caller did not preview, which keeps the optional contract the rest of this
+        /// type follows for the documented direct JSON API.
+        /// </para>
+        /// </remarks>
+        public List<string>? ChildNames { get; set; }
     }
 
     /// <summary>

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -720,6 +720,15 @@
                     }
                 });
             }
+            // The approved-plan 409 carries neither globalErrors nor itemErrors - the reason the
+            // commit was refused travels in `differences`, and without this the operator is told the
+            // plan changed but never told how, with the delta the server had already computed
+            // dropped on the floor. The reconcile wizard renders its own 409's `warnings` for
+            // exactly this reason. .text(), not .html(): these sentences name caller-influenced
+            // values and the blocks either side encode too.
+            if (payload && payload.differences && payload.differences.length > 0) {
+                $.each(payload.differences, function (i, d) { $list.append($('<li></li>').text(d)); });
+            }
             $("#bulk-commit-error").removeClass("d-none");
             $("#bulk-confirm-commit-btn").prop("disabled", false);
         }

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -409,6 +409,20 @@
         // ---------------------------------------------------------------
         $("#bulk-go-preview-btn").on("click", function () {
             const selection = buildSelectionFromUI();
+
+            // Re-lock the later steps before re-previewing. A pill stays clickable once its step has
+            // been visited, and invalidatePlan is the only writer that puts the disabled state back -
+            // so without this, one visit to Commit left step 4 live for the rest of the page's life.
+            // Every later preview then ran with the commit button still armed over a plan that had
+            // not been rendered: if the preview failed, or simply had not landed yet, the operator
+            // could confirm an import whose plan they never saw, and the approved-plan check would
+            // not fire because the fresh selection had never been stamped with an expectation.
+            //
+            // Ordering is load-bearing twice: invalidatePlan nulls lastSelection, so it must run
+            // before the reassignment below, and it re-disables #step3-tab, so it must run before
+            // activateTab re-opens that one step.
+            invalidatePlan();
+
             lastSelection = selection;
             activateTab("step3");
             loadPreview(selection);

--- a/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
+++ b/src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml
@@ -542,7 +542,11 @@
                     autoCreateParentSubnetId: typeof item.autoCreateParentSubnetId === "number" ? item.autoCreateParentSubnetId : null,
                     willRename: item.willRename === true,
                     newName: typeof item.newName === "string" ? item.newName : null,
-                    willMarkFullyAllocated: item.willMarkFullyAllocated === true
+                    willMarkFullyAllocated: item.willMarkFullyAllocated === true,
+                    // The names actually on screen. Defensive `|| []` because this runs in a preview
+                    // success handler: a TypeError here would leave step 3 blank with the commit
+                    // button live over a stale plan.
+                    childNames: (item.childSubnets || []).map(function (c) { return c.name; })
                 };
             });
         }

--- a/src/Bastet/Views/Subnet/Details/_NetworkInformation.cshtml
+++ b/src/Bastet/Views/Subnet/Details/_NetworkInformation.cshtml
@@ -16,7 +16,17 @@
             <dd class="col-sm-8">@Model.SubnetMask</dd>
             
             <dt class="col-sm-4">Broadcast Address</dt>
-            <dd class="col-sm-8">@Model.BroadcastAddress</dd>
+            @* Discriminated rather than blank, and /31 and /32 are not the same case: RFC 3021 is
+               about 31-bit point-to-point prefixes and says nothing about /32, which has none
+               because it is a single host. Labelling both "RFC 3021" would replace one false
+               statement with a differently false one. *@
+            <dd class="col-sm-8">
+                @(Model.Cidr == 31
+                    ? "None (RFC 3021 point-to-point)"
+                    : Model.Cidr == 32
+                        ? "None (single host)"
+                        : Model.BroadcastAddress)
+            </dd>
             
             <dt class="col-sm-4">Total IP Addresses</dt>
             <dd class="col-sm-8">@Model.TotalIpAddresses.ToString("N0")</dd>

--- a/test/Bastet.Tests/Azure/SubnetControllerBulkAzureImportTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerBulkAzureImportTests.cs
@@ -219,6 +219,46 @@ public class SubnetControllerBulkAzureImportTests : IDisposable
         Assert.Equal(VNetId, adopted.AzureResourceId);
     }
 
+    /// <summary>
+    /// A malformed body must come back as the planner's modelled 400, not as an unhandled 500.
+    /// </summary>
+    /// <remarks>
+    /// Round-11 K3. The approved-plan comparison walks <c>selection.VNetPrefixes</c> and reads each
+    /// element before any null guard. System.Text.Json overwrites a collection initialiser with null
+    /// when the body carries an explicit null, and a list element can itself be null - the planner
+    /// guards both and records a global error, but this walk runs *before* the CanCommit check that
+    /// reports them, so it has to survive them. Without the guard both shapes threw
+    /// NullReferenceException from a point outside the transaction's try, where the action's own
+    /// catch handles only TimeoutException: the documented direct JSON API stopped returning JSON at
+    /// all, and the wizard fell back to the literal string "Server error: 500", losing the planner's
+    /// actual message.
+    /// </remarks>
+    [Fact]
+    public async Task BulkCreateFromAzurePlan_NullPrefixCollection_IsABadRequestNotAServerError()
+    {
+        BulkImportSelectionDto selection = Selection(ApprovedNewTopLevel());
+        selection.VNetPrefixes = null!;
+
+        IActionResult result = await Commit(selection);
+
+        BadRequestObjectResult bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("No VNet address prefixes were selected.",
+            System.Text.Json.JsonSerializer.Serialize(bad.Value), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BulkCreateFromAzurePlan_NullPrefixElement_IsABadRequestNotAServerError()
+    {
+        BulkImportSelectionDto selection = Selection(ApprovedNewTopLevel());
+        selection.VNetPrefixes.Add(null!);
+
+        IActionResult result = await Commit(selection);
+
+        BadRequestObjectResult bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Contains("A selected VNet prefix was empty.",
+            System.Text.Json.JsonSerializer.Serialize(bad.Value), StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task BulkCreateFromAzurePlan_NoApprovedOutcome_IsNotRefused()
     {

--- a/test/Bastet.Tests/Azure/SubnetControllerBulkAzureImportTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerBulkAzureImportTests.cs
@@ -220,6 +220,74 @@ public class SubnetControllerBulkAzureImportTests : IDisposable
     }
 
     /// <summary>
+    /// A concurrent rename that moves the planned child names must be refused, not committed.
+    /// </summary>
+    /// <remarks>
+    /// Round-11 K4. The approved-plan expectation carried the target's identity but nothing about
+    /// the children the commit actually writes. <c>BuildPlanItem</c> seeds its disambiguation set
+    /// from the existing tree, so renaming the matched Bastet subnet moves <c>DisambiguateName</c>'s
+    /// output while every compared field stays equal - the commit returned 200 and wrote a child
+    /// under a name the operator never saw. Here the preview approves the disambiguated
+    /// "rig-div (rig-div-vnet)"; the rename removes the collision, so the plan would now write the
+    /// bare "rig-div".
+    /// </remarks>
+    [Fact]
+    public async Task BulkCreateFromAzurePlan_ChildNamesMovedByAConcurrentRename_IsRefused()
+    {
+        // An existing Bastet subnet that the VNet prefix matches exactly, whose name collides with
+        // the incoming Azure child and so forces the child to be disambiguated.
+        await AddSubnetAsync("rig-div", "10.151.0.0", 16);
+        int existingId = (await _context.Subnets.SingleAsync(TestContext.Current.CancellationToken)).Id;
+
+        BulkImportSelectionDto selection = Selection(new BulkImportExpectedTargetDto
+        {
+            TargetType = nameof(BulkImportTargetType.ExactMatch),
+            ExistingTargetSubnetId = existingId,
+            WillRename = false,
+            WillMarkFullyAllocated = false,
+            // What the preview displayed, with the child disambiguated against the target's name.
+            ChildNames = ["rig-div (rig-div)"]
+        });
+        selection.VNetPrefixes[0].Subnets =
+        [
+            new BulkImportSelectedSubnetDto
+            {
+                Name = "rig-div",
+                AddressPrefix = "10.151.1.0/24",
+                AzureResourceId = VNetId + "/subnets/rig-div"
+            }
+        ];
+
+        // The second admin renames the target, so the collision - and the disambiguation - is gone.
+        Subnet target = await _context.Subnets.SingleAsync(TestContext.Current.CancellationToken);
+        target.Name = "renamed-by-someone-else";
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        IActionResult result = await Commit(selection);
+
+        ConflictObjectResult conflict = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Contains("child subnet names have changed",
+            System.Text.Json.JsonSerializer.Serialize(conflict.Value), StringComparison.Ordinal);
+
+        // Nothing was written: the child does not exist under either name.
+        Assert.Equal(1, await _context.Subnets.CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A caller that did not preview still carries no child names, and must not be refused for it.
+    /// </summary>
+    [Fact]
+    public async Task BulkCreateFromAzurePlan_NoChildNamesSupplied_IsNotRefused()
+    {
+        BulkImportSelectionDto selection = Selection(ApprovedNewTopLevel());
+        Assert.Null(selection.VNetPrefixes[0].Expected!.ChildNames);
+
+        IActionResult result = await Commit(selection);
+
+        _ = Assert.IsType<OkObjectResult>(result);
+    }
+
+    /// <summary>
     /// A malformed body must come back as the planner's modelled 400, not as an unhandled 500.
     /// </summary>
     /// <remarks>

--- a/test/Bastet.Tests/SubnetManagement/SubnetDetailsBroadcastAddressTests.cs
+++ b/test/Bastet.Tests/SubnetManagement/SubnetDetailsBroadcastAddressTests.cs
@@ -1,0 +1,85 @@
+using Bastet.Controllers;
+using Bastet.Data;
+using Bastet.Models;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Validation;
+using Bastet.Tests.TestHelpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Bastet.Tests.SubnetManagement;
+
+/// <summary>
+/// The Subnet Details card must not name an address the application will happily assign as the
+/// subnet's broadcast address.
+/// </summary>
+/// <remarks>
+/// Regression for round-11 K5. <c>HostIpValidationService</c> applies the network/broadcast
+/// reservation only when <c>Cidr &lt; 31</c>, so both /31 addresses and the single /32 address are
+/// legitimately assignable - and the details page was computing a broadcast address for them
+/// unconditionally. On a /31 with both addresses assigned the page stated "Usable IP Addresses 2",
+/// named one of those two the broadcast, and listed that same address as a host IP assignment
+/// directly below. On a /32 the Network Address and Broadcast Address rows printed the identical
+/// string.
+/// </remarks>
+public class SubnetDetailsBroadcastAddressTests
+{
+    private static SubnetController CreateController(BastetDbContext context)
+    {
+        IIpUtilityService ip = new IpUtilityService();
+        SubnetController controller = new(
+            context,
+            ip,
+            new SubnetValidationService(ip),
+            new HostIpValidationService(ip, context),
+            ControllerTestHelper.CreateMockUserContextService(),
+            ControllerTestHelper.CreateMockSubnetLockingService(),
+            NullLogger<SubnetController>.Instance);
+        ControllerTestHelper.SetupController(controller);
+        return controller;
+    }
+
+    private static async Task<SubnetDetailsViewModel> DetailsFor(string network, int cidr)
+    {
+        using BastetDbContext context = TestDbContextFactory.CreateDbContext();
+        context.Subnets.Add(new Subnet
+        {
+            Id = 1,
+            Name = "under-test",
+            NetworkAddress = network,
+            Cidr = cidr,
+            CreatedAt = DateTime.UtcNow
+        });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        IActionResult result = await CreateController(context).Details(1);
+
+        ViewResult view = Assert.IsType<ViewResult>(result);
+        return Assert.IsType<SubnetDetailsViewModel>(view.Model);
+    }
+
+    [Theory]
+    [InlineData("10.211.0.0", 31)]
+    [InlineData("10.212.0.0", 32)]
+    public async Task Details_AtOrAbove31_HasNoBroadcastAddress(string network, int cidr)
+    {
+        SubnetDetailsViewModel model = await DetailsFor(network, cidr);
+
+        Assert.Equal(string.Empty, model.BroadcastAddress);
+    }
+
+    /// <summary>
+    /// The guard must not reach below /31, where a broadcast address is real and is enforced -
+    /// assigning it as a host IP is refused.
+    /// </summary>
+    [Theory]
+    [InlineData("10.213.0.0", 30, "10.213.0.3")]
+    [InlineData("10.214.0.0", 24, "10.214.0.255")]
+    public async Task Details_Below31_StillReportsTheBroadcastAddress(string network, int cidr, string expected)
+    {
+        SubnetDetailsViewModel model = await DetailsFor(network, cidr);
+
+        Assert.Equal(expected, model.BroadcastAddress);
+    }
+}


### PR DESCRIPTION
### Improvements
- **A refused bulk Azure import now tells you what changed** — the server already worked out which
  parts of the plan had moved, and the wizard was throwing that away and showing only a generic
  "the plan changed" sentence
- The **Subnet Details** page no longer reports a broadcast address for `/31` and `/32` subnets. It
  showed one even though both addresses of a `/31`, and the single address of a `/32`, are assignable
  — so a page could name an address as the broadcast and list it as an assigned host IP at the same
  time

### Bug Fixes
- The bulk Azure import could **adopt a subnet you never selected**, permanently linking it to a VNet
  with no way to unlink it in the app. Once you had visited the Commit step, it stayed clickable — so
  if you previewed again and that preview failed, or simply had not finished, you could confirm an
  import whose plan was never shown to you, and the safety check that compares the plan against what
  you approved never ran
- A bulk import could **create subnets under names the preview never showed** — if someone renamed the
  matching Bastet subnet while you were reviewing, the imported children were silently renamed to
  match, and the import went through without warning
- Sending a malformed bulk-import request **returned a server error instead of an explanation** —
  callers using the JSON API got an HTML error page rather than the reason their request was rejected,
  and the wizard showed "Server error: 500" in place of the actual message
