### PR TITLE
Audit 13 Cleanup

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -468,3 +468,54 @@ failure, and it must leave the same durable record as any other so the next one 
   mangled through tool round-trips.
 - **Migration `.Designer.cs` snapshots are frozen history.** Never report them as stale.
 - **No novels.** A finding is a citation, a scenario, a reproduction, a fix.
+
+## Scope is the owner's call, never the round's
+
+**A round may decide whether a defect is REAL. It may never decide whether a real defect is WORTH
+FIXING, or that fixing it is "out of scope", "a feature change, not a bug fix", or "too expensive".
+That is a product decision and it belongs to the repository owner. Not to a finder, not to a verifier,
+not to the scribe, and not to you.**
+
+Round 6 broke this and it cost four rounds. It reproduced a real defect — both Azure import wizards
+silently truncate a multi-prefix Azure subnet to its first prefix, after which BASTET advertises
+Azure-assigned ranges as free space — then decided by itself that closing it "means creating several
+Bastet subnets from one Azure subnet, which is a feature change, not a bug fix, and is out of scope
+here." It demoted the finding to a watch-list line. Rounds 7-9 inherited the demotion without
+re-examining it; rounds 10-12 dropped it entirely. Round 13 rediscovered it independently and measured
+the operator-visible consequence for the first time — a *Create Subnet* button over an /24 Azure had
+already assigned. **The owner was never asked, across four rounds, whether an IPAM tool silently lying
+about free space was acceptable.** The answer, when finally put to them, was not close.
+
+The failure mode is specific and worth naming: **every one of those deferrals priced the COST of the
+fix and none of them priced the CONSEQUENCE of the defect.** Cost is visible from inside the code.
+Consequence requires running the thing and looking at what the operator sees. A round that defers on
+cost alone has not done the work that would justify deferring.
+
+Therefore:
+
+- **A reproduced defect gets filed as a finding at the severity its consequence warrants**, whatever
+  the fix costs. Fix cost belongs in the *Fix* section, never in the severity and never in the
+  decision to file.
+- **"Out of scope", "feature change not a bug fix", "too big for this round", "the data model does not
+  support it"** are not verdicts a round may reach. They are *recommendations to the owner*, and they
+  go in the finding's own text where the owner will see them — not in a watch-list line, and never as
+  a reason to lower severity or drop the finding.
+- **Severity is graded on what the software does wrong, not on how often it does it.** Rarity of the
+  trigger is one sentence in the failure scenario. It does not reduce severity. For an IPAM tool
+  specifically, *silently asserting that an allocated range is free* is a top-severity output no matter
+  how narrow the path to it, because the product's entire purpose is being the authority on that
+  question.
+- **Never use the watch list as a place to put a real defect you have decided not to fix.** The watch
+  list is for things a verifier *could not settle* — thin evidence, unproven reachability, patterns
+  worth grepping next round. A reproduced defect on the watch list is a finding that has been hidden,
+  and it will fall off within three rounds. It did.
+- **If a round believes a finding needs a scope decision, say so at the top of the Verdict**, in the
+  words "this needs a decision from you and here is what it costs" — so it is the first thing read,
+  not the last thing skimmed.
+- **The same rule binds `/audit-reconcile`.** Declining to implement a filed finding, narrowing it, or
+  substituting an interim for the real fix is the owner's call. Ask; do not decide and record the
+  decision as though it were settled.
+
+When in doubt: **file it, rate it on consequence, and let the owner say no.** A finding the owner
+declines costs one line in a table. A defect a round declines on their behalf costs four rounds and
+ships the bug.

--- a/docs/AUDIT-FINDINGS-13.md
+++ b/docs/AUDIT-FINDINGS-13.md
@@ -8,7 +8,7 @@
 | Build | **0 warnings, 0 errors** |
 | Tests | **738 passed**, 0 failed, 0 skipped |
 | Date | 2026-08-02 |
-| Status | **3 findings open** — 1 **high**, 1 low, 1 info |
+| Status | **1 fixed** (M1, high), **2 open** — 1 low, 1 info |
 
 > **Post-round amendment (2026-08-02, by the repository owner).** `M1` was filed by this round at
 > **medium** and has been **re-rated HIGH**, and it is **to be fixed, not deferred again**. The round's
@@ -101,149 +101,104 @@ first two split. All three survivors in this file are `[x1]`. The single `[x2]` 
 
 ## M1 — Both Azure import wizards silently drop every IPv4 prefix after the first on a multi-prefix Azure subnet, and BASTET then reports the dropped ranges as free space
 
-**Severity:** **High** (filed by the round at medium; re-rated — see disposition below)  **Tag:** `[x1]`  **Beat:** 3
-**Disposition: MUST FIX. Not eligible for deferral to round 14.**
-**File:** `src/Bastet/Services/Azure/AzureService.cs:352`
-(siblings: `AzureService.cs:275`, `AzureService.cs:418-439`, `AzureBulkImportPlanner.cs:520-527`)
+_M1 is fixed and committed. Both wizards now emit one selectable entry per IPv4 prefix an Azure
+subnet owns, so every prefix can be imported and none is silently dropped._
 
-**Confidence:** **confirmed.** Mechanism, the absence of any warning, the persisted rows and the
-free-space claim were each observed on a live rig, not inferred.
+_**What was done.** The collapse had two sites, both of them the same mistake made when an Azure
+subnet could still only hold one IPv4 prefix. `GetVNetInventory` (`AzureService.cs:350`) built one
+`BulkAzureSubnetViewModel` per Azure subnet from the singular `ExtractIpv4Prefix`; it now calls a new
+`AzureService.BuildInventorySubnetRows`, which returns one row per prefix. `GetCompatibleSubnets`
+(`AzureService.cs:239-277`) carried an explicit `break; // Take only the first valid IPv4 address`,
+which is gone. Nothing else in either wizard needed changing: the bulk wizard already keys its
+checkboxes on `data-address-prefix` and posts `{name, addressPrefix, azureResourceId}` per row, and
+the single-VNet wizard already renders `result.subnets` by index, so both render N rows the moment N
+are returned._
 
-**Failure scenario.** Azure has allowed several IPv4 prefixes on one subnet since Sept 2025 and ARM
-accepts it today. Given VNet `rig-13-b3p2-multi` (10.31.0.0/16) with one subnet
-`rig-13-b3p2-sn-multi` carrying `addressPrefixes: [10.31.0.0/24, 10.31.1.0/24]`, `GetVNetInventory`
-builds one `BulkAzureSubnetViewModel` per Azure subnet and sets
-`AddressPrefix = ExtractIpv4Prefix(subnet)` — the **first** prefix only (`AzureService.cs:352`). The
-single-VNet wizard does the same, with an explicit `break; // Take only the first valid IPv4 address`
-(`AzureService.cs:275`). The planner then creates exactly one Bastet child.
+_**The naming was the only real obstacle, and it is a product decision the owner made, not one this
+reconciliation made for them.** Two Bastet rows from one Azure subnet would otherwise both carry the
+bare Azure name, and `Subnet.Name` has a **non-unique** index (`BastetDbContext.cs:36`) — they would
+persist as rows distinguishable only by CIDR. Each row is now named for the range it holds:
+`rec13-sn-multi (10.41.0.0/24)` and `rec13-sn-multi (10.41.1.0/24)`. **A subnet contributing a single
+row is untouched** — `rec13-sn-single` imported as exactly `rec13-sn-single`, so no existing install
+sees a rename. Applied in the planner (`AzureBulkImportPlanner.cs:486-533`) and, independently,
+server-side in the single-VNet commit via a new `ResolveImportNames` (`SubnetController.Azure.cs:243`),
+because the browser is not the authority there and a crafted or replayed post carries whatever names
+it likes._
 
-The model *does* carry the full list (`BulkAzureSubnetViewModel.Ipv4AddressPrefixes`, populated at
-`AzureService.cs:366`) but its only consumer is the reconciler (`AzureReconciler.cs:391-394`) — no
-view and no planner path reads it. Nothing in either wizard, in the preview, or in `AnnotateSubnet`
-mentions the other prefixes.
+_**Three things the finding asked for were not built, each for a reason established by reading the
+code rather than assuming.** (1) `AnnotateSubnet` needed **no** change: it keys the already-exists
+test on `{NetworkAddress, Cidr}` (`AzureBulkImportPlanner.cs:288-289`), not on the resource id, so
+importing one prefix leaves its sibling `Available` and an unrelated Bastet row still `Blocked` — both
+measured live. The round-13 verifier had already corrected the finder on this point and was right;
+making the instructed change would have been a regression. (2) The **reconciler** needed no change,
+but it did constrain the fix: it shares `GetVNetInventory` (`SubnetController.AzureReconcile.cs:56`)
+and indexes prefixes by resource id at `AzureReconciler.cs:68` with an indexer assignment — not
+`ToDictionary`, so duplicate ids overwrite rather than throw. Every expanded row therefore carries the
+subnet's **complete** prefix list; a row reporting only its own would make the last write win and the
+reconciler would believe the subnet had lost the others, offering a live row for deletion. That
+invariant has its own test. (3) A **new** `PrefixQualifiedName` helper was written and then deleted —
+`SubnetNaming.WithSuffix` (`SubnetNaming.cs:52`) already does exactly this, length-aware, and is used
+by the planner and `SubnetController.Create.cs:81`. Adding a second one would have been the residue
+these rounds keep finding._
 
-**Wrong output:** after import, `10.31.1.0/24` exists in Azure but nowhere in BASTET, and the target's
-Details page advertises it as unallocated with a *Create Subnet* button. An operator allocating from
-BASTET hands out addresses Azure has already assigned. The reconciler cannot correct it: it walks only
-Bastet rows that carry an `AzureResourceId` and has no "present in Azure, absent from Bastet" status at
-all. The wrong state is permanent and invisible.
+_**Proved by A/B against live ARM on the same fixture, not by reading.** Azure subnet
+`rec13-sn-multi` in VNet `rec13-multi` (10.41.0.0/16) created with
+`az network vnet subnet create --address-prefixes 10.41.0.0/24 10.41.1.0/24`; ARM returned
+`addressPrefix: null, addressPrefixes: ["10.41.0.0/24","10.41.1.0/24"]`, confirming both the GA
+behaviour and that the singular field nulls once there are two. A sibling `rec13-sn-single`
+(10.41.5.0/24, singular field set) exercised the unchanged path. The unfixed build was a clone at
+`c04fe21` on port 5402/catalog `bastet_rec13_head`; the fixed build ran on 5401/`bastet_rec13`. Same
+subscription, same fixture, same posts:_
 
-**Reproduction — ran it.** Own instance on port 5313, own catalog `bastet_rig13_v5c`, SP A, real
-Chromium via Playwright, live ARM. The multi-prefix fixture already existed; no new Azure resource was
-created.
+```
+                    unfixed (c04fe21)                    fixed
+GET /Azure/GetSubnets
+  rows offered      2                                    3
+                    sn-multi 10.41.0.0/24                sn-multi 10.41.0.0/24
+                    sn-single 10.41.5.0/24               sn-multi 10.41.1.0/24
+                                                         sn-single 10.41.5.0/24
+after import, GET /Subnet/Details/1 "Unallocated IP Ranges"
+                    10.41.1.0 - 10.41.4.255              10.41.2.0 - 10.41.4.255
+                    1,024 IP addresses  [Create Subnet]  768 IP addresses  [Create Subnet]
+                    10.41.6.0 - 10.41.255.254            10.41.6.0 - 10.41.255.254
+```
 
-1. ARM ground truth, `az network vnet show -g bastet-visible -n rig-13-b3p2-multi`:
-   `space ["10.31.0.0/16"], subnets [{ n: rig-13-b3p2-sn-multi, p: null, ps: ["10.31.0.0/24","10.31.1.0/24"] }]`
-   — the singular `addressPrefix` really is `null` once there are two, exactly as the XML doc at
-   `AzureService.cs:390-396` says.
-2. `GET /Azure/BulkGetVNets` returned
-   `{ name: rig-13-b3p2-sn-multi, addressPrefix: "10.31.0.0/24", ipv4AddressPrefixes: ["10.31.0.0/24","10.31.1.0/24"], statusName: "Available", reason: null, isSelectable: true }`.
-   Step-2 card `innerText`, verbatim and complete:
-   `rig-13-b3p2-multi 10.31.0.0/16 / Will create a new Bastet subnet. / rig-13-b3p2-sn-multi 10.31.0.0/24`
-   — no badge, no reason line, no mention of `10.31.1.0/24`. Zero page errors.
-3. `POST /Azure/BulkImportPreview` → `childSubnets = [{ name: rig-13-b3p2-sn-multi, networkAddress: 10.31.0.0, cidr: 24 }]`,
-   `errors []`, `warnings []`, `canCommit true`.
-4. Confirm Import clicked. SQL on the fresh catalog:
-   `1|rig-13-b3p2-multi|10.31.0.0|16|NULL` and `2|rig-13-b3p2-sn-multi|10.31.0.0|24|1`. Nothing for
-   `10.31.1.0/24`.
-5. `GET /Subnet/Details/1`, verbatim:
-   `Unallocated IP Ranges — 10.31.1.0 … 10.31.255.254 … 65,279 IP addresses … [Create Subnet]`.
-6. Single-VNet wizard, same subnet: `GET /Azure/GetSubnets?vnetResourceId=…/rig-13-b3p2-multi&subnetId=1`
-   returned **one** entry —
-   `{"resourceId":"…/subnets/rig-13-b3p2-sn-multi","name":"rig-13-b3p2-sn-multi","addressPrefix":"10.31.0.0/24","hasMultipleAddressSchemes":false,"fullyEncompassesVNetPrefix":false}`
-   — and `hasMultipleAddressSchemes` is `false` (it is IPv4-only), so not even the dual-stack badge
-   fires. Matches the `break; // Take only the first valid IPv4 address` at `AzureService.cs:275`.
+_The 256-address difference is exactly the dropped /24. On the unfixed build BASTET offered a *Create
+Subnet* button over a range Azure had already assigned; on the fixed build that range is child subnet
+id 3 and is absent from the free list. Persisted rows on the fixed build:_
 
-Instance killed by captured PID 442806, catalog dropped, `git status --porcelain` empty.
+```
+2|rec13-sn-multi (10.41.0.0/24)|10.41.0.0|24|.../subnets/rec13-sn-multi
+3|rec13-sn-multi (10.41.1.0/24)|10.41.1.0|24|.../subnets/rec13-sn-multi
+4|rec13-sn-single             |10.41.5.0|24|.../subnets/rec13-sn-single
+```
 
-**Fix.** Emit one selectable entry per IPv4 prefix: in `GetVNetInventory` (`AzureService.cs:350-368`)
-and `GetCompatibleSubnets` (`AzureService.cs:239-277`), produce a `BulkAzureSubnetViewModel` per
-element of `ExtractIpv4Prefixes(subnet)` rather than per Azure subnet, each carrying the same
-`ResourceId`. The reconciler already copes with several Bastet rows sharing one Azure subnet id,
-because `EvaluateSubnetLevel` tests *membership* in `Ipv4PrefixesOf` (`AzureReconciler.cs:376`).
+_**The bulk wizard and the reconciler were driven too, including the counter-test that proves the
+reconciler still discriminates rather than merely having gone quiet.** `GET /Azure/BulkGetVNets`
+returned both prefixes as separate rows, each resolving to its own Bastet subnet
+(`Already imported as Bastet subnet 'rec13-sn-multi (10.41.1.0/24)'.`) and each carrying the full
+`ipv4AddressPrefixes` list. `POST /Azure/ReconcileScan` with both prefixes live reported
+**0 items, 0 warnings** — no false drift on the row linked at the second prefix. Then
+`az network vnet subnet update --address-prefixes 10.41.0.0/24` genuinely removed the second prefix in
+Azure, and the same scan reported **exactly 1 item**: subnetId 3, `SubnetPrefixChanged`, reason
+*"The Azure subnet still exists but its address prefix is now 10.41.0.0/24, not 10.41.1.0/24."* The
+fixture was then restored._
 
-> **The finder's fix was corrected by the verifier on two points.**
->
-> 1. **Wrong claim, removed.** The original said *"`DisambiguateName` already handles the resulting
->    name collision."* That is true of the **bulk** planner only (`AzureBulkImportPlanner.cs:485-527`,
->    where `usedNames` + `DisambiguateName` run per plan item). The **single-VNet** commit path has no
->    disambiguation at all — `SubnetController.Azure.cs:404` writes `Name = subnet.Name` straight from
->    the posted view model, and `Subnet.Name` carries a non-unique index, so two identically-named rows
->    would persist silently. If the single-VNet leg is taken, `BatchCreateChildSubnetsCore` needs the
->    same used-names pass the planner has, or the wizard must suffix the prefix into the name it posts
->    at `_ImportScripts.cshtml:330`.
-> 2. **Confused claim, removed.** The original said `AnnotateSubnet` *"must then compare per prefix
->    rather than against `subnet.AddressPrefix`."* That is a no-op — once one view model is emitted per
->    prefix, `subnet.AddressPrefix` **is** the per-prefix value, and `AnnotateSubnet`
->    (`AzureBulkImportPlanner.cs:259-307`) needs no change. `encompassesAPrefix` at `:267-268` already
->    compares against the *VNet's* prefix list, which is correct as it stands. Making the instructed
->    change would be a regression.
->
-> Confirmed sound: the duplicate-`AzureResourceId` reasoning. Nothing keys on it in a way that breaks —
-> `AzureSubnetSnapshotService` keys on `SubnetId`/`ParentSubnetId`, `SubnetController.AzureReconcile.cs:78`
-> keys `stillStale` on `SubnetId`, and `AzureService.cs:537`'s `ToDictionary` is over resource ids that
-> `ConfirmResourcesAsync` has already deduplicated at `:524-526`, so a repeated id cannot collide. And
-> `p.Subnets.Count > 1` beside a `FullyEncompasses` entry (`AzureBulkImportPlanner.cs:464`) cannot
-> false-fire, because a prefix equal to the whole VNet prefix leaves no room for the subnet's second
-> prefix.
+_**Tests: 738 → 754** (+16, no test removed). Two failed against the unfixed code for the defect's own
+reason — `Assert.Equal() Failure: Values differ` on the distinct-name assertion, both prefixes having
+persisted under one name. The rest are guards that must never fail: single-prefix subnets keep their
+plain name and shape; ARM reporting a prefix in both the singular property and the collection collapses
+to one row; a prefix occupied by an unrelated Bastet subnet stays `Blocked`; two rows covering the same
+range are still refused by overlap validation rather than renamed and created; and the reconciler
+reports no drift for a row linked at the second prefix but still reports it when the prefix genuinely
+goes. `dotnet build --no-incremental`: 0 warnings._
 
-**Cheaper interim — stop the silence, one file.** Round 6 declined the full change as *"a feature
-change, not a bug fix"*, so an interim that only removes the invisibility is worth having. In
-`GetVNetInventory` (`AzureService.cs:358-367`) and `GetCompatibleSubnets`, when
-`ExtractIpv4Prefixes(subnet)` yields more than one, set `Reason` to name the prefixes that will **not**
-be imported, and have `AnnotateSubnet` *preserve* rather than null that reason (it currently overwrites
-`Reason = null` at `:294` on the Available path). Add the same sentence to `BulkImportPlanItem.Warnings`
-so it survives into step 3 and into the commit-time divergence text. One Bastet row per Azure subnet —
-no data-model change, no name collisions, no new reconciler tests — while removing the property the
-finding is actually about. It does **not** close the "Details page advertises the range as free" half,
-so it is an interim, not a substitute.
-
-**Harder interim — refuse rather than truncate.** Server-side, so the browser is not the authority: in
-`AzureBulkImportPlanner.AnnotateSubnet` (`AzureBulkImportPlanner.cs:259`) set `Status = Blocked`,
-`IsSelectable = false` and a reason naming every prefix whenever `subnet.Ipv4AddressPrefixes.Count > 1`,
-plus the matching hard error in `BuildPlanItem` so a crafted or stale POST is refused too. The operator
-cannot import the subnet, but BASTET never asserts that an Azure-assigned range is free.
-
-### Disposition — fix it, and why the standing deferral is overturned
-
-**This is to be fixed. The interims above are fallbacks if the full change cannot ship immediately;
-they are not the resolution.** The wizards must offer **one selectable entry per IPv4 prefix**, and
-the operator imports the ones they want. No auto-import, no guessing, no truncation.
-
-Round 6 deferred this as *"creating several Bastet subnets from one Azure subnet, which is a feature
-change, not a bug fix."* **That framing is rejected, on the codebase's own evidence:**
-
-- **The pattern already exists in this application, one level up.** `AzureBulkImportPlanner.cs:165` is
-  `vnet.Prefixes = [.. vnet.Ipv4AddressPrefixes.Select(p => AnnotatePrefix(p, vnet, existingSubnets))]`
-  — a prefix list fanned out into one entry per prefix. A **VNet** with four IPv4 prefixes is handled
-  correctly today, and a VNet with four **subnets** is handled correctly today. Only a **subnet** with
-  several prefixes is truncated. Applying an established internal pattern at the level where it was
-  missed is not a new feature.
-- **The truncation predates the problem it fails to handle.** The `break; // Take only the first valid
-  IPv4 address` (`AzureService.cs:275`) comes from `9f220e0` (2025-05-01), the original Azure import
-  feature — written when an Azure subnet could not have more than one IPv4 prefix. Azure changed that
-  in September 2025. This is code that was correct when written and became wrong when the external
-  contract moved: a regression against reality, not an unimplemented feature.
-- **The data has been ready since round 6.** `BulkAzureSubnetViewModel.Ipv4AddressPrefixes` is
-  populated at `AzureService.cs:366`, sits one line below the truncation, and no view or planner path
-  reads it. Round 6 plumbed it specifically so that whoever closed this would not have to re-plumb ARM.
-  The remaining work is rendering and naming, not integration.
-- **Azure's behaviour is confirmed against live ARM, not assumed.** This round ran
-  `az network vnet subnet create ... --address-prefixes 10.31.0.0/24 10.31.1.0/24`; ARM returned 200 and
-  reported `addressPrefix: null, addressPrefixes: ["10.31.0.0/24","10.31.1.0/24"]`. The singular field
-  going null once there are two is exactly what `AzureService.cs:390-395` already documents.
-
-**Deferral history — four rounds, no decision.** Filed as round 6 `F2`; the reconciler half was fixed
-and the import half deferred on cost. It rode the watch list through rounds 7, 8 and 9, then fell off
-in rounds 10-12 without ever being closed or formally accepted. Round 13 rediscovered it independently
-and measured the operator-visible consequence for the first time. **The consequence was never priced in
-any of the four deferrals** — only the cost of the fix was. That is the error being corrected here.
-
-**Definition of done:** a multi-prefix Azure subnet presents every one of its IPv4 prefixes as a
-separate selectable row in both wizards; importing all of them produces one Bastet row per prefix with
-non-colliding names through **both** commit paths (the single-VNet path needs the planner's
-`usedNames`/`DisambiguateName` pass — see the watch-list entry on `SubnetController.Azure.cs:404`); and
-no range Azure has assigned is ever shown as unallocated. Regression test must fail against HEAD.
+_**Not done, deliberately.** The two interim mitigations the finding offered — a `Reason` naming the
+dropped prefixes, and blocking multi-prefix subnets outright — are moot now that no prefix is dropped;
+building either would leave dead advisory code. The finding's remark that a fully-encompassing subnet
+"cannot false-fire" because `p.Subnets.Count > 1` was left as it stands, verified rather than changed:
+a prefix equal to the whole VNet prefix leaves no room for a second prefix on the same subnet, so the
+encompassing path cannot now be reached with siblings from one Azure subnet._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-13.md
+++ b/docs/AUDIT-FINDINGS-13.md
@@ -8,7 +8,7 @@
 | Build | **0 warnings, 0 errors** |
 | Tests | **738 passed**, 0 failed, 0 skipped |
 | Date | 2026-08-02 |
-| Status | **1 fixed** (M1, high), **2 open** — 1 low, 1 info |
+| Status | **2 fixed** (M1 high, M2 low), **1 open** — 1 info |
 
 > **Post-round amendment (2026-08-02, by the repository owner).** `M1` was filed by this round at
 > **medium** and has been **re-rated HIGH**, and it is **to be fixed, not deferred again**. The round's
@@ -206,141 +206,86 @@ encompassing path cannot now be reached with siblings from one Azure subnet._
 
 ## M2 — Round 12's `L4` double-commit guard was applied only to the bulk-import wizard; the reconcile delete wizard, edited in the same commit for `L3`, still re-arms its Confirm Delete button mid-flight
 
-**Severity:** Low  **Tag:** `[x1]`  **Beat:** 6
-**File:** `src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml:76`
-(supporting: `:14`, `:345-408`, `:410`, `:416`, `:435-442`, `:453`, `:489`;
-server: `SubnetController.AzureReconcile.cs:78-93`, `:144-149`, `:193-204`)
+_M2 is fixed and committed. The reconcile delete wizard now carries the same in-flight guard `L4` gave
+the bulk-import wizard, so neither re-arm route can fire a second DELETE._
 
-**Confidence:** **confirmed.** Both re-arm routes driven end to end on the HEAD build, and the fix
-built and re-run on a patched scratch copy.
+_**What was done**, exactly as the finding proposed — it was assessed sound and needed no correction.
+`_ReconcileScripts.cshtml` gains a module-scope `deleting` flag beside `confirmedIds`; `beforeSend`
+sets it; `complete` clears it and then calls `refreshDeleteButton()`; and the single choke point at
+`refreshDeleteButton` became `deleting || !hasSnapshot || !confirmed`. Both re-arm routes run through
+`refreshDeleteButton`, so that one conjunct closes both. No `committed`-style flag was added: the
+button is already `.addClass("d-none")`'d on success, so the post-success re-enable is unreachable by
+a click — confirmed by reading, and by the `hidden` field captured in every run below._
 
-**Failure scenario.** Round 12's `L4` added `committing`/`committed` to `_BulkScripts.cshtml` so
-re-entering step 4 cannot fire a second commit. The same commit (`78fc4c9`) also edited
-`_ReconcileScripts.cshtml` for `L3` but left the identical re-arm in the only Azure-driven DELETE path.
-`refreshDeleteButton()` (`:73-77`) gates `#rec-confirm-delete-btn` on `confirmedIds` + the typed word
-only — **no in-flight flag** — and it is reachable from two ordinary handlers while a delete POST is
-still running: `$("#rec-confirmation").on("input", refreshDeleteButton)` (`:410`) and the
-`#rec-go-confirm-btn` rebuild (`:345-408`). `beforeSend` (`:435`) disables the button but sets no flag,
-so anything that calls `refreshDeleteButton` re-enables it.
-
-Concrete inputs: an Admin imports Azure VNet `rig-13-b6p2-vnet` (10.171.0.0/16 + child
-`rig-13-b6p2-sn-a` 10.171.0.0/24); the VNet is then deleted in Azure. On */Azure/Reconcile* the
-operator scans, ticks the stale row, types `approved`, clicks Confirm Delete.
-`POST /Subnet/BulkDeleteStaleAzureSubnets` runs a **live ARM re-scan before it touches the DB**, so it
-is in flight for ~0.7 s on the rig and multi-second against a real subscription. While the spinner is
-up the operator either **(a)** clicks Back to Review, unticks/re-ticks, Next, retypes `approved`,
-Confirm Delete, or **(b)** simply presses one key and Backspace in the confirmation box. Either
-re-arms the button and a second identical DELETE is posted.
-
-**Wrong output.** The second request's ARM re-scan overlaps the first request's transaction, so its
-`stillStale` map is built *before* the rows are archived and it does **not** hit the 409 at
-`SubnetController.AzureReconcile.cs:80-92`. It queues on `_localGate`, finds every
-`context.Subnets.FindAsync(id)` returns null (`:143-148`), skips them all, and returns
-**HTTP 200 `{"success":true,"targetsDeleted":0,"subnetsArchived":0}`**. That response lands last, so
-its `TempData["SuccessMessage"]` (`:193-195`) overwrites the first one. The operator is redirected to
-*/Subnet* and reads **"Azure reconcile: deleted 0 stale subnet(s), archiving 0 subnet(s) and 0 host IP
-assignment(s) in total."** while `DeletedSubnets` in fact holds both archived rows. This is strictly
-worse than the `L4` case round 12 fixed: there the server *refused* the second attempt; here it accepts
-it and reports a destructive operation as a no-op.
-
-This is not a narrow race. The two requests are ~50 ms apart while the ARM leg is ~700 ms, so the
-200/zero outcome is the **normal** result of a double submit here — it happened on every run.
-
-**Reproduction — ran it.** App on 127.0.0.1:5317, catalog `bastet_rig13_verc2`, SP A,
-Playwright/Chromium, live ARM.
-
-Fixture built for real:
+_**Reproduced first, on the HEAD build, before anything was changed.** Fixture: Azure VNet
+`rec13-stale` (10.42.0.0/16, child `rec13-stale-sn` 10.42.1.0/24) created, imported through the real
+wizard, then deleted in Azure so both Bastet rows went stale. Chromium via Playwright, app on
+127.0.0.1:5401 against SQL Server 2022, live ARM. Route (b), one keystroke plus Backspace:_
 
 ```
-az network vnet create -g bastet-visible -n rig-13-c2ver-vnet \
-  --address-prefixes 10.181.0.0/16 --subnet-name rig-13-c2ver-sn-a --subnet-prefixes 10.181.0.0/24
-# two Azure-linked Bastet rows seeded with those exact ARM ids, then:
-az network vnet delete -g bastet-visible -n rig-13-c2ver-vnet   -> DELETED
+K2 1.432 {'delDisabled': True,  'progressHidden': False}     <- delete in flight
+K4 1.454 {'delDisabled': False, 'progressHidden': False}     <- RE-ARMED, still in flight
+K5 1.482 SECOND CLICK SENT
+REQ  1.432 BulkDeleteStaleAzureSubnets
+REQ  1.481 BulkDeleteStaleAzureSubnets                        <- 49 ms apart
+RESP 2.450 200 {"targetsDeleted":1,"subnetsArchived":2,"hostIpsArchived":0}
+RESP 2.450 200 {"targetsDeleted":0,"subnetsArchived":0,"hostIpsArchived":0}
 ```
 
-Route **(b)** — one keystroke plus Backspace, no navigation, HEAD build:
+_and the database immediately after, showing the response the operator sees is the false one:_
 
 ```
-S2 2.447 stale rows: ['1', '2'] ['rig-13-c2ver-vnet', 'rig-13-c2ver-sn-a']
-K1 2.555 first click sent
-K2 2.558 {'delDisabled': True,  'progressHidden': False}
-K3 2.562 typed "x":  {'delDisabled': True,  'confirmVal': 'approvedx'}
-K4 2.565 Backspace:  {'delDisabled': False, 'progressHidden': False, 'confirmVal': 'approved'}
-K5 2.604 SECOND CLICK SENT
-(2.555, 'REQ',  'BulkDeleteStaleAzureSubnets')
-(2.604, 'REQ',  'BulkDeleteStaleAzureSubnets')
-(3.333, 'RESP', 200, '{"success":true,"redirectUrl":"/Subnet","targetsDeleted":1,"subnetsArchived":2,"hostIpsArchived":0}')
-(3.408, 'RESP', 200, '{"success":true,"redirectUrl":"/Subnet","targetsDeleted":0,"subnetsArchived":0,"hostIpsArchived":0}')
-K8 landed message: Azure reconcile: deleted 0 stale subnet(s), archiving 0 subnet(s) and 0 host IP assignment(s) in total.
-pageerrors: []
+live=4      DeletedSubnets: 5|rec13-stale|10.42.0.0|16
+                            6|rec13-stale-sn|10.42.1.0|24
 ```
 
-Route **(a)** — Back to Review → untick/re-tick → Next → retype → Confirm, HEAD build:
+_Two rows archived while the last response reported zero._
+
+_**Both routes then re-run against the fixed build**, each on its own fresh live fixture rather than a
+replay:_
 
 ```
-A3 2.088 {'delDisabled': True,  'progressHidden': False}
-A4 2.122 Back to Review:       {'delDisabled': True,  'progressHidden': False}
-A5 2.187 untick+retick:        {'delDisabled': True,  'progressHidden': False}
-A6 2.225 re-confirmed+retyped: {'delDisabled': False, 'progressHidden': False}   <- re-armed, delete still in flight
-A7 2.255 SECOND CLICK SENT
-RESP 2.800 200 targetsDeleted:1 subnetsArchived:2
-RESP 2.830 200 targetsDeleted:0 subnetsArchived:0
-A10 landed: deleted 0 stale subnet(s), archiving 0 subnet(s) and 0 host IP assignment(s) in total.
+route (b)  fixture rec13-stale2 (10.43.0.0/16)
+  K4 1.963 {'delDisabled': True} confirmVal='approved'  -> second click impossible
+  one REQ; RESP 200 {"targetsDeleted":1,"subnetsArchived":2}
+
+route (a)  fixture rec13-stale3 (10.44.0.0/16)   Back to Review -> untick/re-tick -> Next -> retype
+  A4 2.567 {'delDisabled': True}    back to review, delete still in flight
+  A5 2.651 {'delDisabled': True}    untick + re-tick
+  A6 2.694 {'delDisabled': True}    re-confirmed and retyped -> second click impossible
+  one REQ; RESP 200 {"targetsDeleted":1,"subnetsArchived":2}
 ```
 
-Database after each run:
+_**The non-regression leg matters more than either**, because a guard that made a failed delete
+un-retryable would be a worse bug than the one being fixed. Fixture `rec13-stale4` (10.45.0.0/16) was
+imported, deleted in Azure, taken to the confirm screen — and then the VNet was **re-created in Azure
+out of band**, inside the wizard's window, so the commit's own ARM re-scan would find it live:_
 
 ```
-SELECT COUNT(*) FROM Subnets; SELECT OriginalId,Name,NetworkAddress,Cidr FROM DeletedSubnets
-LiveSubnets 0
-2|rig-13-c2ver-sn-a|10.181.0.0|24
-1|rig-13-c2ver-vnet|10.181.0.0|16
+R1 after failed delete: {'delDisabled': False, 'hidden': False, 'progressHidden': True}
+R2 error: '2 of the selected subnet(s) are no longer reported as deleted in Azure. Nothing was
+           deleted. Re-run the scan and review the results.'
+R3 retryable (enabled and visible): True
+RESP 409 {"success":false,"error":"...no longer reported as deleted in Azure..."}
 ```
 
-Two subnets archived while the operator is told zero were.
+_`complete` runs after `error`, so clearing the flag there lets `showCommitError`'s own
+`refreshDeleteButton()` bring the button back. `pageerrors: []` on every run of both builds._
 
-**The fix was built and run, not read.** Patched scratch copy, port 5318, catalog
-`bastet_rig13_verc2fix`, `dotnet build` 0 warnings / 0 errors:
+_**No permanent test ships with this.** The defect is client-side wizard state — jQuery handlers,
+`disabled` attributes and AJAX lifecycle callbacks — and the suite has no browser seam
+(`Microsoft.Playwright` is not referenced by `Bastet.Tests`, and the rig rules forbid adding
+scaffolding to the repo for one finding). The measurements above are the record. Test count is
+unchanged at **754**; `dotnet build --no-incremental` 0 warnings._
 
-```
-route b: K4 {'delDisabled': True}  -> second click impossible; one POST; landed "deleted 1 stale subnet(s), archiving 2 subnet(s)"
-route a: A6 {'delDisabled': True}  -> refused;                one POST; landed "deleted 1 stale subnet(s), archiving 2 subnet(s)"
-non-regression (real 409 forced by an out-of-band row delete between confirm and click):
-   HEAD    F3 {'delDisabled': False, 'hidden': False, msg '1 of the selected subnet(s) are no longer reported as deleted in Azure...'}
-   PATCHED F3 {'delDisabled': False, 'hidden': False, msg identical}
-pageerrors: [] on every run of both builds
-```
-
-Both instances killed by captured PID (443034, 448206 — never `pkill`), both catalogs dropped, ports
-free, `git status --porcelain` on the repo empty.
-
-**Fix — verdict: sound, as proposed.** Mirror `L4` in `_ReconcileScripts.cshtml`:
-
-- declare `let deleting = false;` beside `confirmedIds` (`:14`);
-- set `deleting = true` in the delete AJAX `beforeSend` (`:435`);
-- in `complete` (`:440-442`) set `deleting = false;` then call `refreshDeleteButton();` — `complete`
-  runs *after* `success`/`error`, so `showCommitError`'s existing `refreshDeleteButton()` at `:489`
-  still leaves a genuinely-failed delete retryable (verified by the non-regression leg above);
-- make the single choke point honest at `:76`:
-  `$("#rec-confirm-delete-btn").prop("disabled", deleting || !hasSnapshot || !confirmed);`
-
-Because both re-arm routes go through `refreshDeleteButton`, that one conjunct closes both. A
-`committed`-style flag is **not** needed: `#rec-confirm-delete-btn` is already `.addClass("d-none")`'d
-on success (`:453`), so the post-success re-enable is unreachable by a click.
-
-**Optional server-side half — do it separately.** `SubnetController.AzureReconcile.cs:193-204` reports
-`success:true` and stamps `TempData["SuccessMessage"]` even when every requested id resolved to null and
-`targetsDeleted == 0`. Returning the 409 shape instead when `targetsDeleted == 0` with a non-empty
-`SubnetIds` cannot false-fire on a legitimate single request (the smallest-CIDR target always resolves,
-so `targetsDeleted >= 1`), but it would convert the honest out-of-band-concurrent-delete case into an
-error *after* a transaction that has already committed. The client guard alone closes both reachable
-routes; ship that first. This half was **not** built.
-
-**Cheaper interim — one line, no state to reason about.** Guard the click handler itself. In
-`$("#rec-confirm-delete-btn").on("click", …)` at `:416`, after `const ids = confirmedIds || [];`, add a
-module-scope `deleting` flag and `if (deleting) { return; }` before the `$.ajax` call, setting it in
-`beforeSend` and clearing it in `complete`. The button still visually re-arms, but no second POST is
-issued, so the false "deleted 0" message cannot be produced.
+_**The server-side half was deliberately not built**, as the finding itself recommended.
+`SubnetController.AzureReconcile.cs:193-204` still reports `success:true` when every requested id
+resolved to null. Returning the 409 shape on `targetsDeleted == 0` with a non-empty `SubnetIds` would
+convert an honest out-of-band concurrent delete into an error **after** a transaction that has already
+committed — a worse outcome than the message it fixes. The client guard closes both reachable routes;
+the underlying property (no idempotency token, no dedup, no per-user in-flight lock on
+`BulkDeleteStaleAzureSubnets`) stays on the watch list for anything that can post it twice without a
+browser._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-13.md
+++ b/docs/AUDIT-FINDINGS-13.md
@@ -8,7 +8,7 @@
 | Build | **0 warnings, 0 errors** |
 | Tests | **738 passed**, 0 failed, 0 skipped |
 | Date | 2026-08-02 |
-| Status | **2 fixed** (M1 high, M2 low), **1 open** — 1 info |
+| Status | **all 3 fixed** — M1 high, M2 low, M3 info |
 
 > **Post-round amendment (2026-08-02, by the repository owner).** `M1` was filed by this round at
 > **medium** and has been **re-rated HIGH**, and it is **to be fixed, not deferred again**. The round's
@@ -293,101 +293,66 @@ browser._
 
 ## M3 — Azure import re-appends the "fully allocated" note to the target's Description on every run, so a wizard → un-mark → wizard cycle persists the same sentence N times
 
-**Severity:** Info  **Tag:** `[x1]`  **Beat:** 5
-**File:** `src/Bastet/Controllers/SubnetController.Azure.cs:85`
-(callers: `SubnetController.Azure.cs:370`, `SubnetController.BulkAzure.cs:417`)
+_M3 is fixed and committed. The note is now written at most once, and clearing the flag removes it._
 
-**Confidence:** **confirmed.** Four cycles driven through the shipped forms and the persisted column
-read back.
+_**What was done — the finder's proposal was corrected before it was built, on both points the
+verifier raised.** The note logic moved out of `SubnetController.Azure.cs` into a new
+`Bastet.Services.FullyAllocatedNote` with `For`, `Strip` and `Append`, because the un-mark path needs
+the same strip and a private controller method could not be shared or tested.
+`AppendFullyAllocatedNote` is now a one-line delegation and keeps its signature, so its two callers
+(`SubnetController.Azure.cs:370`, `SubnetController.BulkAzure.cs:417`) are unchanged._
 
-**Failure scenario.** Azure VNet `rig-13-b5b-vnet` (10.99.0.0/24) has one subnet `rig-13-b5b-sn` whose
-prefix is the whole VNet prefix, so `GetCompatibleSubnets` returns it with
-`FullyEncompassesVNetPrefix=true`. Bastet subnet 10.99.0.0/24 exists. Running `/Azure/Import/{id}` and
-importing sets `IsFullyAllocated=1` and
-`Description = AppendFullyAllocatedNote(null, 'rig-13-b5b-sn')` (91 chars). The Details page's own
-*Mark as Not Fully Allocated* form (`Views/Subnet/Details/_HostIpAssignments.cshtml:102`, POST
-`HostIp/SetAllocationStatus`) clears the flag but leaves the note. `/Azure/Import/{id}` is now
-reachable again (no children, no host IPs, not fully allocated), so the same import runs again — and
-`AppendFullyAllocatedNote` has **no idempotence check** (`:94` is a bare
-`string combined = $"{existingDescription}\n{note}"`), so it concatenates the identical sentence again.
+_`Strip` removes any line that **both** starts with `Fully allocated by Azure subnet '` and ends with
+`' which encompasses the entire address space.`, ordinal and whole-line after trimming. The finder's
+alternative — a loose pattern matching "the shape" of the note — was **not** used: it can delete
+operator-authored text and would break the helper's own documented contract that existing text is
+never sacrificed. Four `[Theory]` cases pin that, including
+`"Fully allocated by Azure subnet 'sn' which encompasses the entire address space, per ticket 42."`,
+which a loose match would have destroyed and which is kept verbatim. Anchoring both ends also closes
+the gap the verifier found in the finder's own version: exact equality against the *current* note
+misses a note written before the Azure subnet was renamed, so two distinct notes accumulated._
 
-**Wrong state** after four ordinary UI cycles: `Description` is the same 91-char sentence four times
-separated by newlines (367 chars) on a row whose `IsFullyAllocated` is **0** — the description asserts
-*"Fully allocated by Azure subnet 'rig-13-b5b-sn' which encompasses the entire address space."* four
-times about a subnet that is not fully allocated. Growth is bounded only by the 1000-char cap (~10
-repeats), after which the helper silently discards the note. `SubnetController.BulkAzure.cs:417` calls
-the same helper, so the bulk wizard has the identical write.
+_**The un-mark mirror was required, not "ideally", and is built.** `HostIpController.SetAllocationStatus`
+(`HostIpController.cs:735`) now strips the note when it clears the flag, nulling the column if nothing
+else remains. Without it the finding's own scenario still ends with a description asserting
+"fully allocated by Azure subnet ..." about a row whose `IsFullyAllocated` is 0._
 
-**Reproduction — ran it.** Own app on 127.0.0.1:5273 (PID 442252), own catalog `bastet_rig13_v7c`,
-SP A. Reused the existing fixture read-only; created no new Azure resource.
+_**The overflow contract is unchanged and is now better.** If the deduped text plus the note still
+exceeds `MaxSubnetDescriptionLength` the note is dropped and the existing text kept whole, exactly as
+before — overflowing the column fails the insert and rolls back the whole import behind a generic
+error. Because stripping happens first, a description that used to overflow can now fit: pinned by a
+test where 850 characters of operator text plus three stacked notes exceeds the cap and, after the
+strip, the text plus one note does not._
 
-1. Real ARM through the app:
-   `GET /Azure/GetSubnets?vnetResourceId=…/rig-13-b5b-vnet&subnetId=1` →
-   `{"success":true,"subnets":[{"name":"rig-13-b5b-sn","addressPrefix":"10.99.0.0/24","hasMultipleAddressSchemes":false,"fullyEncompassesVNetPrefix":true}]}`
-2. Four cycles of the exact form `_SubnetList.cshtml` posts, each followed by the Details page's own
-   un-mark form, both with a live `__RequestVerificationToken` scraped from the rendered page:
-
-```
-cycle 1: importpage=200 import=302->/Subnet/Details/1 unmark=302 dblen|flag=91|0
-cycle 2: importpage=200 import=302->/Subnet/Details/1 unmark=302 dblen|flag=183|0
-cycle 3: importpage=200 import=302->/Subnet/Details/1 unmark=302 dblen|flag=275|0
-cycle 4: importpage=200 import=302->/Subnet/Details/1 unmark=302 dblen|flag=367|0
-```
-
-3. The persisted row (`sqlcmd … -d bastet_rig13_v7c`, newlines rendered as `<NL>`):
+_**Proved by A/B on a live fixture, not by reading.** Azure VNet `rec13-fa` (10.46.0.0/24) whose only
+subnet `rec13-fa-sn` covers the whole VNet prefix, so `GetSubnets` returns it with
+`fullyEncompassesVNetPrefix: true`. Four cycles of the real import form followed by the Details page's
+own **Mark as Not Fully Allocated** form, each with a live antiforgery token, against SQL Server 2022
+and live ARM. Unfixed build was a clone at `ec9c866` on port 5402/catalog `bastet_rec13_m3`; fixed on
+5401/`bastet_rec13`:_
 
 ```
-1 | rig-13-b5b-vnet | full=0 | len=367 |
-Fully allocated by Azure subnet 'rig-13-b5b-sn' which encompasses the entire address space. <NL>
-(same sentence) <NL> (same sentence) <NL> (same sentence)
+after 4 import -> un-mark cycles     IsFullyAllocated   DescLen
+  unfixed (ec9c866)                        0             359      <- 4 x 89 chars + 3 newlines
+  fixed                                    0               0      <- Description is NULL
+fixed, one import with no un-mark          1              89      <- exactly one note, append works
 ```
 
-+92 bytes per repeat, on a row whose `IsFullyAllocated` is 0. Instance killed by captured PID 442252,
-catalog dropped, `git status --porcelain` empty.
+_359 characters of the identical sentence four times on a row that is not fully allocated, versus
+nothing. The middle row is the finding; the bottom row is the guard that the fix did not simply stop
+writing the note._
 
-**Fix — the finder's proposal was corrected.** The core idea (dedupe before append) is right, but as
-written it had one unsound branch and one gap.
+_**Tests: 754 → 771** (+17), the first coverage `AppendFullyAllocatedNote` has ever had — the finding
+noted it had none. They pin idempotence across four appends, the renamed-Azure-subnet case, operator
+text surviving repeated appends, the four look-alike prose strings that must **not** be stripped,
+`Strip` clearing several stacked notes (the state existing rows are already in), both overflow
+branches, and the first-import case. `dotnet build --no-incremental`: 0 warnings._
 
-> **Unsound branch, removed.** The original offered, as an alternative, stripping lines *"matching the
-> `Fully allocated by Azure subnet '…' which encompasses the entire address space.` shape"* via a loose
-> pattern. That can delete operator-authored text and breaks the helper's own documented contract at
-> `:79-84` (*"Existing text is never sacrificed for the note"*). **Do not use a loose shape match.**
->
-> **Gap.** Exact-line equality against the *current* note alone does not dedupe a note written for a
-> differently-named Azure subnet (rename the Azure subnet between cycles and two distinct notes
-> accumulate), and it leaves the note asserting a state the row no longer has.
-
-Corrected fix, minimal and safe:
-
-1. In `AppendFullyAllocatedNote`, split `existingDescription` on `\n` and drop any line that **both**
-   starts with the literal `"Fully allocated by Azure subnet '"` **and** ends with the literal
-   `"' which encompasses the entire address space."` (ordinal, whole line — narrow enough that operator
-   prose cannot collide, wide enough to catch a renamed Azure subnet). Re-join, then append once.
-2. Keep the overflow contract unchanged: if the deduped-plus-note string still exceeds
-   `MaxSubnetDescriptionLength`, return the deduped existing description rather than truncating
-   mid-note. Dedupe alone already frees ~92 bytes per stale copy, so this is strictly better than today.
-3. Give `HostIpController.SetAllocationStatus` the mirror when it clears the flag: apply the same
-   line-strip to `subnet.Description` so the row stops asserting fully-allocated after an un-mark. The
-   finder listed this as *"ideally"*; it is **required** — without it the finding's own scenario still
-   ends with a stale sentence.
-4. Both call sites are fixed by (1) since they share the helper; factor the strip into a private static
-   so (3) can reuse it.
-
-This is pinnable by ordinary unit tests on the helper — no rendered-view seam needed — which is worth
-doing, since the suite has **no coverage of `AppendFullyAllocatedNote` at all**.
-
-**Cheaper interim — one line.** In `AppendFullyAllocatedNote`, before building `combined`:
-`if (existingDescription is not null && existingDescription.Contains(note, StringComparison.Ordinal)) return existingDescription;`
-Stops the duplication with no change to first-import behaviour and no change to either call site.
-
-**Why Info and not Low.** `docs/AUDIT-FINDINGS-10.md:533` already records the sibling half verbatim as
-a residue of a round-10 kill — *"after un-flagging, the appended note … stays in the description
-(`DescLen 91` with `IsFullyAllocated=0`)"* — which establishes append-and-preserve as deliberate
-design. What is new here is that the append is not **idempotent**, so the residue accumulates. That is
-real but strictly cosmetic and self-limiting: bounded by the 1000-char cap, after which the helper
-correctly drops the note and keeps existing text; no operator-authored text is ever destroyed (a
-pre-existing 950-char description makes `combined.Length > 1000` on the very first import, so nothing
-accumulates); and no count, validation or reconcile decision reads `Description`.
+_**Not done, deliberately.** The one-line interim (`existingDescription.Contains(note)`) was not used:
+it is subsumed by the strip and would not have handled the renamed-subnet case. Nothing was done about
+descriptions **already** carrying stacked notes from before this fix — no migration, no backfill. They
+are cosmetic, `Strip` removes every one of them the next time either path touches the row, and a data
+migration rewriting operator-visible free text is a far larger risk than the residue it would tidy._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-13.md
+++ b/docs/AUDIT-FINDINGS-13.md
@@ -8,7 +8,54 @@
 | Build | **0 warnings, 0 errors** |
 | Tests | **738 passed**, 0 failed, 0 skipped |
 | Date | 2026-08-02 |
-| Status | **all 3 fixed** — M1 high, M2 low, M3 info |
+| Status | **RECONCILED — all 3 fixed**, M1 high, M2 low, M3 info |
+
+## Reconciliation — final state
+
+| | Value |
+|---|---|
+| Build after clean rebuild (`bin`/`obj` deleted, `--no-incremental`) | **0 warnings, 0 errors** |
+| Tests | **771 passed**, 0 failed, 0 skipped (baseline 738, **+33**, none removed) |
+| Commits | `bbf8e42` M1, `ec9c866` M2, `950f838` M3 — one finding each |
+| `main` | unmoved at `78fc4c9` throughout |
+
+**Final sweep — clean.** 20 major areas requested against the real app on SQL Server 2022, asserting
+rendered content and page titles rather than status codes: home, subnet list/details/create/edit/delete,
+purge-deleted-subnets, deleted subnets, host IPs (all, per subnet, create, deleted, purge), all-deleted
+host IPs, all three Azure wizards, and a 404. Security headers (`X-Content-Type-Options`,
+`Referrer-Policy`, `Content-Security-Policy: frame-ancestors 'none'`) present on both a 200 and a 404.
+Application log carried **no `fail:` lines**; the only `warn:` lines were two EF Core
+`MultipleCollectionIncludeWarning` advisories from the pre-existing double-`Include` in
+`SubnetController.Delete.cs`, triggered by requesting the delete-confirm page and untouched by this
+round.
+
+**Both Azure surfaces driven end to end against live ARM**, including the two counter-tests that prove
+the reconciler *discriminates* rather than merely blocking — checking only one would let an
+over-blocking regression pass silently:
+
+- a genuinely deleted VNet was still **offered and deletable** (`VNetDeleted` + `SubnetDeleted`,
+  committed: `targetsDeleted:1, subnetsArchived:2`);
+- a Bastet row linked to a resource in the second resource group, which the running credential has no
+  assignment on, was **withheld and named**: *"…Azure denied access when asked about them directly …
+  They have been withheld from deletion: 'hidden-linked'."*
+
+Bulk import was driven preview-to-commit on a multi-prefix subnet (`createdChildSubnets: 2`), and the
+single-VNet wizard likewise, so both commit paths are covered rather than just the one M1 was filed
+against.
+
+**Deliberately not done** — each recorded in full in the relevant struck entry:
+
+- **M2's server-side half.** `BulkDeleteStaleAzureSubnets` still reports `success:true` when every
+  requested id resolved to null. Returning a 409 there would turn an honest out-of-band concurrent
+  delete into an error *after* a committed transaction. The client guard closes both reachable routes;
+  the underlying absence of an idempotency token stays on the watch list.
+- **No backfill for descriptions already carrying stacked notes.** `Strip` clears them the next time
+  either path touches the row; a data migration rewriting operator-visible free text is a larger risk
+  than the residue it would tidy.
+- **M1's two interim mitigations** are moot now that no prefix is dropped; building either would leave
+  dead advisory code.
+- **No browser test ships for M2.** The suite has no Playwright seam and the rig rules forbid adding
+  scaffolding to the repo for one finding; the measurements in the struck entry are the record.
 
 > **Post-round amendment (2026-08-02, by the repository owner).** `M1` was filed by this round at
 > **medium** and has been **re-rated HIGH**, and it is **to be fixed, not deferred again**. The round's

--- a/docs/AUDIT-FINDINGS-13.md
+++ b/docs/AUDIT-FINDINGS-13.md
@@ -1,0 +1,570 @@
+# Bastet — Round-13 Audit Findings
+
+| | Value |
+|---|---|
+| Round | **13** (finding letter **M** — findings are `M1` … `M3`, numbered sequentially across the whole file) |
+| Branch | `audit/round-13` |
+| HEAD at audit time | `78fc4c9` — *"Audit 12 Cleanup (#157)"* |
+| Build | **0 warnings, 0 errors** |
+| Tests | **738 passed**, 0 failed, 0 skipped |
+| Date | 2026-08-02 |
+| Status | **3 findings open** — 1 **high**, 1 low, 1 info |
+
+> **Post-round amendment (2026-08-02, by the repository owner).** `M1` was filed by this round at
+> **medium** and has been **re-rated HIGH**, and it is **to be fixed, not deferred again**. The round's
+> own reasoning for medium — *"it needs a multi-prefix Azure subnet to fire — not the default and not
+> common"* — prices the **frequency** of the trigger and ignores the **nature** of the output. BASTET's
+> entire purpose is to be the authority on which IPv4 ranges are allocated. A silent, permanent, false
+> *"this range is free"* is not a mid-severity defect in that product; it is the product failing at the
+> only question it exists to answer, and an operator who trusts the answer double-allocates addresses
+> Azure has already assigned. Rarity of trigger does not reduce the severity of a wrong allocation — it
+> only reduces how often you find out. See the amendment block inside `M1` for the disposition and the
+> reason the round-6 "feature change, not a bug fix" framing is rejected.
+
+## Verdict
+
+**`M1` requires action.** No finding in this round destroys data, leaks data, or bypasses
+authorisation — but `M1` causes BASTET to assert something false about IP allocation, which for this
+application is the failure that matters most.
+
+**Read `M1` first.** Both Azure import wizards silently drop every IPv4 prefix after the first when an
+Azure subnet carries several, and BASTET then advertises the dropped ranges as free space with a
+*Create Subnet* button over them. Measured, not argued: after importing a two-prefix Azure subnet, the
+target's Details page offered *"10.31.1.0 — 10.31.255.254, 65,279 IP addresses, [Create Subnet]"* over
+an /24 that Azure has already assigned. That is the one output an IPAM exists to prevent. It is also
+**not new**: it is the explicitly-deferred half of round 6's `F2`, which rode the watch list through
+rounds 7-9 and then fell off. What this round adds is the measurement of what the operator actually
+sees, which was never taken when the deferral was priced — and that measurement is precisely what
+overturns the deferral.
+
+**Read `M2` second, because it is a lesson about round 12.** `L4`'s double-commit guard was applied to
+the bulk-import wizard only. The reconcile delete wizard — edited in the *same commit* for `L3` — still
+re-arms its Confirm Delete button mid-flight, and one keystroke plus Backspace during the spinner fires
+a second DELETE. The server accepts it, returns `200 {"targetsDeleted":0}`, and its `TempData` banner
+overwrites the true one, so the operator lands on */Subnet* reading *"deleted 0 stale subnet(s)"* while
+two rows have in fact been archived. Strictly worse than the `L4` case round 12 shipped at Info (there
+the server *refused* the duplicate; here it accepts it and lies), but the archive itself is correct,
+complete and recoverable — hence low. The fix is four lines of inline JS, built and run.
+
+`M3` is cosmetic: a persisted description accumulates the same sentence once per import cycle. Filed
+for completeness.
+
+The rest of the value in this file is below the findings. **Six candidates were killed by verification**
+(section *Refuted*), including one `[x2]` that both passes found and one severity-high claim whose
+headline consequence turned out to reproduce at HEAD with the alleged defect playing no part. Those
+entries exist so round 14 does not spend twenty agents rediscovering them.
+
+## How this audit ran
+
+Eight beats over the codebase, each covering a distinct surface. **Two independent passes** ran every
+beat without sight of each other, plus a **deep sweep** on beats 1, 3, 6 and 7 — the Azure import,
+reconcile and wizard-state surfaces where the last several rounds have concentrated.
+
+Twenty finder agents were dispatched; twenty returned. They produced **12 raw findings**. Merge dropped
+**1** as a duplicate or out-of-scope shape, leaving **9 candidates**. Of those, **1 was tagged `[x2]`**
+and **8 `[x1]`**. Nineteen verifier agents then took the candidates adversarially — the job was to kill
+the finding, not to confirm it — with instructions to build the fix and run it rather than read it.
+**3 survived, 6 were refuted, and all 3 survivors were reproduced live** against the running
+application and, where the surface required it, live Azure Resource Manager.
+
+| Stage | Count |
+|---|---|
+| Finders dispatched | 20 |
+| Finders returned | 20 |
+| Raw findings | 12 |
+| Dropped at merge | 1 |
+| Candidates | 9 |
+| `[x2]` | 1 |
+| `[x1]` | 8 |
+| Verifiers | 19 |
+| Survived | 3 |
+| Refuted | 6 |
+| Reproduced live | 3 |
+
+### What `[x2]` and `[x1]` mean
+
+- **`[x2]`** — found independently by *both* passes. Two agents with no knowledge of each other landed
+  on the same defect.
+- **`[x1]`** — found by *one* pass only.
+
+**`[x1]` is weak evidence of absence, not evidence of a weak finding, and it got MORE scrutiny, not
+less.** One pass missing something is the expected outcome for a narrow surface — a multi-prefix Azure
+subnet, a mid-flight keystroke — because only one agent happened to build the fixture that exposes it.
+So every `[x1]` candidate drew a **second verifier on a reachability lens** (can a real user, with real
+roles, through shipped UI, actually get here?) and a **third verifier on disagreement** whenever the
+first two split. All three survivors in this file are `[x1]`. The single `[x2]` candidate, `C1`, was
+**refuted** — both passes agreeing is not verification either.
+
+---
+
+# High
+
+## M1 — Both Azure import wizards silently drop every IPv4 prefix after the first on a multi-prefix Azure subnet, and BASTET then reports the dropped ranges as free space
+
+**Severity:** **High** (filed by the round at medium; re-rated — see disposition below)  **Tag:** `[x1]`  **Beat:** 3
+**Disposition: MUST FIX. Not eligible for deferral to round 14.**
+**File:** `src/Bastet/Services/Azure/AzureService.cs:352`
+(siblings: `AzureService.cs:275`, `AzureService.cs:418-439`, `AzureBulkImportPlanner.cs:520-527`)
+
+**Confidence:** **confirmed.** Mechanism, the absence of any warning, the persisted rows and the
+free-space claim were each observed on a live rig, not inferred.
+
+**Failure scenario.** Azure has allowed several IPv4 prefixes on one subnet since Sept 2025 and ARM
+accepts it today. Given VNet `rig-13-b3p2-multi` (10.31.0.0/16) with one subnet
+`rig-13-b3p2-sn-multi` carrying `addressPrefixes: [10.31.0.0/24, 10.31.1.0/24]`, `GetVNetInventory`
+builds one `BulkAzureSubnetViewModel` per Azure subnet and sets
+`AddressPrefix = ExtractIpv4Prefix(subnet)` — the **first** prefix only (`AzureService.cs:352`). The
+single-VNet wizard does the same, with an explicit `break; // Take only the first valid IPv4 address`
+(`AzureService.cs:275`). The planner then creates exactly one Bastet child.
+
+The model *does* carry the full list (`BulkAzureSubnetViewModel.Ipv4AddressPrefixes`, populated at
+`AzureService.cs:366`) but its only consumer is the reconciler (`AzureReconciler.cs:391-394`) — no
+view and no planner path reads it. Nothing in either wizard, in the preview, or in `AnnotateSubnet`
+mentions the other prefixes.
+
+**Wrong output:** after import, `10.31.1.0/24` exists in Azure but nowhere in BASTET, and the target's
+Details page advertises it as unallocated with a *Create Subnet* button. An operator allocating from
+BASTET hands out addresses Azure has already assigned. The reconciler cannot correct it: it walks only
+Bastet rows that carry an `AzureResourceId` and has no "present in Azure, absent from Bastet" status at
+all. The wrong state is permanent and invisible.
+
+**Reproduction — ran it.** Own instance on port 5313, own catalog `bastet_rig13_v5c`, SP A, real
+Chromium via Playwright, live ARM. The multi-prefix fixture already existed; no new Azure resource was
+created.
+
+1. ARM ground truth, `az network vnet show -g bastet-visible -n rig-13-b3p2-multi`:
+   `space ["10.31.0.0/16"], subnets [{ n: rig-13-b3p2-sn-multi, p: null, ps: ["10.31.0.0/24","10.31.1.0/24"] }]`
+   — the singular `addressPrefix` really is `null` once there are two, exactly as the XML doc at
+   `AzureService.cs:390-396` says.
+2. `GET /Azure/BulkGetVNets` returned
+   `{ name: rig-13-b3p2-sn-multi, addressPrefix: "10.31.0.0/24", ipv4AddressPrefixes: ["10.31.0.0/24","10.31.1.0/24"], statusName: "Available", reason: null, isSelectable: true }`.
+   Step-2 card `innerText`, verbatim and complete:
+   `rig-13-b3p2-multi 10.31.0.0/16 / Will create a new Bastet subnet. / rig-13-b3p2-sn-multi 10.31.0.0/24`
+   — no badge, no reason line, no mention of `10.31.1.0/24`. Zero page errors.
+3. `POST /Azure/BulkImportPreview` → `childSubnets = [{ name: rig-13-b3p2-sn-multi, networkAddress: 10.31.0.0, cidr: 24 }]`,
+   `errors []`, `warnings []`, `canCommit true`.
+4. Confirm Import clicked. SQL on the fresh catalog:
+   `1|rig-13-b3p2-multi|10.31.0.0|16|NULL` and `2|rig-13-b3p2-sn-multi|10.31.0.0|24|1`. Nothing for
+   `10.31.1.0/24`.
+5. `GET /Subnet/Details/1`, verbatim:
+   `Unallocated IP Ranges — 10.31.1.0 … 10.31.255.254 … 65,279 IP addresses … [Create Subnet]`.
+6. Single-VNet wizard, same subnet: `GET /Azure/GetSubnets?vnetResourceId=…/rig-13-b3p2-multi&subnetId=1`
+   returned **one** entry —
+   `{"resourceId":"…/subnets/rig-13-b3p2-sn-multi","name":"rig-13-b3p2-sn-multi","addressPrefix":"10.31.0.0/24","hasMultipleAddressSchemes":false,"fullyEncompassesVNetPrefix":false}`
+   — and `hasMultipleAddressSchemes` is `false` (it is IPv4-only), so not even the dual-stack badge
+   fires. Matches the `break; // Take only the first valid IPv4 address` at `AzureService.cs:275`.
+
+Instance killed by captured PID 442806, catalog dropped, `git status --porcelain` empty.
+
+**Fix.** Emit one selectable entry per IPv4 prefix: in `GetVNetInventory` (`AzureService.cs:350-368`)
+and `GetCompatibleSubnets` (`AzureService.cs:239-277`), produce a `BulkAzureSubnetViewModel` per
+element of `ExtractIpv4Prefixes(subnet)` rather than per Azure subnet, each carrying the same
+`ResourceId`. The reconciler already copes with several Bastet rows sharing one Azure subnet id,
+because `EvaluateSubnetLevel` tests *membership* in `Ipv4PrefixesOf` (`AzureReconciler.cs:376`).
+
+> **The finder's fix was corrected by the verifier on two points.**
+>
+> 1. **Wrong claim, removed.** The original said *"`DisambiguateName` already handles the resulting
+>    name collision."* That is true of the **bulk** planner only (`AzureBulkImportPlanner.cs:485-527`,
+>    where `usedNames` + `DisambiguateName` run per plan item). The **single-VNet** commit path has no
+>    disambiguation at all — `SubnetController.Azure.cs:404` writes `Name = subnet.Name` straight from
+>    the posted view model, and `Subnet.Name` carries a non-unique index, so two identically-named rows
+>    would persist silently. If the single-VNet leg is taken, `BatchCreateChildSubnetsCore` needs the
+>    same used-names pass the planner has, or the wizard must suffix the prefix into the name it posts
+>    at `_ImportScripts.cshtml:330`.
+> 2. **Confused claim, removed.** The original said `AnnotateSubnet` *"must then compare per prefix
+>    rather than against `subnet.AddressPrefix`."* That is a no-op — once one view model is emitted per
+>    prefix, `subnet.AddressPrefix` **is** the per-prefix value, and `AnnotateSubnet`
+>    (`AzureBulkImportPlanner.cs:259-307`) needs no change. `encompassesAPrefix` at `:267-268` already
+>    compares against the *VNet's* prefix list, which is correct as it stands. Making the instructed
+>    change would be a regression.
+>
+> Confirmed sound: the duplicate-`AzureResourceId` reasoning. Nothing keys on it in a way that breaks —
+> `AzureSubnetSnapshotService` keys on `SubnetId`/`ParentSubnetId`, `SubnetController.AzureReconcile.cs:78`
+> keys `stillStale` on `SubnetId`, and `AzureService.cs:537`'s `ToDictionary` is over resource ids that
+> `ConfirmResourcesAsync` has already deduplicated at `:524-526`, so a repeated id cannot collide. And
+> `p.Subnets.Count > 1` beside a `FullyEncompasses` entry (`AzureBulkImportPlanner.cs:464`) cannot
+> false-fire, because a prefix equal to the whole VNet prefix leaves no room for the subnet's second
+> prefix.
+
+**Cheaper interim — stop the silence, one file.** Round 6 declined the full change as *"a feature
+change, not a bug fix"*, so an interim that only removes the invisibility is worth having. In
+`GetVNetInventory` (`AzureService.cs:358-367`) and `GetCompatibleSubnets`, when
+`ExtractIpv4Prefixes(subnet)` yields more than one, set `Reason` to name the prefixes that will **not**
+be imported, and have `AnnotateSubnet` *preserve* rather than null that reason (it currently overwrites
+`Reason = null` at `:294` on the Available path). Add the same sentence to `BulkImportPlanItem.Warnings`
+so it survives into step 3 and into the commit-time divergence text. One Bastet row per Azure subnet —
+no data-model change, no name collisions, no new reconciler tests — while removing the property the
+finding is actually about. It does **not** close the "Details page advertises the range as free" half,
+so it is an interim, not a substitute.
+
+**Harder interim — refuse rather than truncate.** Server-side, so the browser is not the authority: in
+`AzureBulkImportPlanner.AnnotateSubnet` (`AzureBulkImportPlanner.cs:259`) set `Status = Blocked`,
+`IsSelectable = false` and a reason naming every prefix whenever `subnet.Ipv4AddressPrefixes.Count > 1`,
+plus the matching hard error in `BuildPlanItem` so a crafted or stale POST is refused too. The operator
+cannot import the subnet, but BASTET never asserts that an Azure-assigned range is free.
+
+### Disposition — fix it, and why the standing deferral is overturned
+
+**This is to be fixed. The interims above are fallbacks if the full change cannot ship immediately;
+they are not the resolution.** The wizards must offer **one selectable entry per IPv4 prefix**, and
+the operator imports the ones they want. No auto-import, no guessing, no truncation.
+
+Round 6 deferred this as *"creating several Bastet subnets from one Azure subnet, which is a feature
+change, not a bug fix."* **That framing is rejected, on the codebase's own evidence:**
+
+- **The pattern already exists in this application, one level up.** `AzureBulkImportPlanner.cs:165` is
+  `vnet.Prefixes = [.. vnet.Ipv4AddressPrefixes.Select(p => AnnotatePrefix(p, vnet, existingSubnets))]`
+  — a prefix list fanned out into one entry per prefix. A **VNet** with four IPv4 prefixes is handled
+  correctly today, and a VNet with four **subnets** is handled correctly today. Only a **subnet** with
+  several prefixes is truncated. Applying an established internal pattern at the level where it was
+  missed is not a new feature.
+- **The truncation predates the problem it fails to handle.** The `break; // Take only the first valid
+  IPv4 address` (`AzureService.cs:275`) comes from `9f220e0` (2025-05-01), the original Azure import
+  feature — written when an Azure subnet could not have more than one IPv4 prefix. Azure changed that
+  in September 2025. This is code that was correct when written and became wrong when the external
+  contract moved: a regression against reality, not an unimplemented feature.
+- **The data has been ready since round 6.** `BulkAzureSubnetViewModel.Ipv4AddressPrefixes` is
+  populated at `AzureService.cs:366`, sits one line below the truncation, and no view or planner path
+  reads it. Round 6 plumbed it specifically so that whoever closed this would not have to re-plumb ARM.
+  The remaining work is rendering and naming, not integration.
+- **Azure's behaviour is confirmed against live ARM, not assumed.** This round ran
+  `az network vnet subnet create ... --address-prefixes 10.31.0.0/24 10.31.1.0/24`; ARM returned 200 and
+  reported `addressPrefix: null, addressPrefixes: ["10.31.0.0/24","10.31.1.0/24"]`. The singular field
+  going null once there are two is exactly what `AzureService.cs:390-395` already documents.
+
+**Deferral history — four rounds, no decision.** Filed as round 6 `F2`; the reconciler half was fixed
+and the import half deferred on cost. It rode the watch list through rounds 7, 8 and 9, then fell off
+in rounds 10-12 without ever being closed or formally accepted. Round 13 rediscovered it independently
+and measured the operator-visible consequence for the first time. **The consequence was never priced in
+any of the four deferrals** — only the cost of the fix was. That is the error being corrected here.
+
+**Definition of done:** a multi-prefix Azure subnet presents every one of its IPv4 prefixes as a
+separate selectable row in both wizards; importing all of them produces one Bastet row per prefix with
+non-colliding names through **both** commit paths (the single-VNet path needs the planner's
+`usedNames`/`DisambiguateName` pass — see the watch-list entry on `SubnetController.Azure.cs:404`); and
+no range Azure has assigned is ever shown as unallocated. Regression test must fail against HEAD.
+
+---
+
+# Low
+
+## M2 — Round 12's `L4` double-commit guard was applied only to the bulk-import wizard; the reconcile delete wizard, edited in the same commit for `L3`, still re-arms its Confirm Delete button mid-flight
+
+**Severity:** Low  **Tag:** `[x1]`  **Beat:** 6
+**File:** `src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml:76`
+(supporting: `:14`, `:345-408`, `:410`, `:416`, `:435-442`, `:453`, `:489`;
+server: `SubnetController.AzureReconcile.cs:78-93`, `:144-149`, `:193-204`)
+
+**Confidence:** **confirmed.** Both re-arm routes driven end to end on the HEAD build, and the fix
+built and re-run on a patched scratch copy.
+
+**Failure scenario.** Round 12's `L4` added `committing`/`committed` to `_BulkScripts.cshtml` so
+re-entering step 4 cannot fire a second commit. The same commit (`78fc4c9`) also edited
+`_ReconcileScripts.cshtml` for `L3` but left the identical re-arm in the only Azure-driven DELETE path.
+`refreshDeleteButton()` (`:73-77`) gates `#rec-confirm-delete-btn` on `confirmedIds` + the typed word
+only — **no in-flight flag** — and it is reachable from two ordinary handlers while a delete POST is
+still running: `$("#rec-confirmation").on("input", refreshDeleteButton)` (`:410`) and the
+`#rec-go-confirm-btn` rebuild (`:345-408`). `beforeSend` (`:435`) disables the button but sets no flag,
+so anything that calls `refreshDeleteButton` re-enables it.
+
+Concrete inputs: an Admin imports Azure VNet `rig-13-b6p2-vnet` (10.171.0.0/16 + child
+`rig-13-b6p2-sn-a` 10.171.0.0/24); the VNet is then deleted in Azure. On */Azure/Reconcile* the
+operator scans, ticks the stale row, types `approved`, clicks Confirm Delete.
+`POST /Subnet/BulkDeleteStaleAzureSubnets` runs a **live ARM re-scan before it touches the DB**, so it
+is in flight for ~0.7 s on the rig and multi-second against a real subscription. While the spinner is
+up the operator either **(a)** clicks Back to Review, unticks/re-ticks, Next, retypes `approved`,
+Confirm Delete, or **(b)** simply presses one key and Backspace in the confirmation box. Either
+re-arms the button and a second identical DELETE is posted.
+
+**Wrong output.** The second request's ARM re-scan overlaps the first request's transaction, so its
+`stillStale` map is built *before* the rows are archived and it does **not** hit the 409 at
+`SubnetController.AzureReconcile.cs:80-92`. It queues on `_localGate`, finds every
+`context.Subnets.FindAsync(id)` returns null (`:143-148`), skips them all, and returns
+**HTTP 200 `{"success":true,"targetsDeleted":0,"subnetsArchived":0}`**. That response lands last, so
+its `TempData["SuccessMessage"]` (`:193-195`) overwrites the first one. The operator is redirected to
+*/Subnet* and reads **"Azure reconcile: deleted 0 stale subnet(s), archiving 0 subnet(s) and 0 host IP
+assignment(s) in total."** while `DeletedSubnets` in fact holds both archived rows. This is strictly
+worse than the `L4` case round 12 fixed: there the server *refused* the second attempt; here it accepts
+it and reports a destructive operation as a no-op.
+
+This is not a narrow race. The two requests are ~50 ms apart while the ARM leg is ~700 ms, so the
+200/zero outcome is the **normal** result of a double submit here — it happened on every run.
+
+**Reproduction — ran it.** App on 127.0.0.1:5317, catalog `bastet_rig13_verc2`, SP A,
+Playwright/Chromium, live ARM.
+
+Fixture built for real:
+
+```
+az network vnet create -g bastet-visible -n rig-13-c2ver-vnet \
+  --address-prefixes 10.181.0.0/16 --subnet-name rig-13-c2ver-sn-a --subnet-prefixes 10.181.0.0/24
+# two Azure-linked Bastet rows seeded with those exact ARM ids, then:
+az network vnet delete -g bastet-visible -n rig-13-c2ver-vnet   -> DELETED
+```
+
+Route **(b)** — one keystroke plus Backspace, no navigation, HEAD build:
+
+```
+S2 2.447 stale rows: ['1', '2'] ['rig-13-c2ver-vnet', 'rig-13-c2ver-sn-a']
+K1 2.555 first click sent
+K2 2.558 {'delDisabled': True,  'progressHidden': False}
+K3 2.562 typed "x":  {'delDisabled': True,  'confirmVal': 'approvedx'}
+K4 2.565 Backspace:  {'delDisabled': False, 'progressHidden': False, 'confirmVal': 'approved'}
+K5 2.604 SECOND CLICK SENT
+(2.555, 'REQ',  'BulkDeleteStaleAzureSubnets')
+(2.604, 'REQ',  'BulkDeleteStaleAzureSubnets')
+(3.333, 'RESP', 200, '{"success":true,"redirectUrl":"/Subnet","targetsDeleted":1,"subnetsArchived":2,"hostIpsArchived":0}')
+(3.408, 'RESP', 200, '{"success":true,"redirectUrl":"/Subnet","targetsDeleted":0,"subnetsArchived":0,"hostIpsArchived":0}')
+K8 landed message: Azure reconcile: deleted 0 stale subnet(s), archiving 0 subnet(s) and 0 host IP assignment(s) in total.
+pageerrors: []
+```
+
+Route **(a)** — Back to Review → untick/re-tick → Next → retype → Confirm, HEAD build:
+
+```
+A3 2.088 {'delDisabled': True,  'progressHidden': False}
+A4 2.122 Back to Review:       {'delDisabled': True,  'progressHidden': False}
+A5 2.187 untick+retick:        {'delDisabled': True,  'progressHidden': False}
+A6 2.225 re-confirmed+retyped: {'delDisabled': False, 'progressHidden': False}   <- re-armed, delete still in flight
+A7 2.255 SECOND CLICK SENT
+RESP 2.800 200 targetsDeleted:1 subnetsArchived:2
+RESP 2.830 200 targetsDeleted:0 subnetsArchived:0
+A10 landed: deleted 0 stale subnet(s), archiving 0 subnet(s) and 0 host IP assignment(s) in total.
+```
+
+Database after each run:
+
+```
+SELECT COUNT(*) FROM Subnets; SELECT OriginalId,Name,NetworkAddress,Cidr FROM DeletedSubnets
+LiveSubnets 0
+2|rig-13-c2ver-sn-a|10.181.0.0|24
+1|rig-13-c2ver-vnet|10.181.0.0|16
+```
+
+Two subnets archived while the operator is told zero were.
+
+**The fix was built and run, not read.** Patched scratch copy, port 5318, catalog
+`bastet_rig13_verc2fix`, `dotnet build` 0 warnings / 0 errors:
+
+```
+route b: K4 {'delDisabled': True}  -> second click impossible; one POST; landed "deleted 1 stale subnet(s), archiving 2 subnet(s)"
+route a: A6 {'delDisabled': True}  -> refused;                one POST; landed "deleted 1 stale subnet(s), archiving 2 subnet(s)"
+non-regression (real 409 forced by an out-of-band row delete between confirm and click):
+   HEAD    F3 {'delDisabled': False, 'hidden': False, msg '1 of the selected subnet(s) are no longer reported as deleted in Azure...'}
+   PATCHED F3 {'delDisabled': False, 'hidden': False, msg identical}
+pageerrors: [] on every run of both builds
+```
+
+Both instances killed by captured PID (443034, 448206 — never `pkill`), both catalogs dropped, ports
+free, `git status --porcelain` on the repo empty.
+
+**Fix — verdict: sound, as proposed.** Mirror `L4` in `_ReconcileScripts.cshtml`:
+
+- declare `let deleting = false;` beside `confirmedIds` (`:14`);
+- set `deleting = true` in the delete AJAX `beforeSend` (`:435`);
+- in `complete` (`:440-442`) set `deleting = false;` then call `refreshDeleteButton();` — `complete`
+  runs *after* `success`/`error`, so `showCommitError`'s existing `refreshDeleteButton()` at `:489`
+  still leaves a genuinely-failed delete retryable (verified by the non-regression leg above);
+- make the single choke point honest at `:76`:
+  `$("#rec-confirm-delete-btn").prop("disabled", deleting || !hasSnapshot || !confirmed);`
+
+Because both re-arm routes go through `refreshDeleteButton`, that one conjunct closes both. A
+`committed`-style flag is **not** needed: `#rec-confirm-delete-btn` is already `.addClass("d-none")`'d
+on success (`:453`), so the post-success re-enable is unreachable by a click.
+
+**Optional server-side half — do it separately.** `SubnetController.AzureReconcile.cs:193-204` reports
+`success:true` and stamps `TempData["SuccessMessage"]` even when every requested id resolved to null and
+`targetsDeleted == 0`. Returning the 409 shape instead when `targetsDeleted == 0` with a non-empty
+`SubnetIds` cannot false-fire on a legitimate single request (the smallest-CIDR target always resolves,
+so `targetsDeleted >= 1`), but it would convert the honest out-of-band-concurrent-delete case into an
+error *after* a transaction that has already committed. The client guard alone closes both reachable
+routes; ship that first. This half was **not** built.
+
+**Cheaper interim — one line, no state to reason about.** Guard the click handler itself. In
+`$("#rec-confirm-delete-btn").on("click", …)` at `:416`, after `const ids = confirmedIds || [];`, add a
+module-scope `deleting` flag and `if (deleting) { return; }` before the `$.ajax` call, setting it in
+`beforeSend` and clearing it in `complete`. The button still visually re-arms, but no second POST is
+issued, so the false "deleted 0" message cannot be produced.
+
+---
+
+# Info
+
+## M3 — Azure import re-appends the "fully allocated" note to the target's Description on every run, so a wizard → un-mark → wizard cycle persists the same sentence N times
+
+**Severity:** Info  **Tag:** `[x1]`  **Beat:** 5
+**File:** `src/Bastet/Controllers/SubnetController.Azure.cs:85`
+(callers: `SubnetController.Azure.cs:370`, `SubnetController.BulkAzure.cs:417`)
+
+**Confidence:** **confirmed.** Four cycles driven through the shipped forms and the persisted column
+read back.
+
+**Failure scenario.** Azure VNet `rig-13-b5b-vnet` (10.99.0.0/24) has one subnet `rig-13-b5b-sn` whose
+prefix is the whole VNet prefix, so `GetCompatibleSubnets` returns it with
+`FullyEncompassesVNetPrefix=true`. Bastet subnet 10.99.0.0/24 exists. Running `/Azure/Import/{id}` and
+importing sets `IsFullyAllocated=1` and
+`Description = AppendFullyAllocatedNote(null, 'rig-13-b5b-sn')` (91 chars). The Details page's own
+*Mark as Not Fully Allocated* form (`Views/Subnet/Details/_HostIpAssignments.cshtml:102`, POST
+`HostIp/SetAllocationStatus`) clears the flag but leaves the note. `/Azure/Import/{id}` is now
+reachable again (no children, no host IPs, not fully allocated), so the same import runs again — and
+`AppendFullyAllocatedNote` has **no idempotence check** (`:94` is a bare
+`string combined = $"{existingDescription}\n{note}"`), so it concatenates the identical sentence again.
+
+**Wrong state** after four ordinary UI cycles: `Description` is the same 91-char sentence four times
+separated by newlines (367 chars) on a row whose `IsFullyAllocated` is **0** — the description asserts
+*"Fully allocated by Azure subnet 'rig-13-b5b-sn' which encompasses the entire address space."* four
+times about a subnet that is not fully allocated. Growth is bounded only by the 1000-char cap (~10
+repeats), after which the helper silently discards the note. `SubnetController.BulkAzure.cs:417` calls
+the same helper, so the bulk wizard has the identical write.
+
+**Reproduction — ran it.** Own app on 127.0.0.1:5273 (PID 442252), own catalog `bastet_rig13_v7c`,
+SP A. Reused the existing fixture read-only; created no new Azure resource.
+
+1. Real ARM through the app:
+   `GET /Azure/GetSubnets?vnetResourceId=…/rig-13-b5b-vnet&subnetId=1` →
+   `{"success":true,"subnets":[{"name":"rig-13-b5b-sn","addressPrefix":"10.99.0.0/24","hasMultipleAddressSchemes":false,"fullyEncompassesVNetPrefix":true}]}`
+2. Four cycles of the exact form `_SubnetList.cshtml` posts, each followed by the Details page's own
+   un-mark form, both with a live `__RequestVerificationToken` scraped from the rendered page:
+
+```
+cycle 1: importpage=200 import=302->/Subnet/Details/1 unmark=302 dblen|flag=91|0
+cycle 2: importpage=200 import=302->/Subnet/Details/1 unmark=302 dblen|flag=183|0
+cycle 3: importpage=200 import=302->/Subnet/Details/1 unmark=302 dblen|flag=275|0
+cycle 4: importpage=200 import=302->/Subnet/Details/1 unmark=302 dblen|flag=367|0
+```
+
+3. The persisted row (`sqlcmd … -d bastet_rig13_v7c`, newlines rendered as `<NL>`):
+
+```
+1 | rig-13-b5b-vnet | full=0 | len=367 |
+Fully allocated by Azure subnet 'rig-13-b5b-sn' which encompasses the entire address space. <NL>
+(same sentence) <NL> (same sentence) <NL> (same sentence)
+```
+
++92 bytes per repeat, on a row whose `IsFullyAllocated` is 0. Instance killed by captured PID 442252,
+catalog dropped, `git status --porcelain` empty.
+
+**Fix — the finder's proposal was corrected.** The core idea (dedupe before append) is right, but as
+written it had one unsound branch and one gap.
+
+> **Unsound branch, removed.** The original offered, as an alternative, stripping lines *"matching the
+> `Fully allocated by Azure subnet '…' which encompasses the entire address space.` shape"* via a loose
+> pattern. That can delete operator-authored text and breaks the helper's own documented contract at
+> `:79-84` (*"Existing text is never sacrificed for the note"*). **Do not use a loose shape match.**
+>
+> **Gap.** Exact-line equality against the *current* note alone does not dedupe a note written for a
+> differently-named Azure subnet (rename the Azure subnet between cycles and two distinct notes
+> accumulate), and it leaves the note asserting a state the row no longer has.
+
+Corrected fix, minimal and safe:
+
+1. In `AppendFullyAllocatedNote`, split `existingDescription` on `\n` and drop any line that **both**
+   starts with the literal `"Fully allocated by Azure subnet '"` **and** ends with the literal
+   `"' which encompasses the entire address space."` (ordinal, whole line — narrow enough that operator
+   prose cannot collide, wide enough to catch a renamed Azure subnet). Re-join, then append once.
+2. Keep the overflow contract unchanged: if the deduped-plus-note string still exceeds
+   `MaxSubnetDescriptionLength`, return the deduped existing description rather than truncating
+   mid-note. Dedupe alone already frees ~92 bytes per stale copy, so this is strictly better than today.
+3. Give `HostIpController.SetAllocationStatus` the mirror when it clears the flag: apply the same
+   line-strip to `subnet.Description` so the row stops asserting fully-allocated after an un-mark. The
+   finder listed this as *"ideally"*; it is **required** — without it the finding's own scenario still
+   ends with a stale sentence.
+4. Both call sites are fixed by (1) since they share the helper; factor the strip into a private static
+   so (3) can reuse it.
+
+This is pinnable by ordinary unit tests on the helper — no rendered-view seam needed — which is worth
+doing, since the suite has **no coverage of `AppendFullyAllocatedNote` at all**.
+
+**Cheaper interim — one line.** In `AppendFullyAllocatedNote`, before building `combined`:
+`if (existingDescription is not null && existingDescription.Contains(note, StringComparison.Ordinal)) return existingDescription;`
+Stops the duplication with no change to first-import behaviour and no change to either call site.
+
+**Why Info and not Low.** `docs/AUDIT-FINDINGS-10.md:533` already records the sibling half verbatim as
+a residue of a round-10 kill — *"after un-flagging, the appended note … stays in the description
+(`DescLen 91` with `IsFullyAllocated=0`)"* — which establishes append-and-preserve as deliberate
+design. What is new here is that the append is not **idempotent**, so the residue accumulates. That is
+real but strictly cosmetic and self-limiting: bounded by the 1000-char cap, after which the helper
+correctly drops the note and keeps existing text; no operator-authored text is ever destroyed (a
+pre-existing 950-char description makes `combined.Length > 1000` on the very first import, so nothing
+accumulates); and no count, validation or reconcile decision reads `Description`.
+
+---
+
+# Refuted — reported by a finder, killed by the verifier
+
+Six candidates died in verification. **This section is the point of the round as much as the findings
+are** — it is what stops round 14 spending agents re-deriving the same non-defects. Every one of these
+was reproduced at the render or request level; what failed was the *harm*, not the observation.
+
+| id | Title | file:line | Why it was killed |
+|---|---|---|---|
+| `C1` `[x2]` | Single-VNet import wizard renders a fully-encompassing Azure subnet as an ordinary child to import; selecting it creates zero children and instead flips the target to fully-allocated, "rewriting" its Description | `src/Bastet/Views/Azure/Import/_ImportScripts.cshtml:338` | Both differentiating consequences are **false when measured**. The Description is **appended**, not rewritten (`AppendFullyAllocatedNote`, `SubnetController.Azure.cs:85-101`) — proven against the reporter's own seeded-description fixture. And the target is **not a one-way door**: `_HostIpAssignments.cshtml:100-109` renders *Mark as Not Fully Allocated* for any Edit-role user, and one click restores `/Azure/Import/{id}` (driven end to end). The rename and `AzureResourceId` stamp happen on **every** single-VNet import regardless of this flag, so they are not consequences of this row either. What remains is one missing line of advisory UI copy on a row whose write is truthful, announced by the flash immediately after, semantically correct, and undoable in two clicks — the exact "one sentence of UI copy" / not-a-runtime-defect shape rounds 4-12 killed every time (round 12 `R3`; the *"'Add Child Subnet' is capacity-gated nowhere"* standing kill from rounds 7 and 11). **Note: this was the round's only `[x2]`. Two passes agreeing is not verification.** |
+| `C3` `[x1]` | Layout nav offers five links that an authenticated user with no Bastet role is refused, on the only two pages such a user can reach | `src/Bastet/Views/Shared/_Layout.cshtml:32` | **Reproduced the render, not the harm.** The Development consequence the finding leads with **cannot occur in an unmodified build** — `DevAuthHandler` grants Admin to every request, and all five targets measured 200 with the header absent. The only real-deployment consequence is a click landing on `/Account/AccessDenied`, the page that states the exact cause and remedy, from a page that already says *"You don't have any Bastet application roles assigned"*. No wrong output, no state change, every target fails closed at 403. The premise is contradicted by deliberate code in the same views: `AccessDenied`'s own *Return to Home* button and `SignedOut`/`SignInFailed`'s Home links are links to pages the current principal cannot render, used as affordances **on purpose**. Unlike round 12's `L2`, **no action or mutation is offered** — that is the whole difference. |
+| `C4` `[x1]` | Azure single-VNet import commit never re-checks the "target must be empty" precondition its own wizard page, the Details page gate and the bulk planner all enforce — so it Azure-links a subnet holding non-Azure children, and reconcile then archives them | `src/Bastet/Controllers/SubnetController.Azure.cs:328` | The commit **really does** skip the GET's precondition (reproduced: wizard GET 302-refuses, the POST 302-accepts and renames + Azure-stamps the parent). **But the claimed harm is not caused by it.** The identical tree shape was built through **fully sanctioned** operations — import onto an empty parent (wizard GET 200), then an ordinary `POST /Subnet/Create` of a manual child under the now-Azure-linked parent, which `SubnetController.Create.cs` permits with **no Azure guard at all**. `POST /Azure/ReconcileScan` reported that control tree exactly like the defect tree (`descendants=[5, 6]`, `warnings: []`), and `POST /Subnet/BulkDeleteStaleAzureSubnets {"subnetIds":[4]}` returned `subnetsArchived:3`, archiving `ctrl-manual-child` — a subnet with no Azure provenance created through the ordinary Create form. **The headline consequence reproduces at HEAD with the alleged defect playing no part.** The premise that this is "a state three independent read-side gates declare impossible" is false — those gates guard an import's *entry point*, not the resulting state. The second leg is empty too: ordinary children onto a fully-allocated parent are already refused and rolled back at `SubnetController.Helpers.cs:197`, and the fully-encompassing leg writes a state identical to a sanctioned import onto an empty parent (`SubnetController.Azure.cs:367` sets `IsFullyAllocated = true` regardless). Rows are **archived** to `DeletedSubnets` and listed at `/Subnet/DeletedSubnets`, not destroyed, behind a plan rendering *"This also archives N child subnet(s)"* and a typed `approved`. What is left is a gate-symmetry hardening observation over a legitimately reachable state, closely covered by the brief's accepted-and-still-open item 7 (`C20`). |
+| `C6` `[x1]` | The delete archive drops `AzureResourceId`, so a wrong Azure reconcile deletion destroys the only record of which Azure resource each row was linked to | `src/Bastet/Controllers/SubnetController.Delete.cs:225` | **Reached and reproduced, but harmless.** The stated harm — *"operator must rediscover the mapping in the Azure portal by hand"* — was **disproven by running it**: after deleting three Azure-linked subnets, a plain re-import restamped all three `AzureResourceId`s byte-for-byte from ARM without consulting the archive. No code anywhere reads `DeletedSubnet` for Azure data, there is **no restore feature** (the archive is a display-only audit list plus a purge), and the reconcile path can only archive a row after a **direct ARM 404** — so the field, if archived, would name a resource Azure has just confirmed does not exist. The archive equally drops `RowVersion` and `IsFullyAllocated` and does not even display stored `Tags`/`OriginalParentId`, so *"the archive is lossy"* is a **design property**, not a defect in this one field. Schema-enhancement observation with no runtime misbehaviour — the "not a runtime defect, but…" shape killed in every round 4-12. |
+| `C8` `[x1]` | Reconciler's cascade guard treats "found in Azure with a different prefix" as unprotected, so archiving a drift target silently archives a child whose Azure resource the same scan just read | `src/Bastet/Services/Azure/AzureReconciler.cs:128` | The cascade guard protects descendants **the operator cannot approve on the review screen** (invisible live rows, invisible out-of-subscription rows, checkbox-less review items, confirm-withheld rows) — not descendants that merely "exist in Azure". **Drift rows are the one Azure-linked class rendered with their own checkbox and their own reason**, so they need no guard. Archiving a row whose Azure resource still exists at a different prefix is the drift feature's **explicitly documented purpose** (`AzureController.ConfirmProposedDeletionsAsync` remarks; `AzureReconciler.cs:180-186` plus the `SurvivesEveryVerdict` tests). The *"silently / never named"* framing is contradicted by the UI as driven: the parent row shows *"Also archives 1 child subnet(s)."* in red, the child row with its reason is on the same screen, and the confirm step restates the cascade count. Unticked descendants being cascaded is the **universal** semantic here (`ParentSubnetId` is `DeleteBehavior.Restrict`; the accepted test `ApplyConfirmations_TargetWhoseDescendantIsAlsoDeleted_IsStillCommittable` has the same shape). |
+| `C9` `[x1]` | `L4`'s `committed` flag is set by the previous plan's commit, permanently hiding Confirm for a different plan the operator has already previewed — and the struck entry's stated recovery does not work | `src/Bastet/Views/Azure/BulkImport/_BulkScripts.cshtml:667` | **The headline consequence does not hold.** `invalidatePlan()` (`_BulkScripts.cshtml:31`, called at `:343` on every checkbox tick and at `:435` in the preview handler) **clears `committed`** at `:36`, so *Back to Selection → Preview → Continue to Commit* re-arms Confirm and P2 commits 200 — measured on the HEAD build. **P2 is not uncommittable.** The stale success banner and the hidden Confirm at the moment the superseded commit lands are produced by the **untouched** success handler (`:698-707`) and reproduce identically on a simulated pre-`78fc4c9` build, so they are not caused by the cited line; and the 2 s `redirectUrl` navigation that "discards P2" is unconditional on every build. The only delta `78fc4c9` introduced is that the shortest recovery is **one click longer**, inside a 2 s window that ends in an automatic navigation. That is precisely the residue round 12 recorded in `L4`'s struck entry and its *Deliberately not done* list — and the novel part (*"the struck entry's stated recovery does not work"*) is a **correction to prose in a prior findings file**, not a runtime defect. |
+
+---
+
+# Watch list
+
+Not findings. Things a verifier could not settle, patterns that will bite later, and places where the
+evidence is thinner than the confidence.
+
+- **The `L4` pattern is a family, not an incident.** `M2` exists because round 12 fixed one member of a
+  two-member family and the struck entry did not say the sibling was left. Before round 14 files
+  anything new here, grep every `.cshtml` under `Views/Azure/` for an AJAX `beforeSend` that disables a
+  button without setting a module-scope in-flight flag. There are three commit-shaped wizards in this
+  app (single-VNet import, bulk import, reconcile delete) and only one of them was guarded at HEAD.
+- **A duplicate destructive POST is accepted by the server, not just re-armed by the client.** `M2`'s
+  fix is client-side and closes both reachable routes, but the underlying property survives:
+  `BulkDeleteStaleAzureSubnets` has **no idempotency token, no dedup, no in-flight per-user lock**, and
+  its 409 is defeated by its own live ARM re-scan latency (~700 ms) whenever two submissions land
+  ~50 ms apart. Any future path that can issue that POST twice — a retry, a proxy, a second tab —
+  reproduces the false "deleted 0" banner. The server-side half of `M2`'s fix was designed but **not
+  built**, and it has a real downside (it converts an honest out-of-band concurrent delete into an
+  error after a committed transaction). Unsettled.
+- **`Ipv4AddressPrefixes` is carried everywhere and read almost nowhere.** `grep -rn Ipv4AddressPrefixes src/`
+  gives thirteen hits, five of them doc comments and model declarations. Of the seven code sites, three
+  (`AzureBulkImportPlanner.cs:165`, `:267`, `AzureReconciler.cs:335`) read the **VNet's** list, three are
+  the producer (`AzureService.cs:332`, `:338`, `:366`), and only `AzureReconciler.cs:392-393` reads the
+  **subnet's**. `M1` is the
+  visible consequence. Any other field on `BulkAzureSubnetViewModel` that no view reads is a candidate
+  for the same class of silent truncation.
+- **BASTET has no "present in Azure, absent from Bastet" reconcile status.** `AzureReconcileStatus` is
+  `VNetDeleted` / `VNetPrefixRemoved` / `FullyAllocatingSubnetDeleted` / `SubnetDeleted` /
+  `SubnetPrefixChanged` / `UnrecognisedResourceId` — every one of which starts from a Bastet row that
+  carries an `AzureResourceId`. The reconciler structurally cannot notice something Azure has that
+  BASTET does not. That is what makes `M1` permanent rather than self-healing, and it will make any
+  future import-side omission permanent too.
+- **`M1` is round 6's `F2` returning, and the process failure matters more than the defect.** It was
+  deferred in round 6 on the *cost* of the fix, rode the watch list through rounds 7-9 as "deliberately
+  left, small", and fell off in 10-12 without ever being closed or formally accepted. The consequence
+  was never measured until now. **Round 14 may not defer `M1`, and no round may make this kind of call
+  again.** Deciding that a reproduced defect is "out of scope" or "a feature change, not a bug fix" is
+  a product decision belonging to the repository owner; four consecutive rounds made it on their behalf
+  and never asked. The rule is now written into `.claude/skills/audit/SKILL.md` under *"Scope is the
+  owner's call, never the round's"*: file it, rate it on consequence, put the fix cost in the *Fix*
+  section, and let the owner say no. Every one of the four deferrals priced the cost of the fix and
+  none priced the consequence of the defect — that is the specific error to not repeat.
+- **`AppendFullyAllocatedNote` has zero test coverage** and is called from two controllers. `M3`'s
+  corrected fix is trivially unit-testable with no rendered-view seam, which makes it the cheapest
+  test-debt repayment currently visible in the Azure surface.
+- **The single-VNet commit path has no name disambiguation.** Surfaced while correcting `M1`'s fix:
+  `SubnetController.Azure.cs:404` writes `Name = subnet.Name` straight from the posted view model, and
+  `Subnet.Name` carries a **non-unique** index. The bulk planner has `usedNames` + `DisambiguateName`;
+  the single-VNet path has nothing. No finding was filed — nobody demonstrated a reachable collision at
+  HEAD — but any change that makes one Azure subnet produce more than one Bastet row through that path
+  will silently persist duplicates.
+- **The single-VNet import commit does not re-check its own GET's precondition.** This is real
+  (`C4` reproduced it: wizard GET 302-refuses, POST 302-accepts) and was refuted only because the harm
+  it claimed is reachable through sanctioned operations anyway. It remains a gate asymmetry. It
+  overlaps the brief's accepted-and-still-open item 7 (`C20`), and if `C20` is ever closed, this should
+  be re-examined rather than assumed closed with it.
+- **Rig hygiene held, and should keep being enforced.** Every verifier that ran the app used its own
+  port and its own catalog, killed by **captured PID** rather than `pkill`, dropped its catalog, and
+  left `git status --porcelain` on `/home/anuj/code/Bastet` empty. Two Azure resources were created for
+  `M2`'s fixture (`rig-13-c2ver-vnet`, `rig-13-c2ver-sn-a`) and both ids were appended to
+  `azure-inventory.txt`. Round 14 should confirm they are gone.

--- a/src/Bastet/Controllers/HostIpController.cs
+++ b/src/Bastet/Controllers/HostIpController.cs
@@ -733,6 +733,17 @@ public class HostIpController(
 
                 // Update the subnet
                 subnet.IsFullyAllocated = dto.IsFullyAllocated;
+
+                // Clearing the flag must also clear the note an Azure import wrote, or the
+                // description goes on asserting "fully allocated by Azure subnet ..." about a row
+                // that is no longer fully allocated. Only the note is removed; operator-authored
+                // text is left exactly as it is.
+                if (!dto.IsFullyAllocated && !string.IsNullOrEmpty(subnet.Description))
+                {
+                    string stripped = FullyAllocatedNote.Strip(subnet.Description);
+                    subnet.Description = string.IsNullOrEmpty(stripped) ? null : stripped;
+                }
+
                 subnet.LastModifiedAt = DateTime.UtcNow;
                 subnet.ModifiedBy = userContextService.GetCurrentUsername();
 

--- a/src/Bastet/Controllers/SubnetController.Azure.cs
+++ b/src/Bastet/Controllers/SubnetController.Azure.cs
@@ -83,23 +83,13 @@ public partial class SubnetController : Controller
     /// IsFullyAllocated flag already records, and overflowing the column fails the insert and rolls
     /// back the entire import behind a generic error. Existing text is never sacrificed for the note.
     /// </summary>
-    private static string AppendFullyAllocatedNote(string? existingDescription, string? azureSubnetName)
-    {
-        string note = $"Fully allocated by Azure subnet '{azureSubnetName}' which encompasses the entire address space.";
-
-        if (string.IsNullOrEmpty(existingDescription))
-        {
-            return Truncate(note);
-        }
-
-        string combined = $"{existingDescription}\n{note}";
-        return combined.Length <= MaxSubnetDescriptionLength
-            ? combined
-            : Truncate(existingDescription);
-
-        static string Truncate(string value) =>
-            value.Length > MaxSubnetDescriptionLength ? value[..MaxSubnetDescriptionLength] : value;
-    }
+    /// <remarks>
+    /// Any earlier note is removed first. The wizard is reachable again after the Details page's own
+    /// "Mark as Not Fully Allocated", so without that an ordinary import - un-mark - import cycle
+    /// concatenated the identical sentence once per pass.
+    /// </remarks>
+    private static string AppendFullyAllocatedNote(string? existingDescription, string? azureSubnetName) =>
+        FullyAllocatedNote.Append(existingDescription, azureSubnetName, MaxSubnetDescriptionLength);
 
     // POST: Subnet/BatchCreateChildSubnets
     /// <param name="isAzureImport">

--- a/src/Bastet/Controllers/SubnetController.Azure.cs
+++ b/src/Bastet/Controllers/SubnetController.Azure.cs
@@ -1,5 +1,6 @@
 using Bastet.Models;
 using Bastet.Models.ViewModels;
+using Bastet.Services;
 using Bastet.Services.Security;
 using Bastet.Services.Validation;
 using Microsoft.AspNetCore.Authorization;
@@ -240,6 +241,58 @@ public partial class SubnetController : Controller
         }
     }
 
+    /// <summary>
+    /// The Bastet name each posted row will be created under, keyed by its index in
+    /// <paramref name="subnets"/>.
+    /// </summary>
+    /// <remarks>
+    /// An Azure subnet owning several IPv4 prefixes posts one row per prefix, all carrying the same
+    /// Azure name, and <c>Subnet.Name</c> has a NON-unique index - so they would persist as rows
+    /// indistinguishable by name in every list and dropdown. Each such row is named for the range it
+    /// holds. The same is done for any other duplicate name in the batch.
+    ///
+    /// Settled server-side because the browser is not the authority: a crafted or replayed post
+    /// carries whatever names it likes. A row contributing no duplicate keeps its name exactly as
+    /// posted, so ordinary single-prefix imports are unchanged.
+    /// </remarks>
+    private static Dictionary<int, string> ResolveImportNames(List<AzureImportSubnetViewModel> subnets)
+    {
+        HashSet<string> multiPrefixResourceIds = [.. subnets
+            .Where(s => !s.FullyEncompassesVNetPrefix && !string.IsNullOrEmpty(s.AzureResourceId))
+            .GroupBy(s => s.AzureResourceId!, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)];
+
+        Dictionary<int, string> names = [];
+        HashSet<string> used = new(StringComparer.OrdinalIgnoreCase);
+
+        for (int i = 0; i < subnets.Count; i++)
+        {
+            AzureImportSubnetViewModel subnet = subnets[i];
+            if (subnet.FullyEncompassesVNetPrefix)
+            {
+                continue;
+            }
+
+            string name = subnet.Name;
+            bool sharesAnAzureSubnet = !string.IsNullOrEmpty(subnet.AzureResourceId)
+                && multiPrefixResourceIds.Contains(subnet.AzureResourceId);
+
+            if (sharesAnAzureSubnet || used.Contains(name))
+            {
+                // {NetworkAddress, Cidr} is unique across a batch - overlap validation refuses a
+                // repeat - so a prefix-qualified name cannot collide with another one.
+                name = SubnetNaming.WithSuffix(
+                    name, $" ({subnet.NetworkAddress}/{subnet.Cidr})", MaxSubnetNameLength);
+            }
+
+            used.Add(name);
+            names[i] = name;
+        }
+
+        return names;
+    }
+
     private async Task<IActionResult> BatchCreateChildSubnetsCore(int parentId, List<AzureImportSubnetViewModel> subnets, string? vnetName, string? vnetResourceId, bool isAzureImport)
     {
         // Begin transaction
@@ -379,9 +432,14 @@ public partial class SubnetController : Controller
             // we don't create any child subnets
             if (!hasFullyEncompassingSubnet)
             {
+                // Settled before the loop so every row is named against the whole batch.
+                Dictionary<int, string> importNames = ResolveImportNames(subnets);
+
                 // Create each subnet - with validation right before adding to catch overlaps
-                foreach (AzureImportSubnetViewModel subnet in subnets)
+                for (int i = 0; i < subnets.Count; i++)
                 {
+                    AzureImportSubnetViewModel subnet = subnets[i];
+
                     // Skip subnets that fully encompass the VNet address prefix
                     if (subnet.FullyEncompassesVNetPrefix)
                     {
@@ -401,7 +459,7 @@ public partial class SubnetController : Controller
                     // Create the subnet entity
                     Subnet newSubnet = new()
                     {
-                        Name = subnet.Name,
+                        Name = importNames[i],
                         NetworkAddress = subnet.NetworkAddress,
                         Cidr = subnet.Cidr,
                         Description = subnet.Description,

--- a/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
+++ b/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
@@ -501,6 +501,17 @@ namespace Bastet.Services.Azure
                 usedNames.Add(targetAutoCreatedName);
             }
 
+            // An Azure subnet owning several IPv4 prefixes contributes one selection per prefix, and
+            // every one of them carries the same Azure name. Subnet.Name has a non-unique index, so
+            // without this they would persist as indistinguishable rows differing only by CIDR.
+            // Name each for the range it actually holds. A subnet contributing a single selection is
+            // untouched, so ordinary imports keep the exact names they have always had.
+            HashSet<string> multiPrefixResourceIds = [.. p.Subnets
+                .Where(s => !s.FullyEncompasses && !string.IsNullOrEmpty(s.Source.AzureResourceId))
+                .GroupBy(s => s.Source.AzureResourceId, StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)];
+
             foreach (ParsedSubnetSelection sub in p.Subnets)
             {
                 if (sub.FullyEncompasses)
@@ -512,6 +523,11 @@ namespace Bastet.Services.Azure
                 if (string.IsNullOrEmpty(baseName))
                 {
                     baseName = $"{sub.Network}_{sub.Cidr}";
+                }
+                else if (multiPrefixResourceIds.Contains(sub.Source.AzureResourceId))
+                {
+                    baseName = SubnetNaming.WithSuffix(
+                        baseName, $" ({sub.Network}/{sub.Cidr})", MaxSubnetNameLength);
                 }
 
                 string finalName = DisambiguateName(baseName, usedNames, p.Source.VNetName);

--- a/src/Bastet/Services/Azure/AzureService.cs
+++ b/src/Bastet/Services/Azure/AzureService.cs
@@ -272,7 +272,12 @@ namespace Bastet.Services.Azure
                                         cidr);
                                 }
 
-                                break; // Take only the first valid IPv4 address
+                                // Every IPv4 prefix gets its own entry. This used to `break` after
+                                // the first, which was right only while Azure allowed one prefix per
+                                // subnet. Azure has allowed several since September 2025, so the
+                                // rest were silently dropped: never offered, never created, and then
+                                // shown on the target's Details page as free space over a range
+                                // Azure had already assigned.
                             }
                         }
                     }
@@ -349,22 +354,10 @@ namespace Bastet.Services.Azure
                     // delete involved. The list response carries every field used here.
                     foreach (SubnetData subnet in vnet.Data.Subnets ?? [])
                     {
-                        string? ipv4Prefix = ExtractIpv4Prefix(subnet);
-                        if (string.IsNullOrEmpty(ipv4Prefix))
-                        {
-                            continue;
-                        }
-
-                        vnetVm.Subnets.Add(new BulkAzureSubnetViewModel
-                        {
-                            ResourceId = subnet.Id?.ToString() ?? string.Empty,
-                            Name = subnet.Name ?? string.Empty,
-                            AddressPrefix = ipv4Prefix,
-                            // Distinct because ARM may report a single prefix in both the singular
-                            // property and the collection; a duplicate would reach the operator in
-                            // the reconcile reason text.
-                            Ipv4AddressPrefixes = [.. ExtractIpv4Prefixes(subnet).Distinct(StringComparer.OrdinalIgnoreCase)]
-                        });
+                        vnetVm.Subnets.AddRange(BuildInventorySubnetRows(
+                            subnet.Id?.ToString() ?? string.Empty,
+                            subnet.Name ?? string.Empty,
+                            [.. ExtractIpv4Prefixes(subnet)]));
                     }
 
                     result.Add(vnetVm);
@@ -470,6 +463,40 @@ namespace Bastet.Services.Azure
                     FullyEncompassesVNetPrefix = false
                 });
             }
+        }
+
+        /// <summary>
+        /// One selectable inventory row per IPv4 prefix the Azure subnet owns.
+        /// </summary>
+        /// <remarks>
+        /// Azure has allowed several IPv4 prefixes on a single subnet since September 2025. This used
+        /// to emit one row carrying only the first, so the remaining prefixes were never offered,
+        /// never created, and the target's Details page then advertised them as unallocated space -
+        /// an operator allocating from Bastet would hand out addresses Azure had already assigned.
+        ///
+        /// Every row keeps the subnet's COMPLETE prefix list. The reconciler shares this inventory
+        /// and indexes prefixes by resource id, so a row reporting only its own prefix would make it
+        /// believe the subnet had lost the others - and a drift row is offered for deletion.
+        /// </remarks>
+        public static List<BulkAzureSubnetViewModel> BuildInventorySubnetRows(
+            string resourceId, string name, IReadOnlyList<string> ipv4Prefixes)
+        {
+            ArgumentNullException.ThrowIfNull(ipv4Prefixes);
+
+            // Distinct because ARM may report a single prefix in both the singular property and the
+            // collection; a duplicate would offer the operator the same range twice and the second
+            // would fail as an overlap.
+            List<string> prefixes = [.. ipv4Prefixes
+                .Where(p => !string.IsNullOrEmpty(p))
+                .Distinct(StringComparer.OrdinalIgnoreCase)];
+
+            return [.. prefixes.Select(prefix => new BulkAzureSubnetViewModel
+            {
+                ResourceId = resourceId,
+                Name = name,
+                AddressPrefix = prefix,
+                Ipv4AddressPrefixes = [.. prefixes]
+            })];
         }
 
         /// <summary>

--- a/src/Bastet/Services/FullyAllocatedNote.cs
+++ b/src/Bastet/Services/FullyAllocatedNote.cs
@@ -1,0 +1,83 @@
+namespace Bastet.Services;
+
+/// <summary>
+/// The sentence an Azure import writes into a subnet's description when an Azure subnet covers the
+/// target's whole prefix, and the rules for keeping exactly one of it.
+/// </summary>
+/// <remarks>
+/// Appending was always deliberate - the note explains a state the operator did not set by hand, and
+/// existing text is never sacrificed for it. What was missing is idempotence: the wizard is reachable
+/// again after the Details page's own "Mark as Not Fully Allocated", so an ordinary
+/// import - un-mark - import cycle concatenated the identical sentence once per pass until the
+/// description hit its cap.
+///
+/// Shared rather than private to the import controller because clearing the flag has to strip the
+/// note too: leaving it behind is a description asserting a state the row no longer has.
+/// </remarks>
+public static class FullyAllocatedNote
+{
+    private const string Prefix = "Fully allocated by Azure subnet '";
+    private const string Suffix = "' which encompasses the entire address space.";
+
+    /// <summary>The note for a given Azure subnet name.</summary>
+    public static string For(string? azureSubnetName) => $"{Prefix}{azureSubnetName}{Suffix}";
+
+    /// <summary>
+    /// <paramref name="description"/> with every fully-allocated note removed, whatever Azure subnet
+    /// name it carries.
+    /// </summary>
+    /// <remarks>
+    /// Whole-line, ordinal, anchored at both ends. Deliberately NOT a loose shape match: a pattern
+    /// broad enough to catch prose that merely resembles the note can delete operator-authored text,
+    /// which would break the "existing text is never sacrificed" contract this type exists to keep.
+    /// Matching both ends also catches a note written for a since-renamed Azure subnet, which exact
+    /// equality against the current note would miss.
+    /// </remarks>
+    public static string Strip(string? description)
+    {
+        if (string.IsNullOrEmpty(description))
+        {
+            return string.Empty;
+        }
+
+        IEnumerable<string> kept = description
+            .Split('\n')
+            .Where(line => !IsNote(line));
+
+        return string.Join('\n', kept).Trim('\n');
+    }
+
+    /// <summary>
+    /// <paramref name="existingDescription"/> carrying exactly one note for
+    /// <paramref name="azureSubnetName"/>, with any earlier note removed first.
+    /// </summary>
+    /// <remarks>
+    /// The overflow contract is unchanged and is the reason this is not simply a concatenation: if
+    /// the result would exceed <paramref name="maxLength"/> the note is dropped and the existing text
+    /// kept, because overflowing the column fails the insert and rolls back the whole import behind a
+    /// generic error. Stripping first means a description that used to overflow may now fit.
+    /// </remarks>
+    public static string Append(string? existingDescription, string? azureSubnetName, int maxLength)
+    {
+        string note = For(azureSubnetName);
+        string existing = Strip(existingDescription);
+
+        if (string.IsNullOrEmpty(existing))
+        {
+            return note.Length > maxLength ? note[..maxLength] : note;
+        }
+
+        string combined = $"{existing}\n{note}";
+        return combined.Length <= maxLength
+            ? combined
+            : existing.Length > maxLength ? existing[..maxLength] : existing;
+    }
+
+    private static bool IsNote(string line)
+    {
+        string trimmed = line.Trim();
+        return trimmed.StartsWith(Prefix, StringComparison.Ordinal)
+            && trimmed.EndsWith(Suffix, StringComparison.Ordinal)
+            && trimmed.Length >= Prefix.Length + Suffix.Length;
+    }
+}

--- a/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
@@ -12,6 +12,14 @@
         // whatever the review checkboxes hold at click time, so it can only ever delete what the
         // confirmation screen listed.
         let confirmedIds = null;
+        // True while a delete POST is in flight. Without it, anything that calls
+        // refreshDeleteButton re-arms the button mid-delete - one keystroke plus Backspace in the
+        // confirmation box is enough - and the second POST's ARM re-scan starts before the first
+        // request's transaction archives the rows, so it misses the 409, finds every id already
+        // gone, and returns 200 with zero counters. That response lands last, so its TempData
+        // banner overwrites the true one and the operator reads "deleted 0 stale subnet(s)" after a
+        // delete that archived two.
+        let deleting = false;
 
         function getAntiForgeryToken() {
             return $("input[name='__RequestVerificationToken']").first().val();
@@ -73,7 +81,7 @@
         function refreshDeleteButton() {
             const hasSnapshot = Array.isArray(confirmedIds) && confirmedIds.length > 0;
             const confirmed = $("#rec-confirmation").val() === "approved";
-            $("#rec-confirm-delete-btn").prop("disabled", !hasSnapshot || !confirmed);
+            $("#rec-confirm-delete-btn").prop("disabled", deleting || !hasSnapshot || !confirmed);
         }
 
         // ------------------------------------------------------------------
@@ -433,12 +441,19 @@
                     confirmation: $("#rec-confirmation").val()
                 }),
                 beforeSend: function () {
+                    deleting = true;
                     $("#rec-confirm-delete-btn").prop("disabled", true);
                     $("#rec-commit-progress").removeClass("d-none");
                     $("#rec-commit-error").addClass("d-none");
                 },
                 complete: function () {
+                    // complete runs after success/error, so clearing the flag here still leaves a
+                    // genuinely failed delete retryable: showCommitError's own refreshDeleteButton
+                    // call re-enables the button once this flag is down. On success the button is
+                    // already .d-none'd, so the re-enable is unreachable by a click.
+                    deleting = false;
                     $("#rec-commit-progress").addClass("d-none");
+                    refreshDeleteButton();
                 },
                 success: function (result) {
                     if (!result.success) {

--- a/test/Bastet.Tests/Azure/AzureMultiPrefixImportCommitTests.cs
+++ b/test/Bastet.Tests/Azure/AzureMultiPrefixImportCommitTests.cs
@@ -1,0 +1,196 @@
+using Bastet.Controllers;
+using Bastet.Data;
+using Bastet.Models;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Validation;
+using Bastet.Tests.TestHelpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// The single-VNet import wizard's commit path, driven with the two rows an Azure subnet owning two
+/// IPv4 prefixes now produces. Both must be created, and their names must not collide: Subnet.Name
+/// carries a NON-unique index, so two identically-named rows would persist silently and be
+/// indistinguishable in every list and dropdown.
+///
+/// The browser is not the authority here. These tests post the rows directly, which is also what a
+/// crafted or replayed request looks like, so the disambiguation has to be server-side.
+/// </summary>
+[Collection(AzureFeatureFlagCollection.Name)]
+public class AzureMultiPrefixImportCommitTests : IDisposable
+{
+    private readonly BastetDbContext _context;
+    private readonly SubnetController _controller;
+
+    private const string VNetId =
+        "/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/multi-vnet";
+    private const string SubnetResourceId = $"{VNetId}/subnets/sn-multi";
+
+    public AzureMultiPrefixImportCommitTests()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "true");
+
+        DbContextOptions<BastetDbContext> options = new DbContextOptionsBuilder<BastetDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        _context = new BastetDbContext(options);
+        _context.Database.OpenConnection();
+        _context.Database.EnsureCreated();
+
+        IIpUtilityService ip = new IpUtilityService();
+        IUserContextService users = ControllerTestHelper.CreateMockUserContextService();
+
+        _controller = new SubnetController(
+            _context,
+            ip,
+            new SubnetValidationService(ip),
+            new HostIpValidationService(ip, _context),
+            users,
+            ControllerTestHelper.CreateMockSubnetLockingService(),
+            NullLogger<SubnetController>.Instance);
+
+        ControllerTestHelper.SetupController(_controller);
+        _controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+        _controller.HttpContext.Request.Headers.Referer = "https://localhost/Azure/Import/1";
+
+        // A /16 target that comfortably contains both prefixes of the Azure subnet.
+        _context.Subnets.Add(new Subnet
+        {
+            Id = 1,
+            Name = "Target",
+            NetworkAddress = "10.31.0.0",
+            Cidr = 16,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = "test-admin"
+        });
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", null);
+        _context.Database.CloseConnection();
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static AzureImportSubnetViewModel Row(string name, string network, int cidr) =>
+        new()
+        {
+            Name = name,
+            NetworkAddress = network,
+            Cidr = cidr,
+            Description = "Imported from Azure VNet: multi-vnet",
+            Tags = "Azure",
+            ParentSubnetId = 1,
+            AzureResourceId = SubnetResourceId
+        };
+
+    /// <summary>
+    /// Both prefixes of one Azure subnet are created, and each Bastet row is named for the range it
+    /// actually holds rather than both taking the bare Azure name.
+    /// </summary>
+    [Fact]
+    public async Task BothPrefixesOfOneAzureSubnet_AreCreatedWithDistinctNames()
+    {
+        List<AzureImportSubnetViewModel> subnets =
+        [
+            Row("sn-multi", "10.31.0.0", 24),
+            Row("sn-multi", "10.31.1.0", 24)
+        ];
+
+        IActionResult result = await _controller.BatchCreateChildSubnets(
+            1, subnets, "multi-vnet", VNetId, isAzureImport: true);
+
+        RedirectToActionResult redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Details", redirect.ActionName);
+
+        List<Subnet> created = await _context.Subnets
+            .Where(s => s.ParentSubnetId == 1)
+            .OrderBy(s => s.NetworkAddress)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, created.Count);
+        Assert.Equal(["10.31.0.0", "10.31.1.0"], created.Select(s => s.NetworkAddress));
+
+        // The names must differ, and each must name its own range.
+        Assert.Equal(2, created.Select(s => s.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.Equal("sn-multi (10.31.0.0/24)", created[0].Name);
+        Assert.Equal("sn-multi (10.31.1.0/24)", created[1].Name);
+
+        // Both stay linked to the one Azure subnet they came from.
+        Assert.All(created, s => Assert.Equal(SubnetResourceId, s.AzureResourceId));
+    }
+
+    /// <summary>
+    /// The guard for every existing install: a single-prefix import is byte-for-byte what it was.
+    /// No suffix appears when there is nothing to disambiguate.
+    /// </summary>
+    [Fact]
+    public async Task SinglePrefixImport_KeepsThePlainAzureName()
+    {
+        List<AzureImportSubnetViewModel> subnets = [Row("web", "10.31.5.0", 24)];
+
+        await _controller.BatchCreateChildSubnets(1, subnets, "multi-vnet", VNetId, isAzureImport: true);
+
+        Subnet created = Assert.Single(await _context.Subnets
+            .Where(s => s.ParentSubnetId == 1)
+            .ToListAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("web", created.Name);
+    }
+
+    /// <summary>
+    /// Two genuinely different Azure subnets that happen to share a name must also stop colliding -
+    /// same non-unique index, same consequence. They are distinguished by their own prefixes.
+    /// </summary>
+    [Fact]
+    public async Task TwoDifferentAzureSubnetsSharingAName_AreAlsoDisambiguated()
+    {
+        AzureImportSubnetViewModel a = Row("web", "10.31.6.0", 24);
+        AzureImportSubnetViewModel b = Row("web", "10.31.7.0", 24);
+        b.AzureResourceId = $"{VNetId}/subnets/web-b";
+
+        await _controller.BatchCreateChildSubnets(1, [a, b], "multi-vnet", VNetId, isAzureImport: true);
+
+        List<Subnet> created = await _context.Subnets
+            .Where(s => s.ParentSubnetId == 1)
+            .OrderBy(s => s.NetworkAddress)
+            .ToListAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, created.Count);
+        Assert.Equal(2, created.Select(s => s.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    /// <summary>
+    /// Overlap validation still runs across the batch: a second row covering the same range as the
+    /// first is refused, not silently renamed and created. Disambiguating names must not become a
+    /// way to smuggle in a duplicate allocation.
+    /// </summary>
+    [Fact]
+    public async Task TwoRowsCoveringTheSameRange_AreStillRefused()
+    {
+        List<AzureImportSubnetViewModel> subnets =
+        [
+            Row("sn-multi", "10.31.0.0", 24),
+            Row("sn-multi", "10.31.0.0", 24)
+        ];
+
+        IActionResult result = await _controller.BatchCreateChildSubnets(
+            1, subnets, "multi-vnet", VNetId, isAzureImport: true);
+
+        RedirectToActionResult redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Details", redirect.ActionName);
+        Assert.True(_controller.TempData.ContainsKey("ErrorMessage"));
+
+        Assert.Empty(await _context.Subnets
+            .Where(s => s.ParentSubnetId == 1)
+            .ToListAsync(TestContext.Current.CancellationToken));
+    }
+}

--- a/test/Bastet.Tests/Azure/AzureMultiPrefixSubnetTests.cs
+++ b/test/Bastet.Tests/Azure/AzureMultiPrefixSubnetTests.cs
@@ -1,0 +1,313 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Security;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// An Azure subnet may own several IPv4 prefixes - GA since September 2025 - and ARM reports the
+/// singular <c>addressPrefix</c> as null once there is more than one. Both import wizards used to
+/// read only the first, so the remaining prefixes were never offered, never created, and then shown
+/// on the target's Details page as unallocated space with a Create Subnet button over a range Azure
+/// had already assigned.
+///
+/// These tests pin the expansion (one selectable entry per prefix), the naming that keeps the
+/// resulting Bastet rows distinct, and - just as importantly - that nothing which already worked
+/// changed: single-prefix subnets, the reconciler's view of the same inventory, and the
+/// already-imported/blocked annotation.
+/// </summary>
+public class AzureMultiPrefixSubnetTests
+{
+    private const string SubId = "11111111-1111-1111-1111-111111111111";
+
+    private static string VNetId(string name) =>
+        $"/subscriptions/{SubId}/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/{name}";
+
+    private static string SubnetId(string vnetName, string subnetName) =>
+        $"{VNetId(vnetName)}/subnets/{subnetName}";
+
+    // -------------------------------------------------------------------------
+    // The expansion itself
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// The defect, at its source: two prefixes must produce two selectable entries, not one.
+    /// </summary>
+    [Fact]
+    public void SubnetWithTwoIpv4Prefixes_ProducesOneRowPerPrefix()
+    {
+        List<BulkAzureSubnetViewModel> rows = AzureService.BuildInventorySubnetRows(
+            SubnetId("multi-vnet", "sn-multi"), "sn-multi", ["10.31.0.0/24", "10.31.1.0/24"]);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(["10.31.0.0/24", "10.31.1.0/24"], rows.Select(r => r.AddressPrefix));
+
+        // Same Azure resource, same Azure name: the rows are two prefixes of one subnet, and the
+        // wizard shows the prefix beside the name so they are already distinguishable on screen.
+        Assert.All(rows, r => Assert.Equal(SubnetId("multi-vnet", "sn-multi"), r.ResourceId));
+        Assert.All(rows, r => Assert.Equal("sn-multi", r.Name));
+    }
+
+    /// <summary>
+    /// Load-bearing for the reconciler: it indexes prefixes by resource id, so every row for one
+    /// subnet must report that subnet's COMPLETE prefix list, not just its own prefix. If a row
+    /// carried only its own, whichever row landed last in the dictionary would make the reconciler
+    /// believe the subnet had lost the others - and a drift row is offered for deletion.
+    /// </summary>
+    [Fact]
+    public void EveryExpandedRow_CarriesTheSubnetsCompletePrefixList()
+    {
+        List<BulkAzureSubnetViewModel> rows = AzureService.BuildInventorySubnetRows(
+            SubnetId("multi-vnet", "sn-multi"), "sn-multi", ["10.31.0.0/24", "10.31.1.0/24"]);
+
+        Assert.All(rows, r => Assert.Equal(["10.31.0.0/24", "10.31.1.0/24"], r.Ipv4AddressPrefixes));
+    }
+
+    /// <summary>The guard: the ordinary single-prefix subnet is completely unchanged.</summary>
+    [Fact]
+    public void SubnetWithOneIpv4Prefix_IsUnchanged()
+    {
+        List<BulkAzureSubnetViewModel> rows = AzureService.BuildInventorySubnetRows(
+            SubnetId("vnet1", "web"), "web", ["10.0.1.0/24"]);
+
+        BulkAzureSubnetViewModel row = Assert.Single(rows);
+        Assert.Equal("web", row.Name);
+        Assert.Equal("10.0.1.0/24", row.AddressPrefix);
+        Assert.Equal(["10.0.1.0/24"], row.Ipv4AddressPrefixes);
+    }
+
+    /// <summary>An IPv6-only subnet has no IPv4 prefixes and must contribute no rows at all.</summary>
+    [Fact]
+    public void SubnetWithNoIpv4Prefixes_ProducesNoRows()
+        => Assert.Empty(AzureService.BuildInventorySubnetRows(SubnetId("vnet1", "v6"), "v6", []));
+
+    /// <summary>
+    /// ARM may report the same prefix in both the singular property and the collection. Emitting it
+    /// twice would offer the operator two identical rows, and the second would fail as a duplicate.
+    /// </summary>
+    [Fact]
+    public void DuplicatePrefixesFromArm_AreCollapsed()
+    {
+        List<BulkAzureSubnetViewModel> rows = AzureService.BuildInventorySubnetRows(
+            SubnetId("vnet1", "web"), "web", ["10.0.1.0/24", "10.0.1.0/24"]);
+
+        Assert.Single(rows);
+    }
+
+    // -------------------------------------------------------------------------
+    // Naming: two Bastet rows from one Azure subnet must not collide
+    // -------------------------------------------------------------------------
+
+    private static readonly AzureBulkImportPlanner _planner =
+        new(new IpUtilityService(), new InputSanitizationService());
+
+    private static BulkImportSelectedSubnetDto Sub(string name, string prefix, string? resourceId = null) =>
+        new() { Name = name, AddressPrefix = prefix, AzureResourceId = resourceId ?? string.Empty };
+
+    private static BulkImportSelectionDto Sel(params BulkImportSelectedSubnetDto[] subs) =>
+        new()
+        {
+            SubscriptionId = "sub-1",
+            SubscriptionName = "Test Sub",
+            VNetPrefixes =
+            [
+                new()
+                {
+                    VNetName = "multi-vnet",
+                    VNetResourceId = VNetId("multi-vnet"),
+                    AddressPrefix = "10.31.0.0/16",
+                    Subnets = [.. subs]
+                }
+            ]
+        };
+
+    /// <summary>
+    /// Selecting both prefixes of one Azure subnet creates two Bastet subnets. Bastet's Name column
+    /// carries a NON-unique index, so two rows named identically would persist silently and be
+    /// indistinguishable in every list. Each row is named for the prefix it actually holds.
+    /// </summary>
+    [Fact]
+    public void BothPrefixesOfOneSubnet_ProduceDistinctlyNamedChildren()
+    {
+        string id = SubnetId("multi-vnet", "sn-multi");
+
+        BulkImportPlanViewModel plan = _planner.BuildPlan(
+            Sel(Sub("sn-multi", "10.31.0.0/24", id), Sub("sn-multi", "10.31.1.0/24", id)), []);
+
+        BulkImportPlanItem item = Assert.Single(plan.Items);
+        Assert.Equal(2, item.ChildSubnets.Count);
+
+        Assert.Equal(
+            ["sn-multi (10.31.0.0/24)", "sn-multi (10.31.1.0/24)"],
+            item.ChildSubnets.Select(c => c.Name).Order());
+
+        // Both keep the true Azure name and the true Azure resource id.
+        Assert.All(item.ChildSubnets, c => Assert.Equal("sn-multi", c.OriginalAzureName));
+        Assert.All(item.ChildSubnets, c => Assert.Equal(id, c.AzureResourceId));
+    }
+
+    /// <summary>
+    /// The guard that matters most for existing installs: a subnet contributing ONE row is named
+    /// exactly as it always was. No suffix, no change.
+    /// </summary>
+    [Fact]
+    public void SinglePrefixSubnet_KeepsItsPlainAzureName()
+    {
+        BulkImportPlanViewModel plan = _planner.BuildPlan(
+            Sel(Sub("web", "10.31.1.0/24", SubnetId("multi-vnet", "web"))), []);
+
+        Assert.Equal("web", Assert.Single(Assert.Single(plan.Items).ChildSubnets).Name);
+    }
+
+    /// <summary>
+    /// Two DIFFERENT Azure subnets that happen to share a name are a pre-existing case handled by
+    /// the VNet-name suffix. Prefix-suffixing must not take that path over.
+    /// </summary>
+    [Fact]
+    public void TwoDistinctAzureSubnetsSharingAName_StillUseTheExistingDisambiguation()
+    {
+        BulkImportPlanViewModel plan = _planner.BuildPlan(
+            Sel(Sub("web", "10.31.1.0/24", SubnetId("multi-vnet", "web-a")),
+                Sub("web", "10.31.2.0/24", SubnetId("multi-vnet", "web-b"))), []);
+
+        List<string> names = [.. Assert.Single(plan.Items).ChildSubnets.Select(c => c.Name)];
+        Assert.Equal(2, names.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        Assert.Contains("web", names);
+    }
+
+    // -------------------------------------------------------------------------
+    // Availability annotation must be per prefix
+    // -------------------------------------------------------------------------
+
+    private static BulkAzureVNetViewModel InventoryVNet(params BulkAzureSubnetViewModel[] subnets) =>
+        new()
+        {
+            ResourceId = VNetId("multi-vnet"),
+            Name = "multi-vnet",
+            Ipv4AddressPrefixes = ["10.31.0.0/16"],
+            Subnets = [.. subnets]
+        };
+
+    /// <summary>
+    /// Importing one prefix must not make the other look imported. The already-exists test is keyed
+    /// on {NetworkAddress, Cidr}, so the sibling prefix - which no Bastet row occupies - stays
+    /// Available. This is what makes the second prefix reachable at all after a partial import.
+    /// </summary>
+    [Fact]
+    public void ImportingOnePrefix_LeavesTheSiblingPrefixAvailable()
+    {
+        string id = SubnetId("multi-vnet", "sn-multi");
+        List<BulkAzureSubnetViewModel> rows =
+            AzureService.BuildInventorySubnetRows(id, "sn-multi", ["10.31.0.0/24", "10.31.1.0/24"]);
+
+        // 10.31.0.0/24 has already been imported from this very Azure subnet.
+        List<ExistingSubnetSnapshot> existing =
+        [
+            new() { Id = 7, Name = "sn-multi (10.31.0.0/24)", NetworkAddress = "10.31.0.0", Cidr = 24, AzureResourceId = id }
+        ];
+
+        _planner.AnnotateAvailability([InventoryVNet([.. rows])], existing);
+
+        BulkAzureSubnetViewModel imported = rows.Single(r => r.AddressPrefix == "10.31.0.0/24");
+        BulkAzureSubnetViewModel sibling = rows.Single(r => r.AddressPrefix == "10.31.1.0/24");
+
+        Assert.Equal(BulkImportAvailability.AlreadyImported, imported.Status);
+        Assert.False(imported.IsSelectable);
+
+        Assert.Equal(BulkImportAvailability.Available, sibling.Status);
+        Assert.True(sibling.IsSelectable);
+    }
+
+    /// <summary>
+    /// The reverse guard: a prefix occupied by an UNRELATED Bastet subnet is still blocked, so the
+    /// expansion cannot be used to create an overlapping row.
+    /// </summary>
+    [Fact]
+    public void PrefixOccupiedByAnUnrelatedBastetSubnet_IsStillBlocked()
+    {
+        string id = SubnetId("multi-vnet", "sn-multi");
+        List<BulkAzureSubnetViewModel> rows =
+            AzureService.BuildInventorySubnetRows(id, "sn-multi", ["10.31.0.0/24", "10.31.1.0/24"]);
+
+        List<ExistingSubnetSnapshot> existing =
+        [
+            new() { Id = 9, Name = "hand-made", NetworkAddress = "10.31.1.0", Cidr = 24 }
+        ];
+
+        _planner.AnnotateAvailability([InventoryVNet([.. rows])], existing);
+
+        BulkAzureSubnetViewModel blocked = rows.Single(r => r.AddressPrefix == "10.31.1.0/24");
+        Assert.Equal(BulkImportAvailability.Blocked, blocked.Status);
+        Assert.False(blocked.IsSelectable);
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-regression: the reconciler sees the same reality through the new shape
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// The reconciler shares GetVNetInventory with the wizards, so the expansion changes what it
+    /// reads. It indexes prefixes by resource id with an indexer assignment, and every expanded row
+    /// reports the complete list, so N rows collapse to the same answer one row gave. A Bastet row
+    /// linked at the SECOND prefix must still be recognised as live - reporting drift here would
+    /// offer a live subnet for deletion.
+    /// </summary>
+    [Fact]
+    public void ReconcilerSeesNoDrift_ForARowLinkedAtTheSecondPrefix()
+    {
+        string id = SubnetId("multi-vnet", "sn-multi");
+        List<BulkAzureSubnetViewModel> rows =
+            AzureService.BuildInventorySubnetRows(id, "sn-multi", ["10.31.0.0/24", "10.31.1.0/24"]);
+
+        AzureVNetInventory inventory = new() { Success = true, VNets = [InventoryVNet([.. rows])] };
+
+        List<AzureLinkedSubnetSnapshot> linked =
+        [
+            new()
+            {
+                Id = 7,
+                Name = "sn-multi (10.31.1.0/24)",
+                NetworkAddress = "10.31.1.0",
+                Cidr = 24,
+                AzureResourceId = id
+            }
+        ];
+
+        AzureReconcilePlanViewModel plan =
+            new AzureReconciler().BuildPlan(SubId, "Test Sub", inventory, linked);
+
+        Assert.Empty(plan.Items);
+    }
+
+    /// <summary>
+    /// And the counter-test, so the one above cannot pass by the reconciler simply having gone
+    /// quiet: a row linked at a prefix the Azure subnet no longer owns is still reported.
+    /// </summary>
+    [Fact]
+    public void ReconcilerStillReportsDrift_WhenThePrefixIsGenuinelyGone()
+    {
+        string id = SubnetId("multi-vnet", "sn-multi");
+        List<BulkAzureSubnetViewModel> rows =
+            AzureService.BuildInventorySubnetRows(id, "sn-multi", ["10.31.0.0/24", "10.31.1.0/24"]);
+
+        AzureVNetInventory inventory = new() { Success = true, VNets = [InventoryVNet([.. rows])] };
+
+        List<AzureLinkedSubnetSnapshot> linked =
+        [
+            new()
+            {
+                Id = 8,
+                Name = "stale",
+                NetworkAddress = "10.31.9.0",
+                Cidr = 24,
+                AzureResourceId = id
+            }
+        ];
+
+        AzureReconcilePlanViewModel plan =
+            new AzureReconciler().BuildPlan(SubId, "Test Sub", inventory, linked);
+
+        Assert.Equal(AzureReconcileStatus.SubnetPrefixChanged, Assert.Single(plan.Items).Status);
+    }
+}

--- a/test/Bastet.Tests/Services/FullyAllocatedNoteTests.cs
+++ b/test/Bastet.Tests/Services/FullyAllocatedNoteTests.cs
@@ -1,0 +1,172 @@
+using Bastet.Services;
+
+namespace Bastet.Tests.Services;
+
+/// <summary>
+/// The "fully allocated by Azure subnet ..." note. Appending it is deliberate and existing operator
+/// text must never be sacrificed for it; what was missing is idempotence, so an ordinary
+/// import - un-mark - import cycle stacked the identical sentence once per pass.
+/// </summary>
+public class FullyAllocatedNoteTests
+{
+    private const int Max = 1000;
+
+    private static string Note(string name) => FullyAllocatedNote.For(name);
+
+    // -------------------------------------------------------------------------
+    // Idempotence - the defect
+    // -------------------------------------------------------------------------
+
+    /// <summary>Four import/un-mark cycles must leave exactly one note, not four.</summary>
+    [Fact]
+    public void RepeatedAppends_LeaveExactlyOneNote()
+    {
+        string d = FullyAllocatedNote.Append(null, "sn", Max);
+        for (int i = 0; i < 3; i++)
+        {
+            d = FullyAllocatedNote.Append(d, "sn", Max);
+        }
+
+        Assert.Equal(Note("sn"), d);
+        Assert.Single(d.Split('\n'));
+    }
+
+    /// <summary>
+    /// The gap the finder's own proposal had: exact equality against the current note would not
+    /// dedupe a note written before the Azure subnet was renamed, so two distinct notes accumulated.
+    /// </summary>
+    [Fact]
+    public void ANoteForADifferentlyNamedAzureSubnet_IsAlsoReplaced()
+    {
+        string d = FullyAllocatedNote.Append(null, "old-name", Max);
+        d = FullyAllocatedNote.Append(d, "new-name", Max);
+
+        Assert.Equal(Note("new-name"), d);
+        Assert.DoesNotContain("old-name", d);
+    }
+
+    // -------------------------------------------------------------------------
+    // Operator text is never destroyed - the contract the loose-match fix would have broken
+    // -------------------------------------------------------------------------
+
+    /// <summary>Operator prose survives an append, and sits above the note.</summary>
+    [Fact]
+    public void OperatorText_SurvivesTheAppend()
+    {
+        string d = FullyAllocatedNote.Append("Prod DMZ. Owner: netops.", "sn", Max);
+
+        Assert.Equal($"Prod DMZ. Owner: netops.\n{Note("sn")}", d);
+    }
+
+    /// <summary>And survives repeated appends, still exactly once, still with one note.</summary>
+    [Fact]
+    public void OperatorText_SurvivesRepeatedAppends()
+    {
+        string d = "Prod DMZ. Owner: netops.";
+        for (int i = 0; i < 4; i++)
+        {
+            d = FullyAllocatedNote.Append(d, "sn", Max);
+        }
+
+        Assert.Equal($"Prod DMZ. Owner: netops.\n{Note("sn")}", d);
+    }
+
+    /// <summary>
+    /// The reason the match is anchored at BOTH ends and whole-line: prose that merely resembles the
+    /// note must not be deleted. A loose shape match here would silently destroy operator text.
+    /// </summary>
+    [Theory]
+    [InlineData("Fully allocated by Azure subnet 'sn' which encompasses the entire address space, per ticket 42.")]
+    [InlineData("Note: fully allocated by Azure subnet 'sn' which encompasses the entire address space.")]
+    [InlineData("Fully allocated by hand.")]
+    [InlineData("which encompasses the entire address space.")]
+    public void ProseThatMerelyResemblesTheNote_IsKept(string prose)
+    {
+        Assert.Equal(prose, FullyAllocatedNote.Strip(prose));
+
+        string appended = FullyAllocatedNote.Append(prose, "sn", Max);
+        Assert.Contains(prose, appended);
+        Assert.EndsWith(Note("sn"), appended);
+    }
+
+    // -------------------------------------------------------------------------
+    // Strip, used by the un-mark path
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Strip_RemovesTheNoteAndLeavesTheRest()
+        => Assert.Equal("Owner: netops.",
+            FullyAllocatedNote.Strip($"Owner: netops.\n{Note("sn")}"));
+
+    /// <summary>A description that was only ever the note strips to empty, so the row can be nulled.</summary>
+    [Fact]
+    public void Strip_OfANoteOnlyDescription_IsEmpty()
+        => Assert.Equal(string.Empty, FullyAllocatedNote.Strip(Note("sn")));
+
+    /// <summary>Several stacked notes - the state existing rows are already in - all go.</summary>
+    [Fact]
+    public void Strip_RemovesEveryStackedNote()
+    {
+        string stacked = string.Join('\n', Enumerable.Repeat(Note("sn"), 4));
+        Assert.Equal(string.Empty, FullyAllocatedNote.Strip(stacked));
+
+        string withText = "Owner: netops.\n" + stacked;
+        Assert.Equal("Owner: netops.", FullyAllocatedNote.Strip(withText));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Strip_OfNothing_IsEmpty(string? input)
+        => Assert.Equal(string.Empty, FullyAllocatedNote.Strip(input));
+
+    // -------------------------------------------------------------------------
+    // The overflow contract, unchanged
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// When the note will not fit, it is dropped and the existing text kept whole - overflowing the
+    /// column fails the insert and rolls back the entire import behind a generic error.
+    /// </summary>
+    [Fact]
+    public void WhenTheNoteWouldNotFit_ExistingTextIsKeptAndTheNoteDropped()
+    {
+        string big = new('x', 950);
+        string result = FullyAllocatedNote.Append(big, "sn", Max);
+
+        Assert.Equal(big, result);
+        Assert.DoesNotContain("Fully allocated by Azure subnet", result);
+    }
+
+    /// <summary>
+    /// Deduping frees room, so a description that had stacked notes and would previously have
+    /// overflowed can now take the note. Strictly better than the old behaviour, never worse.
+    /// </summary>
+    [Fact]
+    public void StrippingStaleNotes_CanFreeEnoughRoomForTheNote()
+    {
+        string text = new('x', 850);
+        string stacked = text + "\n" + string.Join('\n', Enumerable.Repeat(Note("sn"), 3));
+        Assert.True(stacked.Length > Max);
+
+        string result = FullyAllocatedNote.Append(stacked, "sn", Max);
+
+        Assert.True(result.Length <= Max);
+        Assert.StartsWith(text, result);
+        Assert.EndsWith(Note("sn"), result);
+        Assert.Equal(2, result.Split('\n').Length);
+    }
+
+    /// <summary>A note longer than the cap on its own is truncated rather than overflowing.</summary>
+    [Fact]
+    public void ANoteLongerThanTheCap_IsTruncated()
+    {
+        string result = FullyAllocatedNote.Append(null, new string('n', 2000), Max);
+        Assert.Equal(Max, result.Length);
+    }
+
+    /// <summary>First import onto an empty description is the note alone, exactly as before.</summary>
+    [Fact]
+    public void FirstImport_WritesTheNoteAlone()
+        => Assert.Equal(Note("sn"), FullyAllocatedNote.Append(null, "sn", Max));
+}


### PR DESCRIPTION
### Bug Fixes
- The Azure import wizards could **show ranges Azure had already assigned as free space** — an Azure subnet with more than one IPv4 prefix (allowed by Azure since September 2025) had every prefix after the first silently dropped, so those ranges were missing from BASTET entirely and its Details page offered a *Create Subnet* button over them. Every prefix is now offered as its own selectable row; when a subnet contributes more than one, each resulting subnet is named for the range it holds, e.g. `app-subnet (10.31.1.0/24)`. Subnets with a single prefix import exactly as before
- Azure reconcile could report **"deleted 0 stale subnet(s)" after archiving subnets** — a keystroke or a trip back through the wizard while a delete was running re-armed the Confirm Delete button, and the duplicate request's result overwrote the real one. A delete in flight now blocks a second submission, while a genuinely failed delete stays retryable
- Re-importing an Azure subnet that covers a whole VNet prefix **stacked the same "fully allocated" sentence into the target's description** once per import, and clearing *Fully Allocated* left the sentence behind asserting a state the subnet no longer had. The note is now written once and removed when the flag is cleared; text you wrote yourself is never touched
