### PR TITLE
Audit 14 Cleanup

### DIFF
--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -1,0 +1,519 @@
+# Bastet — Round-14 Audit Findings
+
+**Target branch:** `audit/round-14` · **HEAD:** `6d1a4cb` · **Baseline:** 771 tests passing, 0 build warnings · **Date:** 2026-08-02 · **Round letter:** N (findings N1–N10)
+
+---
+
+## Verdict
+
+**Nine findings need a decision from you, and here is what each costs.** Read this list first; nothing below it is safe to skim past.
+
+| Finding | The decision | What it costs |
+|---|---|---|
+| **N1** (critical) — reconcile archives a row whose CIDR is still assigned in Azure | Should reconcile **fail closed** (never offer a deletion whose range is still live in Azure), **warn loudly and still allow it**, or **fail closed plus a new "re-link to Azure subnet X" action**? | Warn-only: ~15 lines, one LINQ pass, ships today, leaves the wrong archive one click away. Fail-closed alone: safe but strands the row in `ReviewItems` forever *and* permanently withholds its ancestors — do not ship alone. Fail-closed + re-link action: correct end state, largest of the three, also fixes N3/N4's un-re-importable case. The range-still-allocated **warning is worth shipping under all three**. |
+| **N2** (high) — archive executed on an approval the server's own re-scan had disproved | Should an out-of-band Azure re-create inside the wizard's confirm window become a **409 the operator must re-scan through**? And is the approved-status check **mandatory** or **optional-and-logged** for direct JSON API callers? | ~20 lines across DTO, view and controller plus one unit test. Cost: a legitimate drift deletion becomes a retry. The same fail-open-and-log trade-off you already accepted for bulk import at `SubnetController.BulkAzure.cs:99-106`. |
+| **N3** (high) — Azure prefix added to an already-imported subnet is invisible and advertised as free | Does the reconciler get an **inbound verdict** at all (new `AzureReconcileStatus`, wider `BuildPlan` input, report-only review row)? | Full: ~1 day plus tests. Cheap half — a plan **warning**, ~30 lines, no schema, no UI change — can ship first and is independently useful. |
+| **N4** (high) — the same range can then never be imported by either wizard | Should there be **any** supported path to pull new Azure prefixes into an already-imported target — and if so, a **new narrow "top-up" action** rather than relaxing the two "target must be empty" gates? | Relaxing the gates is cheaper but re-opens the adopt-and-re-stamp blast radius; the narrow action is smaller in blast radius, larger in code. Either way, **closing the free-space lie on `/Subnet/Details/{id}` is not optional**. |
+| **N5** (medium) — stranded global write lock; peers fail for minutes with a false "high concurrency" message | Is the **pool-wide blast radius of `SqlConnection.ClearPool`** on the release-failure path acceptable? | (a) Accept the pool clear — verified working, one burst of reconnect handshakes on an error path only. (b) Leave it stranded and make the peer's error honest plus a KILL runbook. (c) Change the lock ownership model — explicitly rejected by the class remarks. (a) is cheapest and is the one that was measured to work. |
+| **N6** (low) — one Azure subnet persists as two Bastet rows with the identical name and identical resource id | Should prefix-qualified names apply **across the whole commit and across sessions**? | Changes names some installs see on their **next** import (nothing already persisted is renamed); the alternative is preview-warning only. |
+| **N7** (low) — generated names contain `/`, which the app's own Create form forbids; the prefill persists a garbled false address | Pick the suffix format: **(a)** change the separator to `-` so generated names satisfy SafeText (three test assertions, no rename migration — the code shipped one commit ago), or **(b)** keep `/` and relax `[SafeText]` on `CreateSubnetViewModel.Name`, widening a shared input class. | (a) is two string literals plus tests. (b) has a security-review implication. Doing neither leaves the app generating names it refuses on input. |
+| **N8** (low) — an unstrippable fully-allocated note re-creates M3's stacking defect | Do anything about rows that **already** carry a two-line note? The code fix alone leaves them permanently un-repairable except by hand-editing the description. | A backfill, or accept the residue — the same call round 13 already made explicitly for stacked notes. The code fix itself is one line. |
+| **N10** (low) — a two-address-space VNet persists as two Bastet targets with the identical name and identical VNet resource id | Should `TargetName` be prefix-qualified when a VNet contributes several selected prefixes? | Changes names some installs see on their **next** import of such a VNet (nothing already persisted is renamed); the alternative is a preview warning and a manual rename. Reproduced on every multi-address-space VNet import, so it is not conditional on anything unusual. |
+
+**Read this first: N1.** Reconcile will archive a Bastet subnet whose CIDR is **still assigned in Azure** — because an Azure subnet cannot be renamed, so renaming one means delete-and-recreate, and the reconciler keys only on the recorded ARM resource id. It was driven end to end on a live subscription: after approval, `/Subnet/Details/1` printed the range as free with a **Create Subnet** button over a `/24` ARM still holds. The reconciler had the contradicting evidence in its own hand — `liveSubnetPrefixes`, built from the same scan. Two routes (`SubnetDeleted` and `SubnetPrefixChanged`), both silent, no warning anywhere in the flow, and the archive has no restore.
+
+Three more findings put an **allocated range in front of an operator as free space with a button to allocate from it** (N1, N3, N4). In N3 the harm was not described but *executed*: a `/24` Azure had already committed was handed out by BASTET with no warning, and `ReconcileScan` — the one feature whose job is to compare the two — returned `items 0, warnings []`. N2 is the other side of the same coin: an irreversible archive of a subtree, including a child subnet and a host IP that carry no Azure provenance at all, performed on an approval whose stated premise the server had disproved milliseconds earlier.
+
+**Do you need to act today?** If you run reconcile against a subscription where anyone renames or re-creates subnets — yes. N1's interim warning is ~15 lines and removes the silent part immediately. N3's interim warning is ~30 lines. Both are additive, neither changes what is deletable. The rest (N5–N10) is not same-day.
+
+Six candidates were killed by verification and are recorded in **Refuted** so round 15 does not re-report them — including two dead-code observations and two "the rename is invisible" claims that were false when measured.
+
+---
+
+## How this audit ran
+
+**Eight beats**, each a lens over the whole codebase rather than a directory: (1) the Azure import surface, (2) the Azure reconcile surface, (3) cross-feature interaction between import, reconcile and the IPAM core, (4) infrastructure — locking, migrations, connection lifetime, hosting shape, (5) naming, sanitisation and identity of persisted rows, (6) the round-13 delta itself (multi-prefix import, `FullyAllocatedNote`, `ResolveImportNames`), (7) free-space and allocation arithmetic as rendered to an operator, (8) authorisation, antiforgery and the direct-JSON-API surface.
+
+**Two independent passes** ran every beat without sight of each other's output, plus a **deep sweep** on beats 1, 3, 6 and 7 — the beats covering the round-13 delta and the free-space arithmetic, i.e. where a regression would be both newest and most consequential. 20 finders were dispatched, 20 returned.
+
+**Tag meaning.** `[x2]` = the same defect was found independently by **both** passes. `[x1]` = found by **one** pass only. **`[x1]` is weak evidence of absence, not evidence of weakness** — a defect on a surface only one pass happened to drive is exactly the defect that survives to production. Every `[x1]` candidate therefore got **more** scrutiny, not less: a second verifier on a reachability lens (can a real user, with no crafted request or with only the crafted requests the code itself claims to defend against, reach this?), and a third verifier whenever those two disagreed. Four of the nine findings that came through the funnel are `[x1]` (N2, N5, N7, N9), including the medium-severity stranded-lock defect (N5) that only one pass reached.
+
+**Adversarial verification with live reproduction.** Verifiers were instructed to kill findings, not confirm them: each stood up its own app instance on its own port, its own SQL catalog, and where the finding touched Azure its **own** live ARM fixtures rather than replaying the finder's. Every surviving finding records what was actually run and what came back. Verifiers also re-assessed the proposed fix independently — five of the nine fixes were judged **incomplete or unsound** and were corrected; those corrections are among the most valuable output of this round and are marked inline.
+
+**Funnel.**
+
+| Stage | Count |
+|---|---|
+| Finders dispatched | 20 |
+| Finders returned | 20 |
+| Raw findings | 35 |
+| Dropped at merge (duplicates / out of scope) | 7 |
+| Candidates carried to verification | 15 |
+| — found by both passes `[x2]` | 8 |
+| — found by one pass `[x1]` | 7 |
+| Verifiers dispatched | 23 |
+| Survived verification | 9 |
+| Refuted | 6 |
+| Promoted from the watch list at the citation check | 1 |
+| Findings filed (N1–N10) | 10 |
+| Reproduced live | 10 |
+| Flagged as needing an owner decision | 9 |
+
+All ten findings reproduced on a running instance. Nothing in this file is inferred from reading code alone. N10 did not come through the finder/verifier funnel: it was parked in the watch list despite having been persisted and observed in N6's own reproduction, and the citation check moved it into Low as a finding of its own.
+
+---
+
+# Critical
+
+## N1 — Reconcile archives a Bastet subnet whose CIDR is still allocated in Azure by a *different* Azure subnet, after which BASTET advertises the Azure-assigned range as free space — and re-import is then refused `[x2]`
+
+**Severity:** critical · **Confidence:** confirmed
+**Citation:** `src/Bastet/Services/Azure/AzureReconciler.cs:367` (and the identical hole at `:376-381`)
+
+**Failure scenario.** Azure has no subnet rename, so re-organising one means delete-and-recreate. A VNet holds subnet `sn-a` with prefix `10.111.5.0/24`, imported into Bastet. `sn-a` is deleted and immediately recreated as `sn-a2` carrying the **same** prefix. `EvaluateSubnetLevel` keys only on the recorded ARM resource id (`:365-369`), so the Bastet row becomes `SubnetDeleted` — "The Azure subnet this was imported from no longer exists." That statement is *literally true*; the resource really is gone. What is missing is any range-level check. `ConfirmProposedDeletionsAsync` (`AzureController.cs:368-389`) asks ARM one question only — is this resource id gone — gets a genuine 404, and keeps the row. After approval the parent's Details page advertises the still-assigned `/24` as free with a **Create Subnet** button. The reconciler holds the contradicting evidence: `liveSubnetPrefixes`, built at `AzureReconciler.cs:64-71` from the same scan, contains `sn-a2 -> [10.111.5.0/24]`. The second route, `SubnetPrefixChanged` (`:376-381`), gets no direct ARM confirmation at all — `IsAbsenceStatus` (`:305-306`) covers only `VNetDeleted`/`SubnetDeleted` — so moving a prefix between two Azure subnets produces the same wrong output with even less friction.
+
+**Reproduction** — own instance port 5196, catalog `bastet_rig14_verc7`, own live fixture `rig-14-verc7-vnet` (10.111.0.0/16):
+
+```
+BEFORE  GET /Subnet/Details/1 "Unallocated IP Ranges":
+        10.111.0.0 - 10.111.4.255 (1,279)  |  10.111.7.0 - 10.111.255.254 (63,743)
+
+az network vnet subnet delete ... -n rig-14-verc7-sn-a
+az network vnet subnet create ... -n rig-14-verc7-sn-a2 --address-prefixes 10.111.5.0/24
+
+POST /Azure/ReconcileScan ->
+  items: [{subnetId:2, status:2, statusName:"SubnetDeleted",
+           reason:"The Azure subnet this was imported from no longer exists."}]
+  reviewItems: []  globalErrors: []  warnings: []  canCommit: true
+
+POST /Subnet/BulkDeleteStaleAzureSubnets {"subnetIds":[2],"confirmation":"approved"}
+  -> 200 {"success":true,"targetsDeleted":1,"subnetsArchived":1,"hostIpsArchived":0}
+
+AFTER   GET /Subnet/Details/1:
+        10.111.0.0 - 10.111.5.255 (1,535)   <- grew by exactly the 256 addresses ARM still assigns
+```
+
+Route B (`SubnetPrefixChanged`, no ARM confirmation at all) archived row 3 and left `/Subnet/Details/1` showing `10.111.0.0 - 10.111.255.255, 65,534 IP addresses` while ARM held three `/24`s assigned. While a sibling Azure-linked child survives, re-import is refused by both wizards: `GET /Azure/Import/1` → 302; the VNet prefix is `Blocked`/`isSelectable=false`; a hand-built `BulkImportPreview` returns `canCommit:false`. Once **all** children were archived the prefix returned to `WillUpdateExisting` — so it is un-re-importable while a sibling remains, not permanently unrecoverable.
+
+**Fix (finder's proposal, corrected by the verifier — the original was incomplete on three counts).** Build a second index alongside `liveSubnetPrefixes` at `:64-71` mapping each live IPv4 prefix to its owning Azure subnet, and consult it before adding an item to `plan.Items`. Corrections:
+
+1. **Do not build it with `ToDictionary`.** Two VNets in one subscription can carry overlapping address space (the rig itself ships `10.10.0.0/16` and `10.10.0.0/20`), so one prefix string has several live owners. Use `Dictionary<string, List<(ResourceId, SubnetName, VNetName)>>` with indexer/`TryAdd` accumulation — exactly as `:68` already avoids `ToDictionary` for the same reason. A `ToDictionary` here turns every scan of a subscription with duplicated private CIDRs into "The reconcile scan failed."
+2. **Scope the match to the row's own VNet.** Overlapping RFC1918 across unrelated VNets is the norm; matching on the bare prefix string withholds genuinely stale rows. Parse the `/virtualNetworks/{name}/` segment out of `snapshot.AzureResourceId` (`AzureResourceIdentity` already handles these ids) and treat only a same-VNet live owner as evidence the range is still allocated — which is precisely where a rename or prefix move keeps the range.
+3. **Routing to `ReviewItems` is a dead end as the application stands.** No screen can edit or clear `Subnet.AzureResourceId`; the only writers are the two import commits. Worse, `ApplyConfirmations` adds every `ReviewItem`'s `SubnetId` to the `withheld` set at `:263`, so `WithholdTargetsWhoseCascadeIsBlocked` would permanently withhold the parent VNet-level row too. **Do not ship the fail-closed half alone.** A dedicated status is also cheap and keeps the reason honest — reusing `ReviewItems` renders these rows with the misleading existing copy "Correct or clear the link on this subnet", which no screen can do.
+
+**Interim mitigation (ship this now, under any of the three options).** One LINQ pass, ~15 lines: a `plan.Warnings` entry naming every proposed deletion whose CIDR is still live in the scanned inventory under a different Azure resource id in the same VNet — *"N subnet(s) below are proposed for deletion but their address range is still assigned in Azure to subnet 'X'; archiving them will make BASTET report an allocated range as free."* Put the same sentence on the item's own `Reason` so it appears next to the checkbox, not only in the banner. No new ARM calls, no change to what is deletable, no new stuck state.
+
+**Decision needed from you.** Fail closed, warn loudly, or fail closed plus a new "re-link this subnet to Azure subnet X" action. Fail-closed alone strands the row and its ancestors forever (see correction 3). Fail-closed plus re-link is the correct end state and also fixes the un-re-importable-sibling case; it is the largest of the three. The warning ships under all three.
+
+*Note on grading:* this is the same operator-visible output round 13 filed as High under M1. It is graded critical here because the wrong state is produced by an **irreversible archive** rather than by a display path, and because two independent routes reach it with zero warnings. If your scale caps range-misreporting at High, grade it there — but do not discount it for the rename trigger being uncommon.
+
+---
+
+# High
+
+## N2 — Reconcile delete archives on a re-derived Azure verdict it never compares against the one the operator approved `[x1]`
+
+**Severity:** high · **Confidence:** confirmed
+**Citation:** `src/Bastet/Controllers/SubnetController.AzureReconcile.cs:78`
+
+**Failure scenario.** The wizard deliberately carries each row's *reason* onto the last screen before the archive (`_ReconcileScripts.cshtml:396-408`: "a row whose own reason says the Azure resource still exists was confirmed under a heading saying it did not"). The commit then throws that approval away: `stillStale = plan.Items.ToDictionary(i => i.SubnetId)` and `noLongerStale = request.SubnetIds.Where(id => !stillStale.ContainsKey(id))` test only **set membership** in the re-derived plan, never that the row is stale for the reason the operator saw. `VNetDeleted`/`SubnetDeleted` are absence claims that must survive a direct ARM read; `VNetPrefixRemoved`/`SubnetPrefixChanged` are drift verdicts taken off the listing with no direct read at all (deliberately — see `AzureReconciler.cs:186-196`). A row that moves from the first class to the second between the confirmation screen and the click stays in `plan.Items`, the 409 never fires, and the subtree is archived. Real trigger: an IaC destroy/apply with a changed CIDR — ARM ids are path-based, so the recreated VNet has the same id. The endpoint's own docstring at `:15-18` promises the opposite: *"a resource that reappeared in Azure cannot cause the wrong subnets to be archived."*
+
+**Reproduction** — own instance port 5199, catalog `bastet_rig14_v9c`, live fixture `rig-14-v9c-vnet`. Seeded Bastet subnet `V` 10.111.0.0/16 linked to the VNet, with a **manually created** child `prod-app-tier` 10.111.1.0/24 (no Azure provenance) and host IP `web01` 10.111.1.10:
+
+```
+az network vnet delete       -> rc 0 ; az network vnet show -> rc 3 (404)
+POST /Azure/ReconcileScan    -> statusName "VNetDeleted",
+   reason "The VNet this subnet was imported from no longer exists in Azure...",
+   descendantCount 1, hostIpCount 1, canCommit true       <- what the operator approves
+
+az network vnet create -n rig-14-v9c-vnet --address-prefixes 10.112.0.0/16   (same name = same ARM id)
+re-scan (same session) -> [(1,'VNetPrefixRemoved',"VNet ... still exists but no longer has
+                            the address prefix 10.111.0.0/16.")]
+
+POST /Subnet/BulkDeleteStaleAzureSubnets {"subnetIds":[1],"confirmation":"approved"}
+  -> HTTP 200 {"success":true,"targetsDeleted":1,"subnetsArchived":2,"hostIpsArchived":1}
+
+SELECT COUNT(*) FROM Subnets            -> 0
+SELECT ... FROM DeletedSubnets          -> prod-app-tier 10.111.1.0/24 ; V 10.111.0.0/16
+SELECT COUNT(*) FROM HostIpAssignments  -> 0
+```
+
+The banner reads "Deleted 1 stale subnet(s)" — a staleness claim the server had disproved milliseconds earlier. There is no restore from `DeletedSubnets` (round 13 established this on the record).
+
+**Fix (verifier: sound, with two tightenings).** Carry the approved verdict into the commit and refuse a mismatch, exactly as the bulk import commit already does for its plan (`DescribeApprovedPlanDivergences`, round 10's J2). Add `Statuses` (a per-id `{subnetId, statusName}` list) to `AzureReconcileDeleteDto`; snapshot `i.statusName` alongside `i.subnetId` at `_ReconcileScripts.cshtml:362` where `confirmedIds` is already frozen; at `SubnetController.AzureReconcile.cs:78` add the conjunct `stillStale[id].Status != approvedStatus[id]` returning the same 409 body, worded *"the reason N of the selected subnet(s) were flagged has changed since you reviewed them. Nothing was deleted. Re-run the scan."* Tightenings:
+
+1. The status arrives as a caller-supplied string: parse defensively and treat an **unparseable** value as a divergence, not as "unverified" — mirror how `DescribeApprovedPlanDivergences` handles `TargetType`. Only a **missing** status counts as unverified-and-logged.
+2. Comparing `Status` alone still lets a same-status/different-facts change through (a row approved as `SubnetPrefixChanged :: "now 10.111.1.0/24"` commits unchanged when the prefix has since moved again). If you want the guarantee the docstring claims, compare the server-derived `Reason` (or the observed Azure prefix) too, as the bulk path compares `ChildNames` in addition to `TargetType`.
+
+Keep the refusal all-or-nothing, returned before any lock is taken, and put the mismatched ids in the `subnetIds` array so the wizard can highlight them. Do not merge the two messages — "no longer reported as deleted" and "flagged for a different reason" call for different operator actions.
+
+**Interim mitigation (three lines, no DTO change).** At `:78`, also refuse when any selected id's re-derived status is a drift status (`SubnetPrefixChanged`/`VNetPrefixRemoved`) while `ConfirmProposedDeletionsAsync` was not asked about it — i.e. reject the absence→drift transition specifically, which is the only unprotected transition (every other class change moves the row into `ReviewItems` and out of `plan.Items`, which the existing 409 already catches). Cost: a plan that was drift-only from the start also 409s unless drift statuses are whitelisted.
+
+**Decision needed from you.** Whether an out-of-band Azure re-create inside the confirm window becomes a 409 the operator must re-scan through (safer, converts a legitimate drift deletion into a retry), and whether the approved-status check is mandatory or optional-and-logged for callers using this as the documented direct JSON API — the same fail-open-and-log trade-off already accepted at `SubnetController.BulkAzure.cs:99-106`.
+
+*Scope correction from the verifier:* the id-set archived equals the id-set approved, and every archived target is independently stale under the fresh verdict. The wrongness is that **consent was bound to a fact the server had disproved**, not that unselected rows were touched. Severity stays high: this is the only endpoint that deletes on the strength of what Azure reports, the removal is irreversible, and the operator would plausibly have chosen re-import over archive had the drift reason been shown.
+
+---
+
+## N3 — An IPv4 prefix Azure adds to an already-imported subnet is advertised by BASTET as free space, both import wizards refuse to import it, and the reconcile scan reports no differences `[x2]`
+
+**Severity:** high · **Confidence:** confirmed
+**Citation:** `src/Bastet/Services/Azure/AzureReconciler.cs:73`
+
+**Failure scenario.** Ordinary sequence, no operator error, no crafted request. Bulk-import a VNet and its multi-prefix subnet. Azure later adds a third prefix to that same subnet (`az network vnet subnet update --address-prefixes ...`) — routine since multi-prefix subnets went GA. From that moment: the Details page lists a range **containing** the newly assigned `/24` under "Unallocated IP Ranges" with a **Create Subnet** button; `ReconcileScan` returns `items 0, reviewItems 0, warnings [], globalErrors []`; and neither import path can correct it — `GET /Azure/Import/{id}` 302s with *"Subnet must not have any child subnets or host IP assignments"* (`AzureController.cs:39-45`), and the bulk wizard marks the VNet prefix `Blocked` (`AzureBulkImportPlanner.cs:199`) which disables every subnet row underneath it, including the new row the very same response marks `Available / isSelectable: true`. The tool renders the discrepancy on one page while denying it exists on two others. Structural cause: every `AzureReconcileStatus` starts from a Bastet row carrying an `AzureResourceId` — `BuildPlan` iterates `linkedSubnets` at `:73` and never walks the inventory looking for Azure ranges BASTET has no row for.
+
+**Reproduction** — own instance port 5342, catalog `bastet_rig14_verc1`, live fixture `rig-14-verc1-vnet` (10.90.0.0/16), subnet with prefixes `10.90.200.0/25` + `10.90.200.128/25`:
+
+```
+bulk import -> {"success":true,"createdTargets":1,"createdChildSubnets":2}
+az network vnet subnet update ... --address-prefixes 10.90.200.0/25 10.90.200.128/25 10.90.77.0/24
+
+POST /Azure/ReconcileScan -> {"scanSucceeded":true,"items":[],"reviewItems":[],
+                              "globalErrors":[],"warnings":[],"canCommit":false}
+
+GET /Subnet/Details/1 "Unallocated IP Ranges":
+  10.90.0.0   10.90.199.255   51,199 IP addresses   [Create Subnet]   <- contains 10.90.77.0/24
+  10.90.201.0 10.90.255.254   14,079 IP addresses   [Create Subnet]
+
+GET /Azure/Import/1                 -> 302 /Subnet/Details/1 ("must not have any child subnets")
+GET /Azure/BulkGetVNets             -> PREFIX 10.90.0.0/16 Blocked isSelectable false
+                                       SN 10.90.77.0/24 Available isSelectable TRUE
+POST /Azure/BulkImportPreview (crafted: ONLY the new prefix)
+  -> errors ["Cannot import VNet prefix 10.90.0.0/16: matched Bastet subnet ... already has child subnets."]
+POST /Subnet/BulkCreateFromAzurePlan -> HTTP 400, same error   (the gate is server-side, no API back door)
+
+THE HARM, EXECUTED:
+POST /Subnet/Create Name=team-web-block NetworkAddress=10.90.77.0 Cidr=24 ParentSubnetId=1
+  -> 302 /Subnet/Details/4 ; row persisted, AzureResourceId NULL
+BASTET allocated a /24 Azure had already assigned, with no warning.
+POST /Azure/ReconcileScan (with the double-allocation live) -> items [] warnings [] globalErrors []
+```
+
+**Fix (finder's proposal, corrected by the verifier — part (a) was underspecified and part (b) is dangerous).**
+
+**(a) The inbound verdict cannot be built from `BuildPlan`'s current inputs.** `BuildPlan` only receives `linkedSubnets`, and `AzureSubnetSnapshotService.GetAzureLinkedSubnetsAsync` (`:52`) filters to rows with a non-empty `AzureResourceId`. Proved false-positive: the hand-created `team-web-block` above exactly accounts for the Azure prefix but never enters `linkedSubnets`, so the proposed loop would report `10.90.77.0/24` as "not imported" forever. Two changes are required: **(i)** extend `IAzureReconciler.BuildPlan` to also take the full tree — `IAzureSubnetSnapshotService.GetExistingSubnetsAsync()` already returns every subnet and is already called by the bulk path; **(ii)** match by **containment, not `{network,cidr}` equality** — an IPAM routinely records a coarser allocation (Bastet has `10.90.64.0/18`; Azure carves `10.90.77.0/24` inside it), and that range *is* accounted for. Report only when no Bastet subnet contains the Azure prefix, and scope the walk to VNets at least one of whose prefixes maps to an existing Bastet target, or an unimported subscription produces an item per Azure subnet on every scan.
+
+**(b) Do not relax the two import gates as proposed.** `AnnotatePrefix:197-200` / `BuildPlanItem:379-383` block an exact-match target that has children for a reason that survives this finding: the commit path also renames the target, stamps `AzureResourceId` and can set `IsFullyAllocated` (`SubnetController.Azure.cs:397-399,404,410`). Loosening them to "block only when the selection would create a row that already exists" lets an import adopt and re-stamp a target whose children were created by hand — the state round 13's C4 analysis showed lets a later reconcile cascade archive non-Azure rows. See N4 for the narrower alternative.
+
+**(c)** The interim warning is the right first move, with the same full-tree + containment input as (a), or it fires on ranges Bastet legitimately accounts for and operators learn to ignore it.
+
+**Also worth doing regardless:** `BulkGetVNets` returns `10.90.77.0/24` as `Available / isSelectable: true` under a prefix it marks `Blocked / isSelectable: false` **in the same response**. Whatever is decided about the gates, mark a subnet row unselectable-with-a-reason when its own VNet prefix is blocked, so the wizard stops offering a row nothing can act on.
+
+**Interim mitigation.** A `plan.Warnings` entry (not an item) — *"Azure subnet 'X' owns 10.90.77.0/24, which no Bastet subnet records. BASTET will report that range as free."* Warnings are already rendered on the reconcile review screen, are never deletable, and `nothingToReport` (`_ReconcileScripts.cshtml:287`) already includes `warnings.length === 0`, so this correctly suppresses the "nothing to clean up" banner without touching the deletion path. ~30 lines, no schema, no UI change.
+
+**Decision needed from you.** (1) Does the reconciler get an inbound verdict at all — a new `AzureReconcileStatus`, the wider `BuildPlan` input, and a report-only never-deletable review row? Roughly a day plus tests; the cheap half ships first and is independently useful. (2) Should there be any supported path to pull new Azure prefixes into an already-imported target — covered in N4.
+
+*Narrative correction:* the JSON is `items 0, warnings []`, but the green banner it drives (`_StepReview.cshtml:30`) reads "Everything imported from this subscription still exists in Azure. There is nothing to clean up." — carefully scoped to the outbound direction and not literally false. The defect is that the only comparison feature in the product has **no inbound verdict at all**, so the free-space page lies unopposed.
+
+---
+
+## N4 — An Azure subnet that gains an IPv4 prefix after import can never be imported by either wizard, and the Details page keeps offering the Azure-assigned range as free `[x2]`
+
+**Severity:** high · **Confidence:** confirmed
+**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:199` (server-side mirror at `:382`; single-VNet gate at `AzureController.cs:38-44`)
+
+**Failure scenario.** N3 is the reconciler's blindness; this is the import side of the same dead end, and it is a separate change with a separate owner decision. `AnnotatePrefix:199` blocks the whole VNet prefix — "Bastet subnet 'X' already has child subnets. Already imported?" — and `_BulkScripts.cshtml:249` sets `.prop('disabled', !subnet.isSelectable || !prefixInfo.isSelectable)`, so the one genuinely-new subnet row is un-tickable; `buildSelectionFromUI` only walks *checked* prefixes, so it can never be submitted. A hand-crafted POST is refused server-side by the mirror at `:382`. The single-VNet wizard refuses at the door. The identical dead end is reached by a second, arguably more likely route that starts **inside the reconcile wizard**: remove a prefix in Azure, reconcile correctly offers the drift row, the operator approves and it is archived — then Azure restores the prefix. Both wizards then refuse to bring it back, and the Details page advertises the live Azure-assigned range as free.
+
+**Reproduction** — own instance port 5219, catalog `bastet_rig14_verc2`, own fixture `rig-14-verc2-vnet` 10.90.0.0/16:
+
+```
+bulk import (real endpoints) -> {"success":true,"createdTargets":1,"createdChildSubnets":3}
+az network vnet subnet update ... -n rig-14-verc2-sn-multi \
+   --address-prefixes 10.90.100.0/24 10.90.101.0/24 10.90.102.0/24
+
+GET /Azure/BulkGetVNets (verbatim):
+  PREFIX 10.90.0.0/16      Blocked False  "Bastet subnet ... already has child subnets. Already imported?"
+  SN  10.90.100.0/24       AlreadyImported False
+  SN  10.90.101.0/24       AlreadyImported False
+  SN  10.90.102.0/24       Available       True     <- offered, but un-tickable (parent blocked)
+
+crafted POST (only the new prefix): preview canCommit False ; commit HTTP 400 (BuildPlanItem:382)
+GET /Azure/Import/1 -> 302 /Subnet/Details/1
+POST /Azure/ReconcileScan -> items [] reviewItems [] warnings [] globalErrors []
+
+GET /Subnet/Details/1 "Unallocated IP Ranges":
+  10.90.0.0    10.90.4.255     1,279    Create Subnet
+  10.90.6.0    10.90.99.255   24,064    Create Subnet
+  10.90.102.0  10.90.255.254  39,423    Create Subnet   <- over the /24 Azure just assigned
+
+escape hatch: POST /Subnet/Create 10.90.102.0/24 under parent 1 -> 302, row persists,
+              AzureResourceId NULL (only the two import paths ever write that column)
+```
+
+**Fix (verifier: incomplete — direction right, four gaps).** Narrow the `HasChildSubnets` hard stop to a **top-up import**: when the matched target already has children, keep the prefix selectable and let `AnnotateSubnet` do the discriminating it already does correctly (measured: 3 rows `AlreadyImported`, 1 `Available`). Keep the existing refusals for a target that is fully allocated, has host IPs, or is linked to a different VNet. Gaps to close first:
+
+1. **Scope the exact-match target's side effects.** A selectable ExactMatch prefix drives `SubnetController.BulkAzure.cs:346` (`targetSubnet.AzureResourceId = sanitizedVNetResourceId`) and, when a child fully encompasses the prefix, `WillMarkFullyAllocated`. Re-stamping the same VNet id is idempotent (a different VNet stays blocked at `AzureBulkImportPlanner.cs:216-223`/`:397-401`), but marking a target `IsFullyAllocated` when it already has children is a contradictory write the existing gate has been incidentally preventing. Add an explicit refusal.
+2. **The blocked prefix must become `WillUpdateExisting` with distinct preview copy** — how many children will be created, and that existing ones are untouched — not the first-import wording "Will import into existing Bastet subnet 'X'", which reads as a re-import. `BuildPlanItem`'s `renameMatched` path also needs deciding: renaming a populated target on a top-up is almost certainly not wanted.
+3. **The single-VNet wizard is not fixed by this change.** `AzureController.Import` refuses on `subnet.ChildSubnets.Count != 0` before the planner is consulted. Either narrow that gate the same way, or state explicitly that top-up is bulk-wizard-only — otherwise the headline "neither wizard" stays half-true after the fix.
+4. **The reconciler half (N3) is what stops this recurring and should not be optional.** Without an inbound status the model silently re-diverges on the next Azure change.
+
+**Interim mitigation — put it on the Details page, not the wizard.** Do **not** ship the finder's proposed "extend the Blocked reason to name the un-imported prefixes" alone: it requires reordering `AnnotateAvailability` (prefixes are annotated before subnets, `:164-169`), and it puts the warning on the one screen the operator has no reason to visit while `/Subnet/Details/{id}` keeps printing the allocated range under "Unallocated IP Ranges" with a Create Subnet button. For an Azure-linked subnet, the free-space table is the thing that is wrong.
+
+**Decision needed from you.** Whether BASTET supports a top-up import at all — importing new Azure prefixes into a target that already has children — versus keeping "a populated target is never an import destination" and only *detecting and reporting* the divergence (N3's reconciler status plus a Details-page warning), leaving the operator to create the range by hand. The first is a change to the planner's target rules plus preview copy plus the single-VNet gate; the second is smaller, weakens no existing guard, but leaves the correction manual and the resulting row permanently unlinked from Azure. **Either way the free-space lie on `/Subnet/Details/{id}` needs closing; that part is not optional.**
+
+*Two narrative corrections:* (a) "no in-app path back to a correct model" is too strong — `POST /Subnet/Create` does create the missing range (measured); the correct statement is "no path back to an *Azure-linked* correct model, and nothing in the application tells the operator the model is wrong". (b) The multi-prefix GA feature is the common **trigger**, not the mechanism — any Azure change that adds an unmodelled range under an already-imported VNet prefix reaches the same dead end.
+
+---
+
+# Medium
+
+## N5 — A failed `sp_releaseapplock` is swallowed on a documented invariant that is false: closing the connection returns the session to the pool, so the global subnet write lock stays held and every replica's writes fail for minutes with "high concurrency" `[x1]`
+
+**Severity:** medium · **Confidence:** **plausible**
+**Load-bearing step that could not be established:** no **natural** (non-injected) failure of `sp_releaseapplock` that leaves the SQL session alive was produced. Every fault applicable on the shared rig also kills the session, which releases the lock safely. The trigger class is real rather than invented — a command timeout whose ATTENTION is acked, and Azure SQL 10928/10929/40501 resource-governance errors, all return a `SqlException` on a still-open connection, and the maintainers' own comment at `Program.cs:459-461` records a release failure reproduced against a real server. **Everything downstream of the trigger was measured**, with the failure injected: that the lock survives return-to-pool, for 4+ minutes, and that the peer replica then fails for 30 s with a false message. The migration-lock half was reasoned from the same measured pooling behaviour, not executed.
+**Citation:** `src/Bastet/Services/Locking/SqlServerSubnetLockingService.cs:96` (swallowing catch at `:98-101`, false comment at `:91-93`, outer finally at `:104-107`); same false comment at `Program.cs:461-463`.
+
+**Failure scenario.** Two replicas against one database — the multi-replica shape `Program.cs` and the DataProtection key ring exist to support. Replica A serves `POST /Subnet/Create`; `sp_getapplock 'Bastet:SubnetOperations'` is taken **Session**-owned on the request's EF connection; the subnet is committed; `sp_releaseapplock` fails for any reason that leaves the connection usable. The catch logs and continues on the stated grounds that "if it is alive the outer finally closes it anyway". **It does not.** `context.Database.CloseConnectionAsync()` returns the connection to SqlClient's pool; the SQL session stays open; a Session-owned application lock is dropped only when the pooled connection is next *used* (`sp_reset_connection`) or physically destroyed. During that window every subnet/host-IP write on replica B parks 30 s inside `sp_getapplock` and fails — interactive forms with *"The operation timed out due to high concurrency. Please try again."*, Azure endpoints with 503 "another subnet operation is in progress" — none of which is true. The operator's only offered remedy ("try again") keeps failing. The same false claim governs the `Bastet:Migration` lock; on the bootstrap path that connection lives in a master-catalog pool the app never reuses, so a stranded migration lock persists for the process lifetime and later cold starts burn the full 300000 ms `@LockTimeout` before aborting with "Another replica appears to be stuck applying migrations."
+
+**Reproduction** — scratch copy of HEAD at `$RIG/ver-c8/repo` (nothing written into the repo; `git status --porcelain -uall` empty afterwards). Only change: a one-shot `throw` at the top of `ReleaseAppLockAsync`, gated on `VERC8_FAULT=1`. Two replicas, ports 5231/5232, catalog `bastet_v14c8`:
+
+```
+POST /Subnet/Create (replica A) -> 302 /Subnet/Details/1 in 0.118 s   (row committed)
+log: "Failed to release the subnet operation lock after the operation completed"
+
+APPLOCK_TEST('public','Bastet:SubnetOperations','Exclusive','Session')
+  before POST -> 1 (free)      after POST -> 0 (HELD, request finished, DbContext disposed)
+sys.dm_tran_locks  -> session 96, 0:[Bastet:SubnetOperations]:(b83d66a6)
+sys.dm_exec_sessions -> status 'sleeping', program_name 'EFCore/10.0.10'   <- alive in the pool
+
+POST /Subnet/Create (replica B) -> 200 in 30.049 s,
+  rendered: "The operation timed out due to high concurrency. Please try again."
+  Subnets table: only vc8-a. Nothing written. Repeated 5 minutes later: identical.
+
+Held on an idle holder: t+11s .. t+297s -> APPLOCK_TEST 0 throughout (4m12s watched).
+Holder self-heals: 5 read-only GETs on replica A -> lock free, A's next create 302 in 0.026 s.
+Replica B has no way to cause that; it can only block 30 s and fail.
+
+PROPOSED FIX, same rig, same injected fault (SqlConnection.ClearPool in the catch):
+  create -> 302 in 0.183 s ; log still records the failed release
+  APPLOCK_TEST pre=1 post=1 post+5s=1        <- NOT stranded
+  replica B create immediately after -> 302 in 0.134 s   (was 30 s / failed)
+```
+
+**Fix (primary sound and verified running; the secondary half was corrected).** In the catch at `:98`, destroy the physical connection so the SQL session — and with it the Session-owned lock — actually ends:
+
+```csharp
+catch (Exception ex)
+{
+    logger.LogError(ex, "Failed to release the subnet operation lock; discarding the pooled connection so the session-owned lock is dropped");
+    if (context.Database.GetDbConnection() is SqlConnection stranded)
+    {
+        SqlConnection.ClearPool(stranded);
+    }
+}
+```
+
+`using Microsoft.Data.SqlClient;` is already at the top of the file, so the fully-qualified names in the original proposal are unnecessary. Two things the proposal omitted: **(a)** `ClearPool` empties the **whole** pool for that connection string — a transient reconnect cost paid only on this error path, and there is no per-connection "do not pool" API in Microsoft.Data.SqlClient, so this is the only public mechanism; **(b)** the log message must stop asserting the false invariant, and the comments at `:91-93` and `Program.cs:461-463` must be corrected — closing an EF/ADO connection returns it to the pool, it does not end the session, and a session-owned applock outlives it.
+
+**Correction to the secondary fix.** Do **not** add `Pooling=false` inside `MigrationLockConnectionString.Configured`: that method's documented contract is the connection string returned verbatim, `MigrationLockConnectionStringTests.cs:40` asserts `Assert.Equal(connectionString, Configured(connectionString))` and would fail, and routing it through `SqlConnectionStringBuilder` also destroys the deliberate null-in/null-out behaviour documented at `MigrationLockConnectionString.cs:31-37`. Use the same remedy as the service — `SqlConnection.ClearPool(migrationLockConnection)` inside the existing catch at `Program.cs:475-480`, before the `using` disposes it. That covers both branches uniformly and touches no unit-tested contract.
+
+**Interim mitigation.** Raise `SqlServerSubnetLockingService.cs:100` from `LogError` to `LogCritical` and say what it means — *"the global subnet lock may be stranded on a pooled connection; restart this replica if subnet operations start timing out"* — so the 30-second "high concurrency" failures that follow are diagnosable instead of being misattributed to load.
+
+**Decision needed from you.** Whether the pool-wide blast radius of `ClearPool` on the release-failure path is acceptable: the replica pays a burst of TCP+TLS+login handshakes right after a failed release. Alternatives: (b) leave the lock stranded and make the peer's failure honest — "the lock is held by another replica's stale session" plus a documented `sp_releaseapplock`/KILL runbook; or (c) change the lock's ownership model, which the class remarks at lines 13-20 explicitly rejected for good reasons. **(a) is cheapest and is the one verified to work.**
+
+*Scope narrowed by the verifier:* the holding replica self-heals on its very next query, so single-replica deployments recover almost immediately. The damage that persists is **cross-replica** — replica B has its own pool and can do nothing to reset A's session, so B's writes stay broken until A happens to touch that one connection: unbounded if A is idle, drained, or scaled to zero. Medium is right — writes are denied and the error message is a lie, but nothing is corrupted and no allocated range is ever reported free.
+
+---
+
+# Low
+
+## N6 — Bulk import's multi-prefix name qualification is scoped to one VNet address prefix, so an Azure subnet whose prefixes fall under different VNet prefixes persists as two Bastet rows with the identical name and the identical `AzureResourceId` `[x2]`
+
+**Severity:** low · **Confidence:** confirmed
+**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:509` (grouping at `:511`, `usedNames` at `:486`, `Contains` at `:527`, `DisambiguateName` at `:533`)
+
+**Failure scenario.** A VNet has two address prefixes (10.71.0.0/16, 10.72.0.0/16) and one Azure subnet owns one IPv4 prefix in each. `BuildPlanItem` runs once per selected VNet address prefix, and `multiPrefixResourceIds` is built only from **that prefix's** subnet rows — so each item sees exactly one row for the resource id, `Count() > 1` is false, and no prefix qualification is applied. `usedNames` is also per-item and seeded only from the item's own target names, so `DisambiguateName` cannot catch it either. Result: two child subnets with the **same name** and the **same Azure subnet resource id**, distinguishable only by CIDR — precisely the state round 13's M1 naming work exists to prevent. Reachable in one click of "Select all"; the wizard groups subnet checkboxes under prefixes by containment, so no crafted payload is needed.
+
+**Reproduction** — own instance port 5193, catalog `bastet_rig14_verc3`, existing fixture `rig-14-b5p2-vnet`:
+
+```
+ARM: prefixes ["10.71.0.0/16","10.72.0.0/16"], subnet rig-14-b5p2-sn-span
+     addressPrefix null, addressPrefixes ["10.71.5.0/24","10.72.5.0/24"]
+
+POST /Azure/BulkImportPreview (exact payload buildSelectionFromUI produces for "select all")
+  -> 200, canCommit true, globalErrors []
+     item 10.71.0.0/16 -> childSubnets[0].name "rig-14-b5p2-sn-span"   (UNQUALIFIED)
+     item 10.72.0.0/16 -> childSubnets[0].name "rig-14-b5p2-sn-span"   (UNQUALIFIED)
+
+POST /Subnet/BulkCreateFromAzurePlan -> {"success":true,"createdTargets":2,"createdChildSubnets":2}
+  2 |rig-14-b5p2-vnet   |10.71.0.0|16|NULL
+  3 |rig-14-b5p2-sn-span|10.71.5.0|24|2
+  4 |rig-14-b5p2-vnet   |10.72.0.0|16|NULL
+  5 |rig-14-b5p2-sn-span|10.72.5.0|24|4
+rows 3 and 5 carry the SAME AzureResourceId .../subnets/rig-14-b5p2-sn-span
+
+Counter-test that narrows the finding: splitting an ordinary multi-prefix subnet (both prefixes
+inside ONE VNet prefix) across two sessions was REFUSED — "Cannot import VNet prefix 10.10.0.0/16:
+matched Bastet subnet 'rig-14-vnet-a1' ... already has child subnets." So the cross-session route
+needs the same spanning fixture; the two claimed routes are one trigger, not two.
+```
+
+**Fix (verifier: part 1 sound with one correction, part 2 unsound as written, part 3 split out to N10).**
+
+1. **Hoist the grouping out of `BuildPlanItem` into `BuildPlan`**, computing `multiPrefixResourceIds` once across every selected prefix of every VNet, and pass the set in. That is the whole of the single-session fix. **Keep the `!s.FullyEncompasses && !string.IsNullOrEmpty(s.Source.AzureResourceId)` filter that `:510` has today** — the proposal's wording drops it, and this fixture disproves M1's recorded assumption that an encompassing prefix cannot have a sibling prefix on the same Azure subnet (a subnet may equal VNet prefix 1 exactly and still hold a prefix inside VNet prefix 2). Without the filter, the encompassing selection would inflate the group to 2 and the one child that *is* created would be needlessly renamed.
+2. **Do not seed `usedNames` from the existing tree.** `usedNames` feeds `DisambiguateName`, which appends the **VNet name**, not the prefix — so the cross-session second row would land as `name (vnet-name)`, a different and inconsistent shape from the single-session `name (10.72.5.0/24)`. Worse, seeding from the whole `existingSubnets` list makes every ordinary import rename any child whose Azure name matches **any** existing Bastet subnet anywhere in the tree, including unrelated branches — a broad silent rename regression in the common path, exactly what M1 was careful to avoid. **Correct targeted fix:** in `BuildPlanItem`, prefix-qualify a planned child when `existingSubnets` already contains a row whose `AzureResourceId` equals `sub.Source.AzureResourceId` and whose `{NetworkAddress, Cidr}` is not this selection's. Same `name (network/cidr)` shape, fires only for the real multi-row case, needs no DTO or ARM change (the commit never re-queries Azure and `BulkImportSelectedSubnetDto` carries no prefix count). The already-persisted first row keeps its bare name and remains unambiguous because the new row is qualified.
+3. **The `TargetName(p)` half is a separate reproduced defect, filed as N10 — not deferred.** Two same-named Bastet targets for a two-address-space VNet were persisted in this very run (rows 2 and 4 of the output above). It is a different code path with its own owner decision, so it is fixed there rather than here; it is not a hole in round 13's guard, which is why it is a finding of its own rather than part of this one.
+
+*(If you take N7's separator change, note that the qualification suffix produced here should use it too.)*
+
+**Interim mitigation.** In `DetectExistingBastetSubnetConflicts`/`AnnotateSubnet`, warn per item when a planned child's final name equals an existing Bastet subnet name under the same target or another planned child's name in the same commit, so the preview discloses the collision before the operator confirms. Sound and cheap — but it is a disclosure, not a fix.
+
+**Decision needed from you.** (1) Whether prefix-qualified names apply across the whole commit and across sessions — the fix changes names some installs see on their **next** import of such a VNet (nothing already persisted is renamed) — versus shipping only the preview warning. (2) The `TargetName` question — whether a target should be prefix-qualified when a VNet contributes several selected prefixes — is N10's decision, taken on its own merits.
+
+*Consequence corrected downward by the verifier:* "no way to tell which range they are acting on from the name alone" is overstated — every render carries the address beside the name (`_SubnetTreeItem.cshtml:17-18`, `_ChildSubnets.cshtml:44-45`, `Delete/_WarningAlert.cshtml:6`, `AllHostIps.cshtml:53`, and all three reconcile lists). Every persisted range, parent link and Azure link is correct; nothing is misreported as free. This is a **broken deliberate invariant with a display-ambiguity consequence**, hence low — a judgement on consequence, not on rarity.
+
+---
+
+## N7 — Round 13's name qualification builds subnet names containing `/`, the one character the app's own name rules forbid; the create-from-unallocated-range prefill then silently rewrites `(10.20.40.0/24)` to `(10.20.40.024)` and persists that false token `[x1]`
+
+**Severity:** low · **Confidence:** confirmed
+**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:530` and `src/Bastet/Controllers/SubnetController.Azure.cs:276`
+
+**Failure scenario.** Bulk import creates rows named `rig-14-sn-a2-multi3 (10.20.40.0/24)`. `Subnet.Name` accepts them (Edit applies only `[NoHtml]`/`[SanitizeName]`), but `CreateSubnetViewModel.Name` carries `[SafeText]`, whose class `[a-zA-Z0-9\s\-_.,!?@#$%&()+=]` excludes `/`. Two operator-visible consequences: **(1)** the name the app generated is a name the app's own Create form refuses; **(2)** the Details page's **Create Subnet** button on an unallocated range navigates to `/Subnet/Create?parentId=…`, where `SubnetController.Create.cs:76` runs `SubnetNaming.ToSafeText(parentSubnet.Name)` precisely to avoid that rejection — and `ToSafeText` **deletes** the `/` rather than rejecting, so the prefilled default becomes `rig-14-sn-a2-multi3 (10.20.40.024)-10.20.40.0-25`. An operator who accepts the default — which is what that button exists for — persists it. The rule is written verbatim in a comment in the very controller that prefills the form, at `SubnetController.Create.cs:67-68`: *`"-{cidr}" and not "/{cidr}": [SafeText] on CreateSubnetViewModel.Name forbids "/"`*. This is the exact failure round 4's D19/D8 fixed; round 13 reintroduced the character, and `test/Bastet.Tests/Azure/AzureMultiPrefixImportCommitTests.cs:124-125` now pins the slashed form.
+
+**Reproduction** — own instance port 5891, catalog `bastet_rig14_verc12b`, live ARM:
+
+```
+POST /Subnet/BulkCreateFromAzurePlan -> {"success":true,"createdTargets":1,"createdChildSubnets":5}
+  2|rig-14-sn-a2-multi3 (10.20.40.0/24)|10.20.40.0|24|1        (etc.)
+
+GET /Subnet/Details/2 renders
+  <button class="create-subnet-btn" data-network="10.20.40.0" data-parent-id="2" data-parent-cidr="24">
+  and navigates to /Subnet/Create?networkAddress=..&cidr=..&parentId=..
+
+GET /Subnet/Create?networkAddress=10.20.40.0&cidr=25&parentId=2 ->
+  value="rig-14-sn-a2-multi3 (10.20.40.024)-10.20.40.0-25"      <- the "/" was deleted
+
+POST /Subnet/Create with that default -> 302 /Subnet/Details/7
+  7|rig-14-sn-a2-multi3 (10.20.40.024)-10.20.40.0-25|10.20.40.0|25|2
+
+POST /Subnet/Create Name="rig-14-sn-a2-multi3 (10.20.40.0/24)-child"
+  -> 200 with field error "Subnet name contains invalid characters"
+```
+
+**Fix (verifier: sound, with two additions).** Change the suffix at both sites from `$" ({network}/{cidr})"` to a separator the SafeText class admits — `$" ({network}-{cidr})"`, matching the convention `Create.cs:81` already uses. Verified: `-`, `.`, `(`, `)` are all inside the class, and the prefill then composes the coherent `rig-14-sn-a2-multi3 (10.20.40.0-24)-10.20.40.0-25`. These two are the only name-producing `/` sites in the repo (all other `({x}/{y})` interpolations are validation or error messages, none written to `Subnet.Name`). Additions:
+
+1. **The pinned assertions are in three places, not two** — `AzureMultiPrefixImportCommitTests.cs:124-125` **and** `AzureMultiPrefixSubnetTests.cs:142`, plus fixture names at `:207`/`:270` for consistency.
+2. **Add the recurrence guard that is missing.** `SubnetNamingSafeTextTests` pins `ToSafeText` character-by-character, but nothing asserts that a **generated** name satisfies `IsSafeText` — which is why round 13 reintroduced the character round 4 removed. Assert `new InputSanitizationService().IsSafeText(name)` over the planner's `BulkImportPlannedChildSubnet.Name` and `ResolveImportNames`' output. That is the cheap thing that stops a third occurrence.
+
+**Do not take the finder's own interim instead of the fix.** Making `ToSafeText` map `/` to `-` would leave the app still generating names its Create form rejects, and changes long-standing behaviour for hand-typed parents ("Prod/Web" → "Prod-Web"), breaking the pinned `InlineData` at `SubnetNamingSafeTextTests.cs:42`. As a stop-gap *alongside* the decision it is acceptable — it stops the prefill inventing `(10.20.40.024)` — but it is not a substitute.
+
+**Decision needed from you.** The suffix format is a naming/product call. Either **(a)** change the separator to `-` so generated names satisfy the app's own SafeText class — cosmetically different, three test assertions, and **no rename migration is needed because the code shipped one commit ago; the window to change it freely is now** — or **(b)** keep `/` in stored names and relax `[SafeText]` on `CreateSubnetViewModel.Name` to admit it (which Edit already effectively allows), accepting the security-review implication of widening a shared input class. Doing neither leaves the app generating names it refuses on input.
+
+*Harm corrected downward:* `10.20.40.024` is unparseable gibberish, not a plausible-but-wrong range, so an operator reads it as a mangled name rather than as a false allocation. `NetworkAddress`/`Cidr` are correct everywhere and Details renders `10.20.40.0/25` truthfully. Nothing in the IPAM data model is wrong — hence low, not the "allocated range shown free" class.
+
+---
+
+## N8 — `FullyAllocatedNote.For` can build a note that `FullyAllocatedNote.Strip` is structurally unable to remove, so M3's stacking defect returns in full `[x2]`
+
+**Severity:** low · **Confidence:** confirmed
+**Citation:** `src/Bastet/Services/FullyAllocatedNote.cs:23` (`Strip` at `:36-48`, `IsNote` at `:76-82`)
+
+**Failure scenario.** `For` interpolates the Azure subnet name with no whitespace normalisation, while `Strip`/`IsNote` split the description on `\n` and require a **single line** to both start with the prefix and end with the suffix. A name containing a newline therefore produces a note spanning two lines, neither of which satisfies both anchors, so no later `Strip` can ever remove it. `AzureImportSubnetViewModel.Name` inherits `[SafeText]` from `CreateSubnetViewModel` (`SubnetViewModels.cs:11`), whose class admits `\s` — which includes newline — and `SanitizeName` only trims the ends. An Admin posts `Subnet/BatchCreateChildSubnets` with `isAzureImport=true`, a fully-encompassing entry, and a name of `sn-A<LF>sn-B`. Result: **(1)** after `HostIp/SetAllocationStatus IsFullyAllocated=false` the row has `IsFullyAllocated=0` while its description still reads "Fully allocated by Azure subnet '...' which encompasses the entire address space." — the exact contradiction M3's un-mark mirror exists to eliminate; **(2)** each import→un-mark→import cycle appends another copy, which is M3's original defect verbatim. Azure subnet names cannot contain newlines, so the trigger is a crafted or replayed POST by an Admin — the same threat model `ResolveImportNames` is explicitly settled server-side against (`SubnetController.Azure.cs:244-247`).
+
+**Reproduction** — own instance port 5361, catalog `bastet_rig14_advc5`. Name posted as a literal `sn-A<LF>sn-B` via `--data-urlencode 'subnets[0].Name@nl.txt'`; the server accepted it (302, no ModelState error):
+
+```
+SELECT Id, IsFullyAllocated, LEN(Description), REPLACE(Description,CHAR(10),'<LF>') FROM Subnets WHERE Id=1
+
+  baseline        1|0|19 |Ops owns this range
+  after import 1  1|1|107|Ops owns this range<LF>Fully allocated by Azure subnet 'sn-A<LF>sn-B' which ...
+  after un-mark   1|0|107|<IDENTICAL — the note SURVIVED SetAllocationStatus IsFullyAllocated=false>
+  after import 2  1|1|195|<operator line + TWO identical notes>
+  after cycle 3   1|1|283|<operator line + THREE identical notes>
+  final un-mark   1|0|283
+
+Growth 88 chars per cycle, exactly M3's original arithmetic. Control: the operator line
+"Ops owns this range" is preserved throughout, so Strip works normally — it is specifically
+the two-line note it cannot see. Rendered Details shows three copies on a row whose
+IsFullyAllocated is 0.
+```
+
+**Fix (verifier: sound).** One line at `FullyAllocatedNote.cs:23` — normalise the name before interpolation, e.g. `azureSubnetName?.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ')`. Every note becomes single-line by construction, so `Strip`'s whole-line anchoring becomes total without loosening it. `For` is the single choke point both call sites go through; the null case is unchanged; the four `[Theory]` cases pinning operator prose exercise `Strip`, not `For`, so they are untouched. Add a test asserting `Strip(Append(null, "a\nb", 1000))` is empty. **Do not** take the "cheaper interim" of collapsing newlines at the two producers — it leaves the helper able to build an unstrippable note for any future caller, as the finder himself notes. **Do not** "fix" this by tightening the `[SafeText]` pattern; that class is shared with host names and subnet names across the app.
+
+**Decision needed from you.** Whether to do anything about rows that already carry an unstrippable two-line note. None can exist without someone having already sent a crafted POST, and round 13 explicitly declined a backfill for the analogous stacked-note residue — but the code fix alone leaves those rows permanently un-repairable except by hand-editing the description.
+
+*Bounded harm:* no IPAM correctness impact (the `IsFullyAllocated` flag itself is written correctly, no range is shown free), no data loss (the overflow branch at `:71-73` keeps operator text whole and growth is capped at `MaxSubnetDescriptionLength`), and the row is hand-repairable via Edit. What is wrong is a free-text field asserting the opposite of the row's state, permanently un-removable by the app, plus unbounded restacking. A shade worse than M3's own Info rating because the residue is now un-strippable rather than self-healing.
+
+---
+
+## N9 — Both new `multiPrefixResourceIds` sets are built with a collection expression, silently discarding the `StringComparer.OrdinalIgnoreCase` on the `GroupBy` immediately above `[x1]`
+
+**Severity:** low · **Confidence:** confirmed
+**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:509` (grouping `:511`, `Contains` `:527`) and `src/Bastet/Controllers/SubnetController.Azure.cs:250`
+
+**Failure scenario.** `HashSet<string> multiPrefixResourceIds = [.. …GroupBy(s => s.Source.AzureResourceId, StringComparer.OrdinalIgnoreCase)…]` — the collection expression constructs a plain `HashSet<string>` with `EqualityComparer<string>.Default`, so the later `Contains` is case-**sensitive** even though the grouping that filled the set was case-insensitive. `GroupBy` keeps only the first member's spelling as `g.Key`, so every sibling row whose ARM id differs in case fails the `Contains` test and is not prefix-qualified. ARM resource ids are case-insensitive, so this is a legitimate variation; the wizards echo one server response, which puts the trigger at a crafted or replayed POST — precisely the case `ResolveImportNames`' own remarks say it exists to handle ("a crafted or replayed post carries whatever names it likes"). The hardening added for crafted posts is itself defeated by a crafted post. The intent is unambiguous: `used`, built three lines below the same collection expression at `SubnetController.Azure.cs:257`, `usedNames` at `AzureBulkImportPlanner.cs:486`, and both dictionaries at `AzureReconciler.cs:45-46` are all explicitly `OrdinalIgnoreCase`. These two collection expressions are the only ordinal resource-id collections in the Azure code.
+
+**Reproduction** — own instance port 5211, catalog `bastet_rig14_vc11`. Only variable between runs is the casing of the `subnets`/`Subnets` segment on rows 2 and 3:
+
+```
+POST /Azure/BulkImportPreview
+CONTROL (all ids identically spelled):
+  'rig-14-sn-a2-multi3 (10.20.40.0/24)'  'rig-14-sn-a2-multi3 (10.20.5.0/24)'  'rig-14-sn-a2-multi3 (10.20.20.0/24)'
+MIXED (rows 2-3 use .../Subnets/...):
+  'rig-14-sn-a2-multi3 (10.20.40.0/24)'
+  'rig-14-sn-a2-multi3'                    <- lost its prefix qualification
+  'rig-14-sn-a2-multi3 (rig-14-vnet-a2)'   <- disambiguated by VNet, not by range
+
+POST /Subnet/BatchCreateChildSubnets (same mixed casing) -> 302; persisted:
+  3|rig-14-sn-a2-multi3|10.20.5.0|24        <- bare Azure name in the database
+Control on the same endpoint with identical spellings: all three rows qualified by range.
+```
+
+**Fix (verifier: sound, compiled and run).** Replace both collection expressions with an explicit constructor: `HashSet<string> multiPrefixResourceIds = new([.. …], StringComparer.OrdinalIgnoreCase);` at `AzureBulkImportPlanner.cs:509` and `SubnetController.Azure.cs:250`. Verified in a throwaway net10.0 project: it compiles (the collection expression cannot convert to `int`, so the capacity overload is not a candidate) and yields `contains a/b = True` for a set built from a group keyed `A/b`. Two lines, no behavioural risk to the identical-casing path. **Do not take the offered interim** of `ToLowerInvariant` on ingest: that changes the `AzureResourceId` Bastet persists and displays on every import path — a data change with its own blast radius (`BelongsToSubscription` `StartsWith` checks, existing mixed-case rows) — and is strictly more expensive and more dangerous than the two-line comparer correction.
+
+*Consequence corrected downward — strike the "distinguishable only by CIDR" claim.* Exactly **one** row per group loses its qualification (the `used`/`usedNames` fallback catches every later sibling), traced across 2-, 3- and 4-row groups and every ordering of spellings, so batch names stay mutually distinct and **no name collision occurs**. No prefix is dropped, `AzureResourceId`/`NetworkAddress`/`Cidr` are all correct, no range is shown free, and the reconciler is case-insensitive so nothing escalates there. The surviving harm is a documented naming rule applied **inconsistently** — one row keeps the bare Azure name, and in the bulk path a sibling is disambiguated by VNet name rather than by the range it holds, which is actively misleading about why it was renamed.
+
+---
+
+## N10 — Every selected VNet address prefix creates a target named for the bare VNet, so a VNet with two address prefixes persists as two Bastet subnets with the identical name and the identical `AzureResourceId` *(promoted from the watch list by the citation check)*
+
+**Severity:** low · **Confidence:** confirmed
+**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:728` (callers at `:427` and `:444`; the commit that persists it at `src/Bastet/Controllers/SubnetController.BulkAzure.cs:365-369` and `:394-398`)
+
+**Failure scenario.** `TargetName` returns the sanitised VNet name and nothing else — it never references which of the VNet's address prefixes the target holds. `BuildPlanItem` runs once per selected VNet address prefix, so every item for the same VNet carries the identical `AutoCreateTargetName`, and the commit creates one Bastet subnet per item with no cross-item name check: `usedNames` (`:486`) is per-item and only guards *child* names. A VNet with two address prefixes therefore persists **two top-level Bastet subnets with the same name**, both stamped with the same VNet `AzureResourceId`, distinguishable only by network address. Reachable in one click of "Select all"; no crafted payload. This is N6 one level up the tree: N6 is two same-named children of one Azure *subnet*, this is two same-named targets of one Azure *VNet*, and unlike N6 it fires on **every** multi-address-space VNet import, not only on a prefix-spanning subnet.
+
+**Reproduction** — the same run recorded under N6 (own instance port 5193, catalog `bastet_rig14_verc3`, fixture `rig-14-b5p2-vnet`, prefixes 10.71.0.0/16 and 10.72.0.0/16). Rows 2 and 4 of that output *are* this defect, persisted:
+
+```
+POST /Subnet/BulkCreateFromAzurePlan -> {"success":true,"createdTargets":2,"createdChildSubnets":2}
+  2 |rig-14-b5p2-vnet|10.71.0.0|16|NULL      <- two targets, identical Name,
+  4 |rig-14-b5p2-vnet|10.72.0.0|16|NULL      <- identical AzureResourceId (the VNet)
+```
+
+**Fix.** Qualification has to be decided across the commit, not inside one item, exactly as N6's part 1 concludes: in `BuildPlan`, when more than one address prefix of the same VNet is selected, qualify each item's `AutoCreateTargetName` with the prefix it holds — the same `name (network-cidr)` shape N6 and N7 settle on, so all three stay consistent. Do **not** route this through `DisambiguateName`: it appends the *VNet name*, which is precisely the token that is already identical here, and its numeric fallback would produce `vnet`/`vnet (2)`, which says nothing about which range the row holds. The `ExactMatch` branch is unaffected — it adopts an existing row and does not name anything.
+
+**Decision needed from you.** Whether to prefix-qualify `TargetName` when a VNet contributes several selected prefixes. It changes the names some installs see on their **next** import of a multi-address-space VNet (nothing already persisted is renamed). The alternative is a preview warning only — the wizard discloses that two targets will be created with the same name and the operator renames one afterwards by hand.
+
+*Consequence:* low, on the same reading as N6 — every persisted range, parent link and Azure link is correct, nothing is misreported as free, and every render carries the address beside the name. What is wrong is a duplicated display label that no screen can explain.
+
+*Why this is a finding and not a watch-list item:* it was parked in the watch list as "pre-existing on every build" and excluded from N6's fix as "out of scope", while the two rows above had already been **persisted and observed** in N6's own reproduction. Age, fix cost and blast radius are not severity inputs and are not grounds for withholding a reproduced defect from the findings; it is filed here at the severity its consequence warrants. Its `TargetName` half is therefore removed from N6's fix list and from the watch list.
+
+---
+
+# Refuted — reported by a finder, killed by the verifier
+
+These were reported and then killed under verification. They are recorded so round 15 does not spend effort re-reporting them.
+
+| id | Title | file:line | Why it was killed |
+|---|---|---|---|
+| R1 | Round 13's multi-prefix name qualification is scoped to a single request, so importing an Azure subnet's prefixes in two passes persists two Bastet rows under the identical name `[x1]` | `src/Bastet/Controllers/SubnetController.Azure.cs:250` | The claimed consequence is nil by the reporter's own measurement and by independent re-measurement: allocation data correct, no name-based lookup anywhere in the codebase, the address rendered beside the name on all six surfaces, reconciler reports 0 items. The "invariant" it says is defeated does not exist — two ordinary POSTs to `/Subnet/Create` with the same `Name` both succeed and persist identically-named siblings with **no Azure involvement at all**, because `Subnet.Name` is deliberately non-unique and no validator checks it. The state is sanctioned, reachable in two clicks without the cited code, and harmless: a duplicated display label, i.e. the "not a runtime defect, but the shipped fix is inconsistent" shape. (Distinct from **N6**, which survived: there the two rows share the same `AzureResourceId` and the qualification the code deliberately applies is silently skipped in a single commit.) |
+| R2 | `GetCompatibleSubnets` treats `addressPrefix` and `addressPrefixes` as mutually exclusive while `ExtractIpv4Prefixes` unions them, so the single-VNet wizard would silently drop every extra prefix if ARM ever populated both `[x1]` | `src/Bastet/Services/Azure/AzureService.cs:172` | The cited branch cannot be entered with the stated input. ARM at api-version 2024-05-01 **refuses to store** `addressPrefix` and a multi-entry `addressPrefixes` simultaneously — that exact shape was PUT twice (new subnet, and onto an existing multi-prefix subnet) and ARM discarded the plural both times, and rejected duplicate plural entries with `DuplicateAddressPrefixesFound`. ARM is the sole producer of the `SubnetData` this method reads, so no real caller can reach the divergent path. End to end, `/Azure/GetSubnets` correctly returns both prefixes of a multi-prefix subnet, so the claimed harm (a dropped prefix later advertised as free space) does not occur. What remains is a code-consistency observation between a defensive extractor and one that mirrors the platform invariant. |
+| R3 | The single-VNet import wizard displays one name and persists another: it posts the bare Azure subnet name and the server silently rewrites every multi-prefix row, with nothing on screen saying so `[x2]` | `src/Bastet/Views/Azure/Import/_ImportScripts.cshtml:330` (the posted `subnets[i].Name`; the label showing the same bare Azure name is at `:338`) | The headline consequence — the rename being invisible, "nothing on screen or in the success flash saying so" — is **false when measured**. The commit redirects to `Details/{parentId}` (`SubnetController.Azure.cs:483-486`), and that page's Child Subnets table lists `rig-14-sn-a1-multi2 (10.10.10.0/24)` and `… (10.10.30.0/24)` beside their CIDRs, in the same click, before the operator can act. The premise "the success flash is the only confirmation this wizard produces" is wrong. The write is correct, deliberate (round 13 M1, documented at `SubnetController.Azure.cs:236-247`), reversible via Edit, and preserves `AzureResourceId` verbatim. Both named second-order harms are empty: Bastet has no subnet search at all, and no code keys on `Subnet.Name` (the reconciler keys on resource id, the bulk planner on `{NetworkAddress, Cidr}`). What remains is one line of advisory UI copy on a row whose write is truthful and announced on the following screen — the exact disposition that killed round 13's C1 in this same file (round 13 cited `:338`, the label; the write this finding is about is the hidden input at `:330`). |
+| R4 | Dead `ExtractIpv4Prefix` (first-prefix-only) survives beside the plural replacement M1 introduced `[x2]` | `src/Bastet/Services/Azure/AzureService.cs:411` | True observation, absent consequence. The method has a provably empty in-edge set (private static, zero call sites repo-wide; deleting it builds 0 warnings and passes 771/771), so no execution path in the shipping product reaches it: no request produces a wrong byte, no row is wrong, no range is misreported. Measured live against the very fixture cited, HEAD emits all three prefixes correctly — the "drops two /24s" output reported is the finder **hand-evaluating a method nobody calls**, not an observation of the software. The sole stated consequence is conditional on a future edit that does not exist. Round 11 killed `IInputSanitizationService.SanitizeString` on identical reasoning, and half of this is a re-raise: `docs/AUDIT-FINDINGS-7.md:881` already reports the same orphaned `<summary>` on the same method pair and records it killed at info. Refuted on **absence of any defect**, not on scope, cost or rarity — the deletion is trivial and was proved safe; it is a cleanup-sweep item. |
+| R5 | Dead `TruncateForName` in the bulk import planner is a non-sanitizing near-duplicate of the live `TruncateAndSanitizeName` `[x2]` | `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:790` | Dead private helper, zero callers, no reflection reachability: it never executes, so the software produces no wrong output or state because of it. The stated consequence is explicitly conditional on a hypothetical future edit ("A future planner edit that picks it…") — a bug someone might write later, not a bug present at HEAD. The supporting argument that "nothing in the build flags an unreferenced private method" is a tooling-gap remark of the same family. Refuted because there is no defect, not on scope, cost or rarity. |
+| R6 | `IIpUtilityService` exposes a second `CalculateUnallocatedRanges` overload with no production caller that computes free space ignoring host IP assignments `[x1]` | `src/Bastet/Services/IIpUtilityService.cs:48` | No defect to reach. Full-repo grep (all extensions, excluding `bin`/`obj`/`.git`): the only non-test, non-declaration hit for `CalculateUnallocatedRanges` in the entire tree is `src/Bastet/Controllers/SubnetController.Read.cs:102`, which calls the **4-argument** form passing `subnet.HostIpAssignments`. No reflection dispatch anywhere in `src/`, no plugin surface, no name-based resolution; `IIpUtilityService` is an internal DI abstraction, not a published package. So no request, click or query in any deployment executes `IpUtilityService.cs:224`. The finder's "reproduction" consisted of writing a new test file that calls the overload directly — that is the finder supplying the caller whose absence is the whole finding. The claimed consequence is explicitly about code that does not exist. It is additionally not even latently wrong: the overload's XML doc on both interface and implementation states "taking into account child subnets" — it answers a different, well-defined question correctly, and empty host IPs is the documented semantic of that signature. |
+
+---
+
+# Watch list
+
+Not findings. Only items a verifier could not **settle** — thin evidence, unproven reachability, or patterns that will bite later. Nothing reproduced is parked here; every reproduced defect above is filed at the severity its consequence warrants, regardless of fix cost.
+
+- **No screen anywhere can edit or clear `Subnet.AzureResourceId`.** Grepped across every controller and view: the only writers are the two import commits. This is not itself a defect, but it is load-bearing for N1 — it is why routing a still-allocated row to `ReviewItems` strands it forever, and why the "re-link to Azure subnet X" action is the shape a correct fix eventually needs. Unsettled: whether any other flow silently depends on that column being immutable.
+- **The natural trigger for N5 was never produced.** No non-injected `sp_releaseapplock` failure that leaves the SQL session alive was observed, and pausing the shared container to force one was out of bounds. The trigger class (acked command timeout; Azure SQL 10928/10929/40501) is argued from documented behaviour plus the maintainers' own comment at `Program.cs:459-461`, not measured. Anyone running BASTET on Azure SQL is the population where this becomes measurable.
+- **The `Bastet:Migration` half of N5 was reasoned, not executed.** The pooling behaviour it rests on was measured for the subnet lock; the startup-abort consequence ("Another replica appears to be stuck applying migrations", after a 300000 ms wait) was not driven.
+- **Overlapping RFC1918 space across VNets in one subscription is normal and the code is only partly ready for it.** `AzureReconciler.cs:68` already avoids `ToDictionary` for this reason; the rig itself ships `10.10.0.0/16` and `10.10.0.0/20` in one subscription. Any new prefix-keyed index (N1's fix is the immediate example) that assumes one owner per prefix string will throw and turn a scan into "The reconcile scan failed." This will bite again.
+- **`EditSubnetViewModel.Name` has no `[SafeText]` while `CreateSubnetViewModel.Name` does** (`EditSubnetViewModel.cs:42-47` vs `SubnetViewModels.cs:8-14`). N7 is one consequence of that asymmetry; whether the divergence is deliberate was not established, and other paths that round-trip a name through Edit were not swept.
+- **Nothing asserts that an application-*generated* name satisfies the application's own input rules.** `SubnetNamingSafeTextTests` pins `ToSafeText` character-by-character but never checks a produced name. That gap is exactly how round 13 reintroduced the character round 4 removed (N7). N7's fix proposes the guard; until it lands, a third occurrence is not prevented by anything.
+- **`AzureReconcileStatus` has no inbound direction at all.** N3 and N4 are the two reproduced consequences of that; what was *not* settled is how many other operator-facing statements ("nothing to clean up", the free-space table, `IsFullyAllocated`) are scoped to the outbound direction without saying so on screen.

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -101,55 +101,23 @@ _Tests: 792 → 800. Eight in `SubnetControllerReconcileApprovedVerdictTests`, i
 
 ---
 
-## N3 — An IPv4 prefix Azure adds to an already-imported subnet is advertised by BASTET as free space, both import wizards refuse to import it, and the reconcile scan reports no differences `[x2]`
+## N3 — An IPv4 prefix Azure adds to an already-imported subnet is invisible to reconcile and advertised as free space `[x2]` — FIXED
 
-**Severity:** high · **Confidence:** confirmed
-**Citation:** `src/Bastet/Services/Azure/AzureReconciler.cs:73`
+_N3 is fixed and committed. The reconciler had no inbound direction at all: every status started from a BASTET row and asked what Azure said about it, so an Azure range BASTET has no row for was invisible to all of them. `AzureReconcileStatus.AzureRangeNotImported` is that verdict, reported into `ReviewItems` — report-only, never deletable, because it names no BASTET subnet and the absence of one **is** the finding._
 
-**Failure scenario.** Ordinary sequence, no operator error, no crafted request. Bulk-import a VNet and its multi-prefix subnet. Azure later adds a third prefix to that same subnet (`az network vnet subnet update --address-prefixes ...`) — routine since multi-prefix subnets went GA. From that moment: the Details page lists a range **containing** the newly assigned `/24` under "Unallocated IP Ranges" with a **Create Subnet** button; `ReconcileScan` returns `items 0, reviewItems 0, warnings [], globalErrors []`; and neither import path can correct it — `GET /Azure/Import/{id}` 302s with *"Subnet must not have any child subnets or host IP assignments"* (`AzureController.cs:39-45`), and the bulk wizard marks the VNet prefix `Blocked` (`AzureBulkImportPlanner.cs:199`) which disables every subnet row underneath it, including the new row the very same response marks `Available / isSelectable: true`. The tool renders the discrepancy on one page while denying it exists on two others. Structural cause: every `AzureReconcileStatus` starts from a Bastet row carrying an `AzureResourceId` — `BuildPlan` iterates `linkedSubnets` at `:73` and never walks the inventory looking for Azure ranges BASTET has no row for.
+_The owner chose the full inbound verdict over the warning-only half, so `IAzureReconciler.BuildPlan` now also takes the whole subnet tree (`IAzureSubnetSnapshotService.GetExistingSubnetsAsync`, which already existed and was already called by the bulk path), and `AzureReconciler` takes `IIpUtilityService` for the containment maths — the same shape `AzureBulkImportPlanner` already has, and still pure in the sense that matters: no EF, no Azure calls._
 
-**Reproduction** — own instance port 5342, catalog `bastet_rig14_verc1`, live fixture `rig-14-verc1-vnet` (10.90.0.0/16), subnet with prefixes `10.90.200.0/25` + `10.90.200.128/25`:
+_Both of the verifier's corrections to part (a) were taken and both are pinned by tests. **Containment, not equality**: an IPAM routinely records a coarser allocation than Azure carves out of it, so a BASTET `10.90.64.0/18` accounts for an Azure `10.90.77.0/24` inside it — `ARangeContainedByACoarserBastetSubnet_IsNotReported`. **The whole tree, not just linked rows**: only the two import paths ever write `AzureResourceId`, so a range the operator created by hand carries none, and matching against linked rows alone would report it forever after they had already done exactly what the report asked — `ARangeCreatedByHandCarryingNoAzureLink_IsNotReported`. The walk is scoped to VNets that have actually been imported, or pointing the scan at an untouched subscription produces an item per Azure subnet on every scan._
 
-```
-bulk import -> {"success":true,"createdTargets":1,"createdChildSubnets":2}
-az network vnet subnet update ... --address-prefixes 10.90.200.0/25 10.90.200.128/25 10.90.77.0/24
+_Two corrections were mine, not the audit's, and both were found by running the thing rather than reading it. First, **a VNet-level import target contains every range in its VNet by construction**, so counting a target's containment as "accounted for" made the check vacuous — it could never report anything. Targets are excluded from the containment arm but still honoured on exact match, because an Azure subnet covering a whole VNet prefix is recorded by marking that target fully allocated rather than by creating a child. Two tests pin both halves of that. Second, **`GetVNetInventory` emits one row per prefix and every row carries the complete prefix list** (round 13's `BuildInventorySubnetRows`), so walking rows x prefixes visits an n-prefix subnet n-squared times: the first live run reported one unaccounted range **three times**. Deduped, with `TheRealMultiPrefixInventoryShape_ReportsEachRangeExactlyOnce` built from the real inventory shape rather than a hand-simplified fixture that hides it._
 
-POST /Azure/ReconcileScan -> {"scanSucceeded":true,"items":[],"reviewItems":[],
-                              "globalErrors":[],"warnings":[],"canCommit":false}
+_Part (b) of the finder's proposal — relaxing the two import gates — was **not** done here; it is N4's decision and is answered there._
 
-GET /Subnet/Details/1 "Unallocated IP Ranges":
-  10.90.0.0   10.90.199.255   51,199 IP addresses   [Create Subnet]   <- contains 10.90.77.0/24
-  10.90.201.0 10.90.255.254   14,079 IP addresses   [Create Subnet]
+_Proven by A/B on live Azure. Fixture `rec14-n3-vnet` 10.90.0.0/16 with subnet `rec14-n3-sn-multi` carrying `10.90.200.0/25` + `10.90.200.128/25`, bulk-imported into both builds (`createdTargets: 1, createdChildSubnets: 2`), then `az network vnet subnet update` added `10.90.77.0/24` to that same subnet — ARM confirmed the multi-prefix shape with singular `addressPrefix: null` and `addressPrefixes` populated. Unfixed `77560af`: `items [], reviewItems [], warnings []` — the one feature whose job is comparing the two systems reported nothing at all. Fixed: one `AzureRangeNotImported` review row for `10.90.77.0/24` reading "Azure subnet 'rec14-n3-sn-multi' in VNet 'rec14-n3-vnet' owns 10.90.77.0/24, which no BASTET subnet records. BASTET is reporting that range as free space."_
 
-GET /Azure/Import/1                 -> 302 /Subnet/Details/1 ("must not have any child subnets")
-GET /Azure/BulkGetVNets             -> PREFIX 10.90.0.0/16 Blocked isSelectable false
-                                       SN 10.90.77.0/24 Available isSelectable TRUE
-POST /Azure/BulkImportPreview (crafted: ONLY the new prefix)
-  -> errors ["Cannot import VNet prefix 10.90.0.0/16: matched Bastet subnet ... already has child subnets."]
-POST /Subnet/BulkCreateFromAzurePlan -> HTTP 400, same error   (the gate is server-side, no API back door)
+_Still true after this fix, and deliberately: `/Subnet/Details/{id}` continues to print the range under Unallocated IP Ranges with a Create Subnet button. Closing that is N4's half of the same defect and is answered there — this finding is the detection._
 
-THE HARM, EXECUTED:
-POST /Subnet/Create Name=team-web-block NetworkAddress=10.90.77.0 Cidr=24 ParentSubnetId=1
-  -> 302 /Subnet/Details/4 ; row persisted, AzureResourceId NULL
-BASTET allocated a /24 Azure had already assigned, with no warning.
-POST /Azure/ReconcileScan (with the double-allocation live) -> items [] warnings [] globalErrors []
-```
-
-**Fix (finder's proposal, corrected by the verifier — part (a) was underspecified and part (b) is dangerous).**
-
-**(a) The inbound verdict cannot be built from `BuildPlan`'s current inputs.** `BuildPlan` only receives `linkedSubnets`, and `AzureSubnetSnapshotService.GetAzureLinkedSubnetsAsync` (`:52`) filters to rows with a non-empty `AzureResourceId`. Proved false-positive: the hand-created `team-web-block` above exactly accounts for the Azure prefix but never enters `linkedSubnets`, so the proposed loop would report `10.90.77.0/24` as "not imported" forever. Two changes are required: **(i)** extend `IAzureReconciler.BuildPlan` to also take the full tree — `IAzureSubnetSnapshotService.GetExistingSubnetsAsync()` already returns every subnet and is already called by the bulk path; **(ii)** match by **containment, not `{network,cidr}` equality** — an IPAM routinely records a coarser allocation (Bastet has `10.90.64.0/18`; Azure carves `10.90.77.0/24` inside it), and that range *is* accounted for. Report only when no Bastet subnet contains the Azure prefix, and scope the walk to VNets at least one of whose prefixes maps to an existing Bastet target, or an unimported subscription produces an item per Azure subnet on every scan.
-
-**(b) Do not relax the two import gates as proposed.** `AnnotatePrefix:197-200` / `BuildPlanItem:379-383` block an exact-match target that has children for a reason that survives this finding: the commit path also renames the target, stamps `AzureResourceId` and can set `IsFullyAllocated` (`SubnetController.Azure.cs:397-399,404,410`). Loosening them to "block only when the selection would create a row that already exists" lets an import adopt and re-stamp a target whose children were created by hand — the state round 13's C4 analysis showed lets a later reconcile cascade archive non-Azure rows. See N4 for the narrower alternative.
-
-**(c)** The interim warning is the right first move, with the same full-tree + containment input as (a), or it fires on ranges Bastet legitimately accounts for and operators learn to ignore it.
-
-**Also worth doing regardless:** `BulkGetVNets` returns `10.90.77.0/24` as `Available / isSelectable: true` under a prefix it marks `Blocked / isSelectable: false` **in the same response**. Whatever is decided about the gates, mark a subnet row unselectable-with-a-reason when its own VNet prefix is blocked, so the wizard stops offering a row nothing can act on.
-
-**Interim mitigation.** A `plan.Warnings` entry (not an item) — *"Azure subnet 'X' owns 10.90.77.0/24, which no Bastet subnet records. BASTET will report that range as free."* Warnings are already rendered on the reconcile review screen, are never deletable, and `nothingToReport` (`_ReconcileScripts.cshtml:287`) already includes `warnings.length === 0`, so this correctly suppresses the "nothing to clean up" banner without touching the deletion path. ~30 lines, no schema, no UI change.
-
-**Decision needed from you.** (1) Does the reconciler get an inbound verdict at all — a new `AzureReconcileStatus`, the wider `BuildPlan` input, and a report-only never-deletable review row? Roughly a day plus tests; the cheap half ships first and is independently useful. (2) Should there be any supported path to pull new Azure prefixes into an already-imported target — covered in N4.
-
-*Narrative correction:* the JSON is `items 0, warnings []`, but the green banner it drives (`_StepReview.cshtml:30`) reads "Everything imported from this subscription still exists in Azure. There is nothing to clean up." — carefully scoped to the outbound direction and not literally false. The defect is that the only comparison feature in the product has **no inbound verdict at all**, so the free-space page lies unopposed.
+_Tests: 800 → 812. Twelve in `AzureReconcilerInboundTests`, seven of which are false-positive tests: an inbound report that fires on ranges BASTET legitimately accounts for is a warning operators learn to ignore, which is worse than no warning._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -133,65 +133,21 @@ _Proven by A/B on live Azure, continuing N3's fixture (`rec14-n3-vnet`, subnet `
 
 _Tests: 812 → 822. Ten in `AzureBulkImportTopUpTests`, six of which are refusals — the allowance is only correct if adoption, a different VNet, host IPs, the fully-allocated flag, the fully-allocated marking and the rename all stay refused._
 
-## N5 — A failed `sp_releaseapplock` is swallowed on a documented invariant that is false: closing the connection returns the session to the pool, so the global subnet write lock stays held and every replica's writes fail for minutes with "high concurrency" `[x1]`
+## N5 — A failed `sp_releaseapplock` is swallowed on a documented invariant that is false `[x1]` — FIXED
 
-**Severity:** medium · **Confidence:** **plausible**
-**Load-bearing step that could not be established:** no **natural** (non-injected) failure of `sp_releaseapplock` that leaves the SQL session alive was produced. Every fault applicable on the shared rig also kills the session, which releases the lock safely. The trigger class is real rather than invented — a command timeout whose ATTENTION is acked, and Azure SQL 10928/10929/40501 resource-governance errors, all return a `SqlException` on a still-open connection, and the maintainers' own comment at `Program.cs:459-461` records a release failure reproduced against a real server. **Everything downstream of the trigger was measured**, with the failure injected: that the lock survives return-to-pool, for 4+ minutes, and that the peer replica then fails for 30 s with a false message. The migration-lock half was reasoned from the same measured pooling behaviour, not executed.
-**Citation:** `src/Bastet/Services/Locking/SqlServerSubnetLockingService.cs:96` (swallowing catch at `:98-101`, false comment at `:91-93`, outer finally at `:104-107`); same false comment at `Program.cs:461-463`.
+_N5 is fixed and committed. The swallow stays — every guarded path has already committed by then, and an exception raised in a `finally` replaces the one in flight — but it is no longer swallowed on a false premise. `CloseConnectionAsync` returns the connection to SqlClient's **pool**; the SQL session stays open, and a Session-owned application lock is only dropped when that pooled connection is next reused or physically destroyed. On a failed release the physical connection is now discarded via `SqlConnection.ClearPool`, which ends the session and the lock with it._
 
-**Failure scenario.** Two replicas against one database — the multi-replica shape `Program.cs` and the DataProtection key ring exist to support. Replica A serves `POST /Subnet/Create`; `sp_getapplock 'Bastet:SubnetOperations'` is taken **Session**-owned on the request's EF connection; the subnet is committed; `sp_releaseapplock` fails for any reason that leaves the connection usable. The catch logs and continues on the stated grounds that "if it is alive the outer finally closes it anyway". **It does not.** `context.Database.CloseConnectionAsync()` returns the connection to SqlClient's pool; the SQL session stays open; a Session-owned application lock is dropped only when the pooled connection is next *used* (`sp_reset_connection`) or physically destroyed. During that window every subnet/host-IP write on replica B parks 30 s inside `sp_getapplock` and fails — interactive forms with *"The operation timed out due to high concurrency. Please try again."*, Azure endpoints with 503 "another subnet operation is in progress" — none of which is true. The operator's only offered remedy ("try again") keeps failing. The same false claim governs the `Bastet:Migration` lock; on the bootstrap path that connection lives in a master-catalog pool the app never reuses, so a stranded migration lock persists for the process lifetime and later cold starts burn the full 300000 ms `@LockTimeout` before aborting with "Another replica appears to be stuck applying migrations."
+_The comments that asserted the false invariant are corrected in both places — `SqlServerSubnetLockingService` ("if it is alive the outer finally closes it anyway") and `Program.cs` ("if it is alive the using block closes it here") — and the log message no longer implies the lock takes care of itself. Those comments were the reason the defect survived review; leaving them would have re-taught the next reader the thing that was wrong._
 
-**Reproduction** — scratch copy of HEAD at `$RIG/ver-c8/repo` (nothing written into the repo; `git status --porcelain -uall` empty afterwards). Only change: a one-shot `throw` at the top of `ReleaseAppLockAsync`, gated on `VERC8_FAULT=1`. Two replicas, ports 5231/5232, catalog `bastet_v14c8`:
+_The verifier's correction to the secondary fix was taken. `Pooling=false` was **not** added to `MigrationLockConnectionString.Configured`: that method's contract is the connection string returned verbatim, `MigrationLockConnectionStringTests` asserts exactly that, and routing it through `SqlConnectionStringBuilder` would also destroy its documented null-in/null-out behaviour. The migration lock uses the same `ClearPool` remedy in its existing catch instead, which covers both branches uniformly and touches no unit-tested contract. The discard is itself wrapped, because it runs inside the catch of a release that already failed and must not throw from there._
 
-```
-POST /Subnet/Create (replica A) -> 302 /Subnet/Details/1 in 0.118 s   (row committed)
-log: "Failed to release the subnet operation lock after the operation completed"
+_The owner accepted the pool-wide blast radius knowingly: `ClearPool` empties the whole pool for that connection string, so the replica pays a burst of reconnect handshakes — on an error path only. Microsoft.Data.SqlClient exposes no per-connection "do not pool" switch, so this is the only public mechanism, and the alternative is denying every write on every replica until something happens to reuse that one connection, which a peer replica cannot cause._
 
-APPLOCK_TEST('public','Bastet:SubnetOperations','Exclusive','Session')
-  before POST -> 1 (free)      after POST -> 0 (HELD, request finished, DbContext disposed)
-sys.dm_tran_locks  -> session 96, 0:[Bastet:SubnetOperations]:(b83d66a6)
-sys.dm_exec_sessions -> status 'sleeping', program_name 'EFCore/10.0.10'   <- alive in the pool
+_Proven on a rig, not by a unit test, because the suite runs SQLite and this is real SQL Server locking behaviour. Two scratch copies — the fixed tree and a clone of `77560af` — each with a one-shot injected release failure gated on an env var, run against the real SQL Server container, one replica each plus a peer replica on the same catalog. Both builds accepted the create (302) and both logged the failed release exactly once, so the fault fired identically. **Unfixed:** `APPLOCK_TEST('public','Bastet:SubnetOperations','Exclusive','Session')` returned **0 — held** after the request had completed and the DbContext was disposed, and the peer replica's `POST /Subnet/Create` returned HTTP 200 after **30.06 seconds** rendering "The operation timed out due to high concurrency. Please try again." with the row never written. **Fixed:** the same query returned **1 — free**, and the peer replica's identical write returned 302 in **0.15 seconds** with the row persisted._
 
-POST /Subnet/Create (replica B) -> 200 in 30.049 s,
-  rendered: "The operation timed out due to high concurrency. Please try again."
-  Subnets table: only vc8-a. Nothing written. Repeated 5 minutes later: identical.
+_Not done, and deliberately: the interim mitigation of raising the log to `LogCritical` was dropped rather than shipped alongside. It existed to make the 30-second "high concurrency" failures diagnosable while the lock stayed stranded; with the lock no longer stranded there are no such failures to diagnose, and a Critical line for a condition the process has just repaired would be noise. The natural (non-injected) trigger remains unproduced — that stays on the watch list, where the audit put it._
 
-Held on an idle holder: t+11s .. t+297s -> APPLOCK_TEST 0 throughout (4m12s watched).
-Holder self-heals: 5 read-only GETs on replica A -> lock free, A's next create 302 in 0.026 s.
-Replica B has no way to cause that; it can only block 30 s and fail.
-
-PROPOSED FIX, same rig, same injected fault (SqlConnection.ClearPool in the catch):
-  create -> 302 in 0.183 s ; log still records the failed release
-  APPLOCK_TEST pre=1 post=1 post+5s=1        <- NOT stranded
-  replica B create immediately after -> 302 in 0.134 s   (was 30 s / failed)
-```
-
-**Fix (primary sound and verified running; the secondary half was corrected).** In the catch at `:98`, destroy the physical connection so the SQL session — and with it the Session-owned lock — actually ends:
-
-```csharp
-catch (Exception ex)
-{
-    logger.LogError(ex, "Failed to release the subnet operation lock; discarding the pooled connection so the session-owned lock is dropped");
-    if (context.Database.GetDbConnection() is SqlConnection stranded)
-    {
-        SqlConnection.ClearPool(stranded);
-    }
-}
-```
-
-`using Microsoft.Data.SqlClient;` is already at the top of the file, so the fully-qualified names in the original proposal are unnecessary. Two things the proposal omitted: **(a)** `ClearPool` empties the **whole** pool for that connection string — a transient reconnect cost paid only on this error path, and there is no per-connection "do not pool" API in Microsoft.Data.SqlClient, so this is the only public mechanism; **(b)** the log message must stop asserting the false invariant, and the comments at `:91-93` and `Program.cs:461-463` must be corrected — closing an EF/ADO connection returns it to the pool, it does not end the session, and a session-owned applock outlives it.
-
-**Correction to the secondary fix.** Do **not** add `Pooling=false` inside `MigrationLockConnectionString.Configured`: that method's documented contract is the connection string returned verbatim, `MigrationLockConnectionStringTests.cs:40` asserts `Assert.Equal(connectionString, Configured(connectionString))` and would fail, and routing it through `SqlConnectionStringBuilder` also destroys the deliberate null-in/null-out behaviour documented at `MigrationLockConnectionString.cs:31-37`. Use the same remedy as the service — `SqlConnection.ClearPool(migrationLockConnection)` inside the existing catch at `Program.cs:475-480`, before the `using` disposes it. That covers both branches uniformly and touches no unit-tested contract.
-
-**Interim mitigation.** Raise `SqlServerSubnetLockingService.cs:100` from `LogError` to `LogCritical` and say what it means — *"the global subnet lock may be stranded on a pooled connection; restart this replica if subnet operations start timing out"* — so the 30-second "high concurrency" failures that follow are diagnosable instead of being misattributed to load.
-
-**Decision needed from you.** Whether the pool-wide blast radius of `ClearPool` on the release-failure path is acceptable: the replica pays a burst of TCP+TLS+login handshakes right after a failed release. Alternatives: (b) leave the lock stranded and make the peer's failure honest — "the lock is held by another replica's stale session" plus a documented `sp_releaseapplock`/KILL runbook; or (c) change the lock's ownership model, which the class remarks at lines 13-20 explicitly rejected for good reasons. **(a) is cheapest and is the one verified to work.**
-
-*Scope narrowed by the verifier:* the holding replica self-heals on its very next query, so single-replica deployments recover almost immediately. The damage that persists is **cross-replica** — replica B has its own pool and can do nothing to reset A's session, so B's writes stay broken until A happens to touch that one connection: unbounded if A is idle, drained, or scaled to zero. Medium is right — writes are denied and the error message is a lie, but nothing is corrupted and no allocated range is ever reported free.
-
----
-
-# Low
+_Tests: unchanged at 822. Nothing was added, because nothing in the suite can reach this: SQLite has no `sp_getapplock`, and the defect is in what SqlClient does with a connection after it is closed._
 
 ## N6 — Bulk import's multi-prefix name qualification is scoped to one VNet address prefix, so an Azure subnet whose prefixes fall under different VNet prefixes persists as two Bastet rows with the identical name and the identical `AzureResourceId` `[x2]`
 

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -121,55 +121,17 @@ _Tests: 800 → 812. Twelve in `AzureReconcilerInboundTests`, seven of which are
 
 ---
 
-## N4 — An Azure subnet that gains an IPv4 prefix after import can never be imported by either wizard, and the Details page keeps offering the Azure-assigned range as free `[x2]`
+## N4 — An Azure subnet that gains an IPv4 prefix after import can never be imported by either wizard `[x2]` — FIXED
 
-**Severity:** high · **Confidence:** confirmed
-**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:199` (server-side mirror at `:382`; single-VNet gate at `AzureController.cs:38-44`)
+_N4 is fixed and committed. The owner chose the narrow top-up action over detect-and-report-only, so a populated target is no longer refused outright — but the allowance is deliberately narrow: **the target must already be linked to THIS VNet**. That is what separates topping up an import that has happened from adopting a subtree somebody built by hand, which is the adopt-and-re-stamp blast radius the verifier warned about. A populated target with no Azure link, or one linked to a different VNet, is still refused, and both refusals are pinned by tests._
 
-**Failure scenario.** N3 is the reconciler's blindness; this is the import side of the same dead end, and it is a separate change with a separate owner decision. `AnnotatePrefix:199` blocks the whole VNet prefix — "Bastet subnet 'X' already has child subnets. Already imported?" — and `_BulkScripts.cshtml:249` sets `.prop('disabled', !subnet.isSelectable || !prefixInfo.isSelectable)`, so the one genuinely-new subnet row is un-tickable; `buildSelectionFromUI` only walks *checked* prefixes, so it can never be submitted. A hand-crafted POST is refused server-side by the mirror at `:382`. The single-VNet wizard refuses at the door. The identical dead end is reached by a second, arguably more likely route that starts **inside the reconcile wizard**: remove a prefix in Azure, reconcile correctly offers the drift row, the operator approves and it is archived — then Azure restores the prefix. Both wizards then refuse to bring it back, and the Details page advertises the live Azure-assigned range as free.
+_All four of the verifier's gaps were closed. **(1)** A populated target can no longer be marked fully allocated: the commit marks the flag INSTEAD of creating children, so the existing rows would have been stranded under a target claiming nothing more fits — the old blanket refusal was preventing this incidentally, and the top-up made it reachable, so it is now refused explicitly. Host IPs and the fully-allocated flag remain hard refusals. **(2)** The prefix now previews as `WillUpdateExisting` with distinct copy — "Will add any missing subnets to existing Bastet subnet 'X'. Subnets already imported are left untouched." — rather than the first-import wording, and `renameMatched` no longer renames a populated target, because renaming a label the operator has been living with is not what a run to add one missing subnet is for. **(3)** The single-VNet wizard was narrowed the same way rather than left half-fixed: `AzureController.Import` admits a populated target when it is Azure-linked, and `GetAzureSubnets` now filters out ranges BASTET already records, server-side, so a top-up there cannot re-offer a subnet a previous import created. **(4)** The reconciler half is N3 and shipped with it._
 
-**Reproduction** — own instance port 5219, catalog `bastet_rig14_verc2`, own fixture `rig-14-verc2-vnet` 10.90.0.0/16:
+_One part of this finding could not be done as specified, and the reason matters. "Closing the free-space lie on `/Subnet/Details/{id}`" cannot mean asking Azure on page render: **BASTET is self-hosted and must keep working with no outbound internet**, so making the free-space table depend on reaching ARM would break air-gapped deployments and hang the page whenever Azure is slow. Two things close it instead. The top-up import closes it *properly* — once the range is imported it is a real subnet and stops being listed as free, which is what the measurement below shows. And for the window before that, an offline-safe note now sits above the table on any Azure-linked subnet, saying the ranges are free according to what BASTET has imported and linking to Azure Reconcile, which is the feature that establishes the rest._
 
-```
-bulk import (real endpoints) -> {"success":true,"createdTargets":1,"createdChildSubnets":3}
-az network vnet subnet update ... -n rig-14-verc2-sn-multi \
-   --address-prefixes 10.90.100.0/24 10.90.101.0/24 10.90.102.0/24
+_Proven by A/B on live Azure, continuing N3's fixture (`rec14-n3-vnet`, subnet `rec14-n3-sn-multi` with `10.90.77.0/24` added after import). The wizard annotation first, and it reproduces the contradiction the finding describes: unfixed `77560af` returned `PREFIX 10.90.0.0/16 Blocked selectable=False` while the row underneath read `SN 10.90.77.0/24 Available selectable=True` — offered and un-tickable in the same response. Fixed: `PREFIX 10.90.0.0/16 WillUpdateExisting selectable=True` with the top-up copy. Then the commit: unfixed returned **HTTP 400** "matched Bastet subnet 'rec14-n3-vnet' already has child subnets" with free space unchanged; fixed returned **HTTP 200 `createdChildSubnets: 1`**, after which `/Subnet/Details/1` reports `10.90.0.0-10.90.76.255`, `10.90.78.0-10.90.199.255`, `10.90.201.0-10.90.255.254` — 65,278 addresses free before, 65,022 after, a difference of exactly the 256 the `/24` holds, with the range carved out rather than advertised. The reconcile scan that reported `AzureRangeNotImported` before the top-up returns `items [], reviewItems [], warnings []` after it._
 
-GET /Azure/BulkGetVNets (verbatim):
-  PREFIX 10.90.0.0/16      Blocked False  "Bastet subnet ... already has child subnets. Already imported?"
-  SN  10.90.100.0/24       AlreadyImported False
-  SN  10.90.101.0/24       AlreadyImported False
-  SN  10.90.102.0/24       Available       True     <- offered, but un-tickable (parent blocked)
-
-crafted POST (only the new prefix): preview canCommit False ; commit HTTP 400 (BuildPlanItem:382)
-GET /Azure/Import/1 -> 302 /Subnet/Details/1
-POST /Azure/ReconcileScan -> items [] reviewItems [] warnings [] globalErrors []
-
-GET /Subnet/Details/1 "Unallocated IP Ranges":
-  10.90.0.0    10.90.4.255     1,279    Create Subnet
-  10.90.6.0    10.90.99.255   24,064    Create Subnet
-  10.90.102.0  10.90.255.254  39,423    Create Subnet   <- over the /24 Azure just assigned
-
-escape hatch: POST /Subnet/Create 10.90.102.0/24 under parent 1 -> 302, row persists,
-              AzureResourceId NULL (only the two import paths ever write that column)
-```
-
-**Fix (verifier: incomplete — direction right, four gaps).** Narrow the `HasChildSubnets` hard stop to a **top-up import**: when the matched target already has children, keep the prefix selectable and let `AnnotateSubnet` do the discriminating it already does correctly (measured: 3 rows `AlreadyImported`, 1 `Available`). Keep the existing refusals for a target that is fully allocated, has host IPs, or is linked to a different VNet. Gaps to close first:
-
-1. **Scope the exact-match target's side effects.** A selectable ExactMatch prefix drives `SubnetController.BulkAzure.cs:346` (`targetSubnet.AzureResourceId = sanitizedVNetResourceId`) and, when a child fully encompasses the prefix, `WillMarkFullyAllocated`. Re-stamping the same VNet id is idempotent (a different VNet stays blocked at `AzureBulkImportPlanner.cs:216-223`/`:397-401`), but marking a target `IsFullyAllocated` when it already has children is a contradictory write the existing gate has been incidentally preventing. Add an explicit refusal.
-2. **The blocked prefix must become `WillUpdateExisting` with distinct preview copy** — how many children will be created, and that existing ones are untouched — not the first-import wording "Will import into existing Bastet subnet 'X'", which reads as a re-import. `BuildPlanItem`'s `renameMatched` path also needs deciding: renaming a populated target on a top-up is almost certainly not wanted.
-3. **The single-VNet wizard is not fixed by this change.** `AzureController.Import` refuses on `subnet.ChildSubnets.Count != 0` before the planner is consulted. Either narrow that gate the same way, or state explicitly that top-up is bulk-wizard-only — otherwise the headline "neither wizard" stays half-true after the fix.
-4. **The reconciler half (N3) is what stops this recurring and should not be optional.** Without an inbound status the model silently re-diverges on the next Azure change.
-
-**Interim mitigation — put it on the Details page, not the wizard.** Do **not** ship the finder's proposed "extend the Blocked reason to name the un-imported prefixes" alone: it requires reordering `AnnotateAvailability` (prefixes are annotated before subnets, `:164-169`), and it puts the warning on the one screen the operator has no reason to visit while `/Subnet/Details/{id}` keeps printing the allocated range under "Unallocated IP Ranges" with a Create Subnet button. For an Azure-linked subnet, the free-space table is the thing that is wrong.
-
-**Decision needed from you.** Whether BASTET supports a top-up import at all — importing new Azure prefixes into a target that already has children — versus keeping "a populated target is never an import destination" and only *detecting and reporting* the divergence (N3's reconciler status plus a Details-page warning), leaving the operator to create the range by hand. The first is a change to the planner's target rules plus preview copy plus the single-VNet gate; the second is smaller, weakens no existing guard, but leaves the correction manual and the resulting row permanently unlinked from Azure. **Either way the free-space lie on `/Subnet/Details/{id}` needs closing; that part is not optional.**
-
-*Two narrative corrections:* (a) "no in-app path back to a correct model" is too strong — `POST /Subnet/Create` does create the missing range (measured); the correct statement is "no path back to an *Azure-linked* correct model, and nothing in the application tells the operator the model is wrong". (b) The multi-prefix GA feature is the common **trigger**, not the mechanism — any Azure change that adds an unmodelled range under an already-imported VNet prefix reaches the same dead end.
-
----
-
-# Medium
+_Tests: 812 → 822. Ten in `AzureBulkImportTopUpTests`, six of which are refusals — the allowance is only correct if adoption, a different VNet, host IPs, the fully-allocated flag, the fully-allocated marking and the rename all stay refused._
 
 ## N5 — A failed `sp_releaseapplock` is swallowed on a documented invariant that is false: closing the connection returns the session to the pool, so the global subnet write lock stays held and every replica's writes fail for minutes with "high concurrency" `[x1]`
 

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -4,6 +4,36 @@
 
 ---
 
+## Reconciliation — final state
+
+**All ten findings are fixed, verified and struck.** One commit per finding, ten in all, on `audit/round-14`.
+
+| | |
+|---|---|
+| Build | 0 warnings after deleting `bin`/`obj` and rebuilding `--no-incremental` |
+| Tests | 771 → **847** (+76, none removed) |
+| App sweep | 24 checks over every major area, asserting rendered content and page titles, not just HTTP 200 — all pass |
+| Security headers | present on 200 and on 404 |
+| Log | **0 `fail:`, 0 `crit:`** |
+| Azure end to end | subscriptions → discovery (both wizards) → single-VNet listing → bulk preview → commit → reconcile scan → delete commit |
+| Discrimination | both counter-tests pass (below) |
+| `main` | `6d1a4cb`, byte-identical to the pre-round state |
+
+**Every finding was proven by A/B**, not by reasoning: the fixed tree and a clone of the unfixed commit `77560af` were driven through the identical scenario — against the same live Azure subscription for N1–N4, against real SQL Server with an injected release failure for N5, and at the unit level for N6–N10 by copying the new tests into the unfixed clone and watching them fail there.
+
+**The two counter-tests that prove the reconciler discriminates rather than merely blocks**, both re-run at the end: a Bastet row linked to a VNet in the resource group this credential has no assignment on was **withheld and named in a warning** ("…withheld from deletion: 'hidden-linked'"), while in the same commit four rows whose VNet was genuinely deleted were **offered and archived** (`targetsDeleted: 1, subnetsArchived: 4`). Checking only the first would let an over-blocking regression pass silently.
+
+**Eight `warn:` lines, all accounted for and none a defect:** one DataProtection "no XML encryptor" (Development default), three EF `MultipleCollectionIncludeWarning` performance advisories (pre-existing), three "Azure denied access … (403), so it cannot be reported as deleted" — the deliberate permission-denied probe logging *by design*, which is exactly what makes the first counter-test work — and one "carried no previewed outcome", the documented fail-open-and-log path for direct JSON API callers, triggered by the test driver posting a commit without carrying its preview.
+
+### Deliberately not done
+
+- **No backfill anywhere.** Rows already archived by N1's defect are not restored (`DeletedSubnets` has no restore path; re-import is the route back), and rows already carrying N8's unstrippable note are hand-repairable via Edit only — the same call round 13 made for the analogous residue, and the owner's choice here.
+- **N4's Details-page fix is a static note, not a live check.** BASTET is self-hosted and must work with no outbound internet, so the free-space table must never depend on reaching ARM. The top-up import closes the false claim properly by making the range a real subnet; the note covers the window before that.
+- **N5's `LogCritical` interim was dropped rather than shipped alongside** — it existed to make the stranded-lock symptoms diagnosable, and the lock is no longer stranded.
+- **N5's natural (non-injected) trigger was never produced.** It stays on the watch list, where the audit put it.
+
+---
+
 ## Verdict
 
 **Nine findings need a decision from you, and here is what each costs.** Read this list first; nothing below it is safe to skim past.

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -199,32 +199,19 @@ _Tests: 833 → 838._
 
 ---
 
-## N9 — Both new `multiPrefixResourceIds` sets are built with a collection expression, silently discarding the `StringComparer.OrdinalIgnoreCase` on the `GroupBy` immediately above `[x1]`
+## N9 — Both new `multiPrefixResourceIds` sets are built with a collection expression, silently discarding the `StringComparer.OrdinalIgnoreCase` on the `GroupBy` immediately above `[x1]` — FIXED
 
-**Severity:** low · **Confidence:** confirmed
-**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:509` (grouping `:511`, `Contains` `:527`) and `src/Bastet/Controllers/SubnetController.Azure.cs:250`
+_N9 is fixed and committed exactly as the verifier proposed and verified: both sets are now built with `new(..., StringComparer.OrdinalIgnoreCase)` instead of a collection expression. `[.. query]` constructs a plain `HashSet<string>` with `EqualityComparer<string>.Default`, so the later `Contains` was case-sensitive even though the grouping that filled it was not, and `GroupBy` keeps only the first member's spelling as `g.Key` — so a sibling row spelled `.../Subnets/...` fell out of the set and kept its bare Azure name._
 
-**Failure scenario.** `HashSet<string> multiPrefixResourceIds = [.. …GroupBy(s => s.Source.AzureResourceId, StringComparer.OrdinalIgnoreCase)…]` — the collection expression constructs a plain `HashSet<string>` with `EqualityComparer<string>.Default`, so the later `Contains` is case-**sensitive** even though the grouping that filled the set was case-insensitive. `GroupBy` keeps only the first member's spelling as `g.Key`, so every sibling row whose ARM id differs in case fails the `Contains` test and is not prefix-qualified. ARM resource ids are case-insensitive, so this is a legitimate variation; the wizards echo one server response, which puts the trigger at a crafted or replayed POST — precisely the case `ResolveImportNames`' own remarks say it exists to handle ("a crafted or replayed post carries whatever names it likes"). The hardening added for crafted posts is itself defeated by a crafted post. The intent is unambiguous: `used`, built three lines below the same collection expression at `SubnetController.Azure.cs:257`, `usedNames` at `AzureBulkImportPlanner.cs:486`, and both dictionaries at `AzureReconciler.cs:45-46` are all explicitly `OrdinalIgnoreCase`. These two collection expressions are the only ordinal resource-id collections in the Azure code.
+_One of the two sites was necessarily corrected an hour earlier: N6 hoisted the planner's set out of `BuildPlanItem` into `BuildPlan`, and that finding could not move the line without either writing the comparer correctly or knowingly re-writing it wrong. This finding covers the remaining site, `SubnetController.ResolveImportNames`, and pins **both** with tests so neither can regress independently. Each site now carries a comment saying why it is not a collection expression, because the defect is invisible at the call site — the two forms look interchangeable._
 
-**Reproduction** — own instance port 5211, catalog `bastet_rig14_vc11`. Only variable between runs is the casing of the `subnets`/`Subnets` segment on rows 2 and 3:
+_The offered interim was **not** taken, on the verifier's reasoning: `ToLowerInvariant` on ingest would change the `AzureResourceId` BASTET persists and displays on every import path, with its own blast radius through `BelongsToSubscription`'s `StartsWith` checks and existing mixed-case rows — strictly more expensive and more dangerous than a two-line comparer correction._
 
-```
-POST /Azure/BulkImportPreview
-CONTROL (all ids identically spelled):
-  'rig-14-sn-a2-multi3 (10.20.40.0/24)'  'rig-14-sn-a2-multi3 (10.20.5.0/24)'  'rig-14-sn-a2-multi3 (10.20.20.0/24)'
-MIXED (rows 2-3 use .../Subnets/...):
-  'rig-14-sn-a2-multi3 (10.20.40.0/24)'
-  'rig-14-sn-a2-multi3'                    <- lost its prefix qualification
-  'rig-14-sn-a2-multi3 (rig-14-vnet-a2)'   <- disambiguated by VNet, not by range
+_Proven by A/B: the bulk-planner half of the new test file was copied into a clone of `77560af` and fails there — the child whose resource ID differs only in the casing of the `subnets` segment comes back unqualified. The single-VNet half could not run against that commit, because `ResolveImportNames` was private until N7 opened it as a test seam; it is covered against the fixed tree, where all three pass._
 
-POST /Subnet/BatchCreateChildSubnets (same mixed casing) -> 302; persisted:
-  3|rig-14-sn-a2-multi3|10.20.5.0|24        <- bare Azure name in the database
-Control on the same endpoint with identical spellings: all three rows qualified by range.
-```
+_The verifier's downward correction of the consequence is recorded rather than argued with: exactly one row per group loses its qualification, the `used`/`usedNames` fallback catches every later sibling, so batch names stay mutually distinct and no collision occurs. No prefix is dropped, no range is shown free. The harm is a documented naming rule applied inconsistently — one row keeping the bare Azure name, and in the bulk path a sibling disambiguated by VNet name rather than by the range it holds, which is actively misleading about why it was renamed._
 
-**Fix (verifier: sound, compiled and run).** Replace both collection expressions with an explicit constructor: `HashSet<string> multiPrefixResourceIds = new([.. …], StringComparer.OrdinalIgnoreCase);` at `AzureBulkImportPlanner.cs:509` and `SubnetController.Azure.cs:250`. Verified in a throwaway net10.0 project: it compiles (the collection expression cannot convert to `int`, so the capacity overload is not a candidate) and yields `contains a/b = True` for a set built from a group keyed `A/b`. Two lines, no behavioural risk to the identical-casing path. **Do not take the offered interim** of `ToLowerInvariant` on ingest: that changes the `AzureResourceId` Bastet persists and displays on every import path — a data change with its own blast radius (`BelongsToSubscription` `StartsWith` checks, existing mixed-case rows) — and is strictly more expensive and more dangerous than the two-line comparer correction.
-
-*Consequence corrected downward — strike the "distinguishable only by CIDR" claim.* Exactly **one** row per group loses its qualification (the `used`/`usedNames` fallback catches every later sibling), traced across 2-, 3- and 4-row groups and every ordering of spellings, so batch names stay mutually distinct and **no name collision occurs**. No prefix is dropped, `AzureResourceId`/`NetworkAddress`/`Cidr` are all correct, no range is shown free, and the reconciler is case-insensitive so nothing escalates there. The surviving harm is a documented naming rule applied **inconsistently** — one row keeps the bare Azure name, and in the bulk path a sibling is disambiguated by VNet name rather than by the range it holds, which is actively misleading about why it was renamed.
+_Tests: 838 → 841._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -149,50 +149,21 @@ _Not done, and deliberately: the interim mitigation of raising the log to `LogCr
 
 _Tests: unchanged at 822. Nothing was added, because nothing in the suite can reach this: SQLite has no `sp_getapplock`, and the defect is in what SqlClient does with a connection after it is closed._
 
-## N6 — Bulk import's multi-prefix name qualification is scoped to one VNet address prefix, so an Azure subnet whose prefixes fall under different VNet prefixes persists as two Bastet rows with the identical name and the identical `AzureResourceId` `[x2]`
+## N6 — Bulk import's multi-prefix name qualification is scoped to one VNet address prefix `[x2]` — FIXED
 
-**Severity:** low · **Confidence:** confirmed
-**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:509` (grouping at `:511`, `usedNames` at `:486`, `Contains` at `:527`, `DisambiguateName` at `:533`)
+_N6 is fixed and committed. The `multiPrefixResourceIds` grouping is hoisted out of `BuildPlanItem` into `BuildPlan` and computed once across every selected prefix of every VNet, then passed in — so an Azure subnet owning one prefix under `10.71.0.0/16` and another under `10.72.0.0/16` is now seen as multi-prefix by both items instead of looking single-prefix to each. The owner chose qualification across the whole commit and across sessions over the preview-warning alternative._
 
-**Failure scenario.** A VNet has two address prefixes (10.71.0.0/16, 10.72.0.0/16) and one Azure subnet owns one IPv4 prefix in each. `BuildPlanItem` runs once per selected VNet address prefix, and `multiPrefixResourceIds` is built only from **that prefix's** subnet rows — so each item sees exactly one row for the resource id, `Count() > 1` is false, and no prefix qualification is applied. `usedNames` is also per-item and seeded only from the item's own target names, so `DisambiguateName` cannot catch it either. Result: two child subnets with the **same name** and the **same Azure subnet resource id**, distinguishable only by CIDR — precisely the state round 13's M1 naming work exists to prevent. Reachable in one click of "Select all"; the wizard groups subnet checkboxes under prefixes by containment, so no crafted payload is needed.
+_The verifier's correction to part 1 was taken: the `!s.FullyEncompasses && !string.IsNullOrEmpty(s.Source.AzureResourceId)` filter is kept exactly as it was. `AnEncompassingSelectionDoesNotInflateTheGroup` pins why — a subnet may equal one VNet prefix exactly and still hold a prefix inside another, so dropping the filter would inflate the group and needlessly rename the one child that is actually created._
 
-**Reproduction** — own instance port 5193, catalog `bastet_rig14_verc3`, existing fixture `rig-14-b5p2-vnet`:
+_Part 2 was implemented as the verifier's **corrected** version, not as proposed. `usedNames` is **not** seeded from the existing tree: that would rename any child whose Azure name merely matched some unrelated Bastet subnet anywhere in the tree — a broad silent rename in the ordinary path — and `DisambiguateName` appends the VNet name rather than the range, so a cross-session second row would land in a different shape from the single-session one. Instead a planned child is qualified when the tree already holds a row with the **same `AzureResourceId` and a different `{NetworkAddress, Cidr}``_. Fires only for the real multi-row case, keeps one shape, needs no DTO or ARM change. `AnUnrelatedBastetSubnetWithTheSameName_DoesNotCauseARename` and `ThePersistedRowForTheSameRange_IsNotTreatedAsASibling` pin both edges._
 
-```
-ARM: prefixes ["10.71.0.0/16","10.72.0.0/16"], subnet rig-14-b5p2-sn-span
-     addressPrefix null, addressPrefixes ["10.71.5.0/24","10.72.5.0/24"]
+_Part 3 — the `TargetName` half — is N10 and is fixed there, on its own merits._
 
-POST /Azure/BulkImportPreview (exact payload buildSelectionFromUI produces for "select all")
-  -> 200, canCommit true, globalErrors []
-     item 10.71.0.0/16 -> childSubnets[0].name "rig-14-b5p2-sn-span"   (UNQUALIFIED)
-     item 10.72.0.0/16 -> childSubnets[0].name "rig-14-b5p2-sn-span"   (UNQUALIFIED)
+_Proven by A/B at the unit level, which is where this defect lives: the new test file was copied unchanged into a clone of `77560af` and run. Against the unfixed planner **2 of 6 fail** — `AnAzureSubnetSpanningTwoVNetPrefixes_HasBothChildrenQualified` (both children came back as the bare `sn-span`) and `ASelectionWhoseAzureSubnetAlreadyHasAPersistedSibling_IsQualified` — while the other 4 pass on both builds, because they assert behaviour the fix had to preserve rather than change._
 
-POST /Subnet/BulkCreateFromAzurePlan -> {"success":true,"createdTargets":2,"createdChildSubnets":2}
-  2 |rig-14-b5p2-vnet   |10.71.0.0|16|NULL
-  3 |rig-14-b5p2-sn-span|10.71.5.0|24|2
-  4 |rig-14-b5p2-vnet   |10.72.0.0|16|NULL
-  5 |rig-14-b5p2-sn-span|10.72.5.0|24|4
-rows 3 and 5 carry the SAME AzureResourceId .../subnets/rig-14-b5p2-sn-span
+_One incidental correction: the hoisted set is constructed with an explicit `StringComparer.OrdinalIgnoreCase` rather than the collection expression it replaced. That is N9's defect, and this finding could not move the line without either fixing it or knowingly re-writing it wrong. N9 covers the remaining site and pins both._
 
-Counter-test that narrows the finding: splitting an ordinary multi-prefix subnet (both prefixes
-inside ONE VNet prefix) across two sessions was REFUSED — "Cannot import VNet prefix 10.10.0.0/16:
-matched Bastet subnet 'rig-14-vnet-a1' ... already has child subnets." So the cross-session route
-needs the same spanning fixture; the two claimed routes are one trigger, not two.
-```
-
-**Fix (verifier: part 1 sound with one correction, part 2 unsound as written, part 3 split out to N10).**
-
-1. **Hoist the grouping out of `BuildPlanItem` into `BuildPlan`**, computing `multiPrefixResourceIds` once across every selected prefix of every VNet, and pass the set in. That is the whole of the single-session fix. **Keep the `!s.FullyEncompasses && !string.IsNullOrEmpty(s.Source.AzureResourceId)` filter that `:510` has today** — the proposal's wording drops it, and this fixture disproves M1's recorded assumption that an encompassing prefix cannot have a sibling prefix on the same Azure subnet (a subnet may equal VNet prefix 1 exactly and still hold a prefix inside VNet prefix 2). Without the filter, the encompassing selection would inflate the group to 2 and the one child that *is* created would be needlessly renamed.
-2. **Do not seed `usedNames` from the existing tree.** `usedNames` feeds `DisambiguateName`, which appends the **VNet name**, not the prefix — so the cross-session second row would land as `name (vnet-name)`, a different and inconsistent shape from the single-session `name (10.72.5.0/24)`. Worse, seeding from the whole `existingSubnets` list makes every ordinary import rename any child whose Azure name matches **any** existing Bastet subnet anywhere in the tree, including unrelated branches — a broad silent rename regression in the common path, exactly what M1 was careful to avoid. **Correct targeted fix:** in `BuildPlanItem`, prefix-qualify a planned child when `existingSubnets` already contains a row whose `AzureResourceId` equals `sub.Source.AzureResourceId` and whose `{NetworkAddress, Cidr}` is not this selection's. Same `name (network/cidr)` shape, fires only for the real multi-row case, needs no DTO or ARM change (the commit never re-queries Azure and `BulkImportSelectedSubnetDto` carries no prefix count). The already-persisted first row keeps its bare name and remains unambiguous because the new row is qualified.
-3. **The `TargetName(p)` half is a separate reproduced defect, filed as N10 — not deferred.** Two same-named Bastet targets for a two-address-space VNet were persisted in this very run (rows 2 and 4 of the output above). It is a different code path with its own owner decision, so it is fixed there rather than here; it is not a hole in round 13's guard, which is why it is a finding of its own rather than part of this one.
-
-*(If you take N7's separator change, note that the qualification suffix produced here should use it too.)*
-
-**Interim mitigation.** In `DetectExistingBastetSubnetConflicts`/`AnnotateSubnet`, warn per item when a planned child's final name equals an existing Bastet subnet name under the same target or another planned child's name in the same commit, so the preview discloses the collision before the operator confirms. Sound and cheap — but it is a disclosure, not a fix.
-
-**Decision needed from you.** (1) Whether prefix-qualified names apply across the whole commit and across sessions — the fix changes names some installs see on their **next** import of such a VNet (nothing already persisted is renamed) — versus shipping only the preview warning. (2) The `TargetName` question — whether a target should be prefix-qualified when a VNet contributes several selected prefixes — is N10's decision, taken on its own merits.
-
-*Consequence corrected downward by the verifier:* "no way to tell which range they are acting on from the name alone" is overstated — every render carries the address beside the name (`_SubnetTreeItem.cshtml:17-18`, `_ChildSubnets.cshtml:44-45`, `Delete/_WarningAlert.cshtml:6`, `AllHostIps.cshtml:53`, and all three reconcile lists). Every persisted range, parent link and Azure link is correct; nothing is misreported as free. This is a **broken deliberate invariant with a display-ambiguity consequence**, hence low — a judgement on consequence, not on rarity.
+_Tests: 822 → 828. Four of the six are counter-tests._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -183,36 +183,19 @@ _Tests: 828 → 833._
 
 ---
 
-## N8 — `FullyAllocatedNote.For` can build a note that `FullyAllocatedNote.Strip` is structurally unable to remove, so M3's stacking defect returns in full `[x2]`
+## N8 — `FullyAllocatedNote.For` can build a note that `FullyAllocatedNote.Strip` is structurally unable to remove `[x2]` — FIXED
 
-**Severity:** low · **Confidence:** confirmed
-**Citation:** `src/Bastet/Services/FullyAllocatedNote.cs:23` (`Strip` at `:36-48`, `IsNote` at `:76-82`)
+_N8 is fixed and committed, as the verifier proposed: `For` normalises every line-break form in the Azure subnet name to a space, so a note is single-line **by construction** and `Strip`'s whole-line anchoring becomes total without being loosened. The name stays readable — collapsed to a space, not deleted._
 
-**Failure scenario.** `For` interpolates the Azure subnet name with no whitespace normalisation, while `Strip`/`IsNote` split the description on `\n` and require a **single line** to both start with the prefix and end with the suffix. A name containing a newline therefore produces a note spanning two lines, neither of which satisfies both anchors, so no later `Strip` can ever remove it. `AzureImportSubnetViewModel.Name` inherits `[SafeText]` from `CreateSubnetViewModel` (`SubnetViewModels.cs:11`), whose class admits `\s` — which includes newline — and `SanitizeName` only trims the ends. An Admin posts `Subnet/BatchCreateChildSubnets` with `isAzureImport=true`, a fully-encompassing entry, and a name of `sn-A<LF>sn-B`. Result: **(1)** after `HostIp/SetAllocationStatus IsFullyAllocated=false` the row has `IsFullyAllocated=0` while its description still reads "Fully allocated by Azure subnet '...' which encompasses the entire address space." — the exact contradiction M3's un-mark mirror exists to eliminate; **(2)** each import→un-mark→import cycle appends another copy, which is M3's original defect verbatim. Azure subnet names cannot contain newlines, so the trigger is a crafted or replayed POST by an Admin — the same threat model `ResolveImportNames` is explicitly settled server-side against (`SubnetController.Azure.cs:244-247`).
+_Fixed at the helper rather than at the two producers, on the finder's own reasoning: `For` is the single choke point both call sites go through, and leaving the helper able to build an unstrippable note for any future caller is the same latent defect one step removed. **Not** fixed by tightening the `[SafeText]` pattern — that class is shared with host names and subnet names across the app, and narrowing it to close this would be a far wider change than the defect warrants._
 
-**Reproduction** — own instance port 5361, catalog `bastet_rig14_advc5`. Name posted as a literal `sn-A<LF>sn-B` via `--data-urlencode 'subnets[0].Name@nl.txt'`; the server accepted it (302, no ModelState error):
+_The owner declined a backfill, so rows that already carry an unstrippable two-line note stay hand-repairable via Edit only. That matches the call round 13 made explicitly for the analogous stacked-note residue, and no such row can exist without someone having already sent a crafted POST._
 
-```
-SELECT Id, IsFullyAllocated, LEN(Description), REPLACE(Description,CHAR(10),'<LF>') FROM Subnets WHERE Id=1
+_Proven by A/B: the updated test file was copied unchanged into a clone of `77560af` and run — **4 of the 5 new cases fail there**, including `Strip(Append(null, "sn-A\nsn-B", 1000))` returning the note instead of empty, and the four-cycle stacking test. The fifth, a name carrying a bare `\r`, passes on both builds: `Strip` splits on `\n` only, so that spelling never produced a two-line note in the first place. It is kept as a test because the fix now normalises it too, and a future change to the splitting would otherwise reintroduce the defect through a spelling nobody was watching._
 
-  baseline        1|0|19 |Ops owns this range
-  after import 1  1|1|107|Ops owns this range<LF>Fully allocated by Azure subnet 'sn-A<LF>sn-B' which ...
-  after un-mark   1|0|107|<IDENTICAL — the note SURVIVED SetAllocationStatus IsFullyAllocated=false>
-  after import 2  1|1|195|<operator line + TWO identical notes>
-  after cycle 3   1|1|283|<operator line + THREE identical notes>
-  final un-mark   1|0|283
+_The seventeen existing `FullyAllocatedNoteTests` are untouched and still pass, including the four `[Theory]` cases pinning operator prose that merely resembles the note — those exercise `Strip`, not `For`, which is why this fix could not disturb them._
 
-Growth 88 chars per cycle, exactly M3's original arithmetic. Control: the operator line
-"Ops owns this range" is preserved throughout, so Strip works normally — it is specifically
-the two-line note it cannot see. Rendered Details shows three copies on a row whose
-IsFullyAllocated is 0.
-```
-
-**Fix (verifier: sound).** One line at `FullyAllocatedNote.cs:23` — normalise the name before interpolation, e.g. `azureSubnetName?.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ')`. Every note becomes single-line by construction, so `Strip`'s whole-line anchoring becomes total without loosening it. `For` is the single choke point both call sites go through; the null case is unchanged; the four `[Theory]` cases pinning operator prose exercise `Strip`, not `For`, so they are untouched. Add a test asserting `Strip(Append(null, "a\nb", 1000))` is empty. **Do not** take the "cheaper interim" of collapsing newlines at the two producers — it leaves the helper able to build an unstrippable note for any future caller, as the finder himself notes. **Do not** "fix" this by tightening the `[SafeText]` pattern; that class is shared with host names and subnet names across the app.
-
-**Decision needed from you.** Whether to do anything about rows that already carry an unstrippable two-line note. None can exist without someone having already sent a crafted POST, and round 13 explicitly declined a backfill for the analogous stacked-note residue — but the code fix alone leaves those rows permanently un-repairable except by hand-editing the description.
-
-*Bounded harm:* no IPAM correctness impact (the `IsFullyAllocated` flag itself is written correctly, no range is shown free), no data loss (the overflow branch at `:71-73` keeps operator text whole and growth is capped at `MaxSubnetDescriptionLength`), and the row is hand-repairable via Edit. What is wrong is a free-text field asserting the opposite of the row's state, permanently un-removable by the app, plus unbounded restacking. A shade worse than M3's own Info rating because the residue is now un-strippable rather than self-healing.
+_Tests: 833 → 838._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -215,28 +215,19 @@ _Tests: 838 → 841._
 
 ---
 
-## N10 — Every selected VNet address prefix creates a target named for the bare VNet, so a VNet with two address prefixes persists as two Bastet subnets with the identical name and the identical `AzureResourceId` *(promoted from the watch list by the citation check)*
+## N10 — Every selected VNet address prefix creates a target named for the bare VNet `[x2 via N6's reproduction]` — FIXED
 
-**Severity:** low · **Confidence:** confirmed
-**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:728` (callers at `:427` and `:444`; the commit that persists it at `src/Bastet/Controllers/SubnetController.BulkAzure.cs:365-369` and `:394-398`)
+_N10 is fixed and committed. The owner chose to prefix-qualify `TargetName` over the preview-warning alternative. Qualification is decided across the whole commit, exactly as N6's part 1 concluded: `BuildPlan` computes which VNets contribute more than one **distinct** selected address prefix and passes that set into `BuildPlanItem`, so each target is named for the range it holds — `vnet-a (10.71.0.0-16)` — using the same `name (network-cidr)` shape N6 and N7 settled on, so all three naming paths stay consistent._
 
-**Failure scenario.** `TargetName` returns the sanitised VNet name and nothing else — it never references which of the VNet's address prefixes the target holds. `BuildPlanItem` runs once per selected VNet address prefix, so every item for the same VNet carries the identical `AutoCreateTargetName`, and the commit creates one Bastet subnet per item with no cross-item name check: `usedNames` (`:486`) is per-item and only guards *child* names. A VNet with two address prefixes therefore persists **two top-level Bastet subnets with the same name**, both stamped with the same VNet `AzureResourceId`, distinguishable only by network address. Reachable in one click of "Select all"; no crafted payload. This is N6 one level up the tree: N6 is two same-named children of one Azure *subnet*, this is two same-named targets of one Azure *VNet*, and unlike N6 it fires on **every** multi-address-space VNet import, not only on a prefix-spanning subnet.
+_Not routed through `DisambiguateName`, on the finding's own reasoning: that appends the **VNet name**, which is precisely the token that is already identical here, and its numeric fallback would produce `vnet` and `vnet (2)` — neither of which says which range the row holds. The `ExactMatch` branch is unaffected because it adopts an existing row and names nothing; `AnExactMatchTargetIsNotRenamedByTheQualification` pins that._
 
-**Reproduction** — the same run recorded under N6 (own instance port 5193, catalog `bastet_rig14_verc3`, fixture `rig-14-b5p2-vnet`, prefixes 10.71.0.0/16 and 10.72.0.0/16). Rows 2 and 4 of that output *are* this defect, persisted:
+_A pre-existing test had to change, and it is worth recording why. `AzureBulkImportPlannerTests.MultipleVNetPrefixes_EachIsIndependentTarget` asserted the **opposite** — both targets keeping the bare VNet name — under a comment reading "If a future change introduces auto-disambiguation of these names, this assertion will catch it." It did exactly that, on the first run after the change. The assertion was updated rather than worked around, because the behaviour it pinned is the defect: two Bastet subnets with the identical name and the identical VNet resource id, on every multi-address-space VNet import._
 
-```
-POST /Subnet/BulkCreateFromAzurePlan -> {"success":true,"createdTargets":2,"createdChildSubnets":2}
-  2 |rig-14-b5p2-vnet|10.71.0.0|16|NULL      <- two targets, identical Name,
-  4 |rig-14-b5p2-vnet|10.72.0.0|16|NULL      <- identical AzureResourceId (the VNet)
-```
+_Proven by A/B: the new test file was copied unchanged into a clone of `77560af` and run — `AVNetWithTwoAddressPrefixes_NamesEachTargetForTheRangeItHolds` fails there while the other five pass, because those five assert behaviour the fix had to preserve: a single-prefix VNet keeps its bare name, two different VNets are both left bare, the same prefix selected twice is not two prefixes, an ExactMatch target is untouched, and every generated name satisfies the app's own `[SafeText]` rules._
 
-**Fix.** Qualification has to be decided across the commit, not inside one item, exactly as N6's part 1 concludes: in `BuildPlan`, when more than one address prefix of the same VNet is selected, qualify each item's `AutoCreateTargetName` with the prefix it holds — the same `name (network-cidr)` shape N6 and N7 settle on, so all three stay consistent. Do **not** route this through `DisambiguateName`: it appends the *VNet name*, which is precisely the token that is already identical here, and its numeric fallback would produce `vnet`/`vnet (2)`, which says nothing about which range the row holds. The `ExactMatch` branch is unaffected — it adopts an existing row and does not name anything.
+_Nothing already persisted is renamed; this changes only the names an install sees on its **next** import of a multi-address-space VNet._
 
-**Decision needed from you.** Whether to prefix-qualify `TargetName` when a VNet contributes several selected prefixes. It changes the names some installs see on their **next** import of a multi-address-space VNet (nothing already persisted is renamed). The alternative is a preview warning only — the wizard discloses that two targets will be created with the same name and the operator renames one afterwards by hand.
-
-*Consequence:* low, on the same reading as N6 — every persisted range, parent link and Azure link is correct, nothing is misreported as free, and every render carries the address beside the name. What is wrong is a duplicated display label that no screen can explain.
-
-*Why this is a finding and not a watch-list item:* it was parked in the watch list as "pre-existing on every build" and excluded from N6's fix as "out of scope", while the two rows above had already been **persisted and observed** in N6's own reproduction. Age, fix cost and blast radius are not severity inputs and are not grounds for withholding a reproduced defect from the findings; it is filed here at the severity its consequence warrants. Its `TargetName` half is therefore removed from N6's fix list and from the watch list.
+_Tests: 841 → 847._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -83,47 +83,21 @@ _Tests: 771 → 792. Nine in `AzureReconcilerRangeStillAllocatedTests` (four of 
 
 # High
 
-## N2 — Reconcile delete archives on a re-derived Azure verdict it never compares against the one the operator approved `[x1]`
+## N2 — Reconcile delete archives on a re-derived Azure verdict it never compares against the one the operator approved `[x1]` — FIXED
 
-**Severity:** high · **Confidence:** confirmed
-**Citation:** `src/Bastet/Controllers/SubnetController.AzureReconcile.cs:78`
+_N2 is fixed and committed. `AzureReconcileDeleteDto` gained `Statuses`, a per-row `{subnetId, statusName, reason}` snapshot taken where `confirmedIds` is already frozen in `_ReconcileScripts.cshtml`, so both describe the same reviewed plan. The commit now refuses the whole batch when any selected row's re-derived verdict differs from the approved one, returning a 409 worded separately from the existing "no longer reported as deleted" refusal — deliberately not merged, because the two call for different operator actions: the first means the row is fine, the second means it is still wrong but wrong in a way they have not seen and might well answer by re-importing rather than archiving._
 
-**Failure scenario.** The wizard deliberately carries each row's *reason* onto the last screen before the archive (`_ReconcileScripts.cshtml:396-408`: "a row whose own reason says the Azure resource still exists was confirmed under a heading saying it did not"). The commit then throws that approval away: `stillStale = plan.Items.ToDictionary(i => i.SubnetId)` and `noLongerStale = request.SubnetIds.Where(id => !stillStale.ContainsKey(id))` test only **set membership** in the re-derived plan, never that the row is stale for the reason the operator saw. `VNetDeleted`/`SubnetDeleted` are absence claims that must survive a direct ARM read; `VNetPrefixRemoved`/`SubnetPrefixChanged` are drift verdicts taken off the listing with no direct read at all (deliberately — see `AzureReconciler.cs:186-196`). A row that moves from the first class to the second between the confirmation screen and the click stays in `plan.Items`, the 409 never fires, and the subtree is archived. Real trigger: an IaC destroy/apply with a changed CIDR — ARM ids are path-based, so the recreated VNet has the same id. The endpoint's own docstring at `:15-18` promises the opposite: *"a resource that reappeared in Azure cannot cause the wrong subnets to be archived."*
+_Both of the verifier's tightenings were taken, and the owner chose the strict reading of each. The **reason** is compared as well as the status, so a same-status/different-facts change — a prefix that has moved again, re-deriving as `SubnetPrefixChanged` both times while naming a different live prefix — is caught; `ApprovedWithTheSameStatusButADifferentReason_IsRefused` pins it. An **unparseable** status name is a divergence rather than "unverified", mirroring how `DescribeApprovedPlanDivergences` handles `TargetType`; a `[Theory]` covers `"NotAStatus"`, `""` and `"42"`. And the check is **mandatory**, not optional-and-logged: a request naming no verdict at all is refused, because an omitted verdict is exactly what a replayed or hand-built post carries. The refusal is all-or-nothing, returned before any lock is taken, and puts the mismatched ids in `subnetIds` so the wizard can highlight them._
 
-**Reproduction** — own instance port 5199, catalog `bastet_rig14_v9c`, live fixture `rig-14-v9c-vnet`. Seeded Bastet subnet `V` 10.111.0.0/16 linked to the VNet, with a **manually created** child `prod-app-tier` 10.111.1.0/24 (no Azure provenance) and host IP `web01` 10.111.1.10:
+_The interim mitigation was **not** taken. It rejected the absence-to-drift transition specifically, which is narrower than the defect: comparing the approved verdict covers that transition and every other, at the same cost, without the interim's side effect of 409ing a plan that was drift-only from the start._
 
-```
-az network vnet delete       -> rc 0 ; az network vnet show -> rc 3 (404)
-POST /Azure/ReconcileScan    -> statusName "VNetDeleted",
-   reason "The VNet this subnet was imported from no longer exists in Azure...",
-   descendantCount 1, hostIpCount 1, canCommit true       <- what the operator approves
+_Making the check mandatory is a contract change, so three existing tests that drove a successful delete without naming a verdict were updated to supply one. They derive it from a real scan through a new `AzureReconcileApproval.ForAsync` helper rather than hardcoding a status — a test that hardcodes what it expects would keep passing if the reconciler started reporting something else, which is the very drift this check exists to catch._
 
-az network vnet create -n rig-14-v9c-vnet --address-prefixes 10.112.0.0/16   (same name = same ARM id)
-re-scan (same session) -> [(1,'VNetPrefixRemoved',"VNet ... still exists but no longer has
-                            the address prefix 10.111.0.0/16.")]
+_Proven by A/B on the same live Azure, driving the exact IaC destroy/apply the finding describes: scan while the VNet is deleted (operator approves `VNetDeleted`), recreate the VNet at the same ARM id with prefix `10.112.0.0/16` — ARM ids are path-based, so the id is unchanged — then commit carrying the original approval. Unfixed `77560af`: the server re-derived `VNetPrefixRemoved` and still returned **HTTP 200 `targetsDeleted: 1, subnetsArchived: 1`**, taking the database from 1 subnet / 1 archived to 0 / 2. Fixed, same sequence: **HTTP 409**, `subnetIds: [1]`, "The reason 1 of the selected subnet(s) were flagged has changed since you reviewed them", and the database unchanged at 2 subnets / 0 archived. The 409 named only row 1; row 2, whose `SubnetDeleted` verdict was genuinely unchanged, was not falsely implicated._
 
-POST /Subnet/BulkDeleteStaleAzureSubnets {"subnetIds":[1],"confirmation":"approved"}
-  -> HTTP 200 {"success":true,"targetsDeleted":1,"subnetsArchived":2,"hostIpsArchived":1}
+_One measurement was discarded rather than recorded: the first fixed-build run also returned 200, because the app process had been started before the N2 edit and was still serving N1-era code. It was rebuilt and re-run before anything was concluded._
 
-SELECT COUNT(*) FROM Subnets            -> 0
-SELECT ... FROM DeletedSubnets          -> prod-app-tier 10.111.1.0/24 ; V 10.111.0.0/16
-SELECT COUNT(*) FROM HostIpAssignments  -> 0
-```
-
-The banner reads "Deleted 1 stale subnet(s)" — a staleness claim the server had disproved milliseconds earlier. There is no restore from `DeletedSubnets` (round 13 established this on the record).
-
-**Fix (verifier: sound, with two tightenings).** Carry the approved verdict into the commit and refuse a mismatch, exactly as the bulk import commit already does for its plan (`DescribeApprovedPlanDivergences`, round 10's J2). Add `Statuses` (a per-id `{subnetId, statusName}` list) to `AzureReconcileDeleteDto`; snapshot `i.statusName` alongside `i.subnetId` at `_ReconcileScripts.cshtml:362` where `confirmedIds` is already frozen; at `SubnetController.AzureReconcile.cs:78` add the conjunct `stillStale[id].Status != approvedStatus[id]` returning the same 409 body, worded *"the reason N of the selected subnet(s) were flagged has changed since you reviewed them. Nothing was deleted. Re-run the scan."* Tightenings:
-
-1. The status arrives as a caller-supplied string: parse defensively and treat an **unparseable** value as a divergence, not as "unverified" — mirror how `DescribeApprovedPlanDivergences` handles `TargetType`. Only a **missing** status counts as unverified-and-logged.
-2. Comparing `Status` alone still lets a same-status/different-facts change through (a row approved as `SubnetPrefixChanged :: "now 10.111.1.0/24"` commits unchanged when the prefix has since moved again). If you want the guarantee the docstring claims, compare the server-derived `Reason` (or the observed Azure prefix) too, as the bulk path compares `ChildNames` in addition to `TargetType`.
-
-Keep the refusal all-or-nothing, returned before any lock is taken, and put the mismatched ids in the `subnetIds` array so the wizard can highlight them. Do not merge the two messages — "no longer reported as deleted" and "flagged for a different reason" call for different operator actions.
-
-**Interim mitigation (three lines, no DTO change).** At `:78`, also refuse when any selected id's re-derived status is a drift status (`SubnetPrefixChanged`/`VNetPrefixRemoved`) while `ConfirmProposedDeletionsAsync` was not asked about it — i.e. reject the absence→drift transition specifically, which is the only unprotected transition (every other class change moves the row into `ReviewItems` and out of `plan.Items`, which the existing 409 already catches). Cost: a plan that was drift-only from the start also 409s unless drift statuses are whitelisted.
-
-**Decision needed from you.** Whether an out-of-band Azure re-create inside the confirm window becomes a 409 the operator must re-scan through (safer, converts a legitimate drift deletion into a retry), and whether the approved-status check is mandatory or optional-and-logged for callers using this as the documented direct JSON API — the same fail-open-and-log trade-off already accepted at `SubnetController.BulkAzure.cs:99-106`.
-
-*Scope correction from the verifier:* the id-set archived equals the id-set approved, and every archived target is independently stale under the fresh verdict. The wrongness is that **consent was bound to a fact the server had disproved**, not that unselected rows were touched. Severity stays high: this is the only endpoint that deletes on the strength of what Azure reports, the removal is irreversible, and the operator would plausibly have chosen re-import over archive had the drift reason been shown.
+_Tests: 792 → 800. Eight in `SubnetControllerReconcileApprovedVerdictTests`, including the counter-test that a verdict which still matches archives normally — without it this fix would be indistinguishable from breaking the feature._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -167,43 +167,19 @@ _Tests: 822 → 828. Four of the six are counter-tests._
 
 ---
 
-## N7 — Round 13's name qualification builds subnet names containing `/`, the one character the app's own name rules forbid; the create-from-unallocated-range prefill then silently rewrites `(10.20.40.0/24)` to `(10.20.40.024)` and persists that false token `[x1]`
+## N7 — Round 13's name qualification builds subnet names containing `/`, the one character the app's own name rules forbid `[x1]` — FIXED
 
-**Severity:** low · **Confidence:** confirmed
-**Citation:** `src/Bastet/Services/Azure/AzureBulkImportPlanner.cs:530` and `src/Bastet/Controllers/SubnetController.Azure.cs:276`
+_N7 is fixed and committed. The owner chose option (a): the suffix at both name-producing sites is now `$" ({network}-{cidr})"`, matching the convention `SubnetController.Create` already uses and documents. Option (b) — keeping `/` and relaxing `[SafeText]` on `CreateSubnetViewModel.Name` — was declined, so the shared input class is untouched and carries no new security-review surface. No rename migration was needed: the slashed form shipped one commit ago, which is why the window to change it freely was now._
 
-**Failure scenario.** Bulk import creates rows named `rig-14-sn-a2-multi3 (10.20.40.0/24)`. `Subnet.Name` accepts them (Edit applies only `[NoHtml]`/`[SanitizeName]`), but `CreateSubnetViewModel.Name` carries `[SafeText]`, whose class `[a-zA-Z0-9\s\-_.,!?@#$%&()+=]` excludes `/`. Two operator-visible consequences: **(1)** the name the app generated is a name the app's own Create form refuses; **(2)** the Details page's **Create Subnet** button on an unallocated range navigates to `/Subnet/Create?parentId=…`, where `SubnetController.Create.cs:76` runs `SubnetNaming.ToSafeText(parentSubnet.Name)` precisely to avoid that rejection — and `ToSafeText` **deletes** the `/` rather than rejecting, so the prefilled default becomes `rig-14-sn-a2-multi3 (10.20.40.024)-10.20.40.0-25`. An operator who accepts the default — which is what that button exists for — persists it. The rule is written verbatim in a comment in the very controller that prefills the form, at `SubnetController.Create.cs:67-68`: *`"-{cidr}" and not "/{cidr}": [SafeText] on CreateSubnetViewModel.Name forbids "/"`*. This is the exact failure round 4's D19/D8 fixed; round 13 reintroduced the character, and `test/Bastet.Tests/Azure/AzureMultiPrefixImportCommitTests.cs:124-125` now pins the slashed form.
+_Both of the verifier's additions were taken. The pinned assertions were in **three** files, not two — `AzureMultiPrefixImportCommitTests`, `AzureMultiPrefixSubnetTests` (including its fixture names), and the `AzureBulkImportSpanningNameTests` added by N6 an hour earlier. And the missing recurrence guard now exists: `GeneratedNameSafeTextTests` asserts that every name the bulk planner and `ResolveImportNames` **generate** satisfies `IInputSanitizationService.IsSafeText`. That assertion is the cheap thing that stops a third occurrence — round 4 removed this character, round 13 put it back, and nothing in the suite noticed either time because `SubnetNamingSafeTextTests` pins `ToSafeText` character-by-character without ever checking a produced name._
 
-**Reproduction** — own instance port 5891, catalog `bastet_rig14_verc12b`, live ARM:
+_`ResolveImportNames` was made `public static` as a test seam, the same way round 13 made `AzureService.BuildInventorySubnetRows` public and for the same reason: the surrounding action needs a DbContext, an antiforgery token and a live Azure credential, so the naming rules cannot otherwise be asserted directly._
 
-```
-POST /Subnet/BulkCreateFromAzurePlan -> {"success":true,"createdTargets":1,"createdChildSubnets":5}
-  2|rig-14-sn-a2-multi3 (10.20.40.0/24)|10.20.40.0|24|1        (etc.)
+_The finder's own interim was **not** taken, on the verifier's reasoning: mapping `/` to `-` inside `ToSafeText` would leave the app still generating names its Create form rejects, and would change long-standing behaviour for hand-typed parents ("Prod/Web" becoming "Prod-Web"), breaking a pinned `InlineData` in `SubnetNamingSafeTextTests`._
 
-GET /Subnet/Details/2 renders
-  <button class="create-subnet-btn" data-network="10.20.40.0" data-parent-id="2" data-parent-cidr="24">
-  and navigates to /Subnet/Create?networkAddress=..&cidr=..&parentId=..
+_Proven by A/B at the unit level. The guard was copied into a clone of `77560af` (minus the two parts that need the new seam) and run: it fails there with **"The planner generated 'sn-multi (10.20.40.0/24)', which the app's own [SafeText] rules reject."**, and both prefill cases fail alongside it — 3 of 4 red. Against the fixed tree all five pass. `TheForwardSlashIsStillForbidden_SoTheSeparatorMayNotGoBack` pins the character itself, so putting the separator back is now a test failure rather than a silent regression._
 
-GET /Subnet/Create?networkAddress=10.20.40.0&cidr=25&parentId=2 ->
-  value="rig-14-sn-a2-multi3 (10.20.40.024)-10.20.40.0-25"      <- the "/" was deleted
-
-POST /Subnet/Create with that default -> 302 /Subnet/Details/7
-  7|rig-14-sn-a2-multi3 (10.20.40.024)-10.20.40.0-25|10.20.40.0|25|2
-
-POST /Subnet/Create Name="rig-14-sn-a2-multi3 (10.20.40.0/24)-child"
-  -> 200 with field error "Subnet name contains invalid characters"
-```
-
-**Fix (verifier: sound, with two additions).** Change the suffix at both sites from `$" ({network}/{cidr})"` to a separator the SafeText class admits — `$" ({network}-{cidr})"`, matching the convention `Create.cs:81` already uses. Verified: `-`, `.`, `(`, `)` are all inside the class, and the prefill then composes the coherent `rig-14-sn-a2-multi3 (10.20.40.0-24)-10.20.40.0-25`. These two are the only name-producing `/` sites in the repo (all other `({x}/{y})` interpolations are validation or error messages, none written to `Subnet.Name`). Additions:
-
-1. **The pinned assertions are in three places, not two** — `AzureMultiPrefixImportCommitTests.cs:124-125` **and** `AzureMultiPrefixSubnetTests.cs:142`, plus fixture names at `:207`/`:270` for consistency.
-2. **Add the recurrence guard that is missing.** `SubnetNamingSafeTextTests` pins `ToSafeText` character-by-character, but nothing asserts that a **generated** name satisfies `IsSafeText` — which is why round 13 reintroduced the character round 4 removed. Assert `new InputSanitizationService().IsSafeText(name)` over the planner's `BulkImportPlannedChildSubnet.Name` and `ResolveImportNames`' output. That is the cheap thing that stops a third occurrence.
-
-**Do not take the finder's own interim instead of the fix.** Making `ToSafeText` map `/` to `-` would leave the app still generating names its Create form rejects, and changes long-standing behaviour for hand-typed parents ("Prod/Web" → "Prod-Web"), breaking the pinned `InlineData` at `SubnetNamingSafeTextTests.cs:42`. As a stop-gap *alongside* the decision it is acceptable — it stops the prefill inventing `(10.20.40.024)` — but it is not a substitute.
-
-**Decision needed from you.** The suffix format is a naming/product call. Either **(a)** change the separator to `-` so generated names satisfy the app's own SafeText class — cosmetically different, three test assertions, and **no rename migration is needed because the code shipped one commit ago; the window to change it freely is now** — or **(b)** keep `/` in stored names and relax `[SafeText]` on `CreateSubnetViewModel.Name` to admit it (which Edit already effectively allows), accepting the security-review implication of widening a shared input class. Doing neither leaves the app generating names it refuses on input.
-
-*Harm corrected downward:* `10.20.40.024` is unparseable gibberish, not a plausible-but-wrong range, so an operator reads it as a mangled name rather than as a false allocation. `NetworkAddress`/`Cidr` are correct everywhere and Details renders `10.20.40.0/25` truthfully. Nothing in the IPAM data model is wrong — hence low, not the "allocated range shown free" class.
+_Tests: 828 → 833._
 
 ---
 

--- a/docs/AUDIT-FINDINGS-14.md
+++ b/docs/AUDIT-FINDINGS-14.md
@@ -65,47 +65,19 @@ All ten findings reproduced on a running instance. Nothing in this file is infer
 
 # Critical
 
-## N1 — Reconcile archives a Bastet subnet whose CIDR is still allocated in Azure by a *different* Azure subnet, after which BASTET advertises the Azure-assigned range as free space — and re-import is then refused `[x2]`
+## N1 — Reconcile archives a Bastet subnet whose CIDR is still allocated in Azure by a *different* Azure subnet `[x2]` — FIXED
 
-**Severity:** critical · **Confidence:** confirmed
-**Citation:** `src/Bastet/Services/Azure/AzureReconciler.cs:367` (and the identical hole at `:376-381`)
+_N1 is fixed and committed. The reconciler now answers the question the four stale statuses never asked: is the RANGE still assigned in Azure, even though the resource that carried it is gone? `BuildPlan` builds a second index alongside `liveSubnetPrefixes` mapping each live IPv4 prefix to the Azure subnet holding it, and any row that would have been offered for deletion while its range is still assigned becomes a new report-only status, `RangeStillAllocatedInAzure`, in `ReviewItems` — never deletable — plus a plan warning naming the Azure subnet that holds it._
 
-**Failure scenario.** Azure has no subnet rename, so re-organising one means delete-and-recreate. A VNet holds subnet `sn-a` with prefix `10.111.5.0/24`, imported into Bastet. `sn-a` is deleted and immediately recreated as `sn-a2` carrying the **same** prefix. `EvaluateSubnetLevel` keys only on the recorded ARM resource id (`:365-369`), so the Bastet row becomes `SubnetDeleted` — "The Azure subnet this was imported from no longer exists." That statement is *literally true*; the resource really is gone. What is missing is any range-level check. `ConfirmProposedDeletionsAsync` (`AzureController.cs:368-389`) asks ARM one question only — is this resource id gone — gets a genuine 404, and keeps the row. After approval the parent's Details page advertises the still-assigned `/24` as free with a **Create Subnet** button. The reconciler holds the contradicting evidence: `liveSubnetPrefixes`, built at `AzureReconciler.cs:64-71` from the same scan, contains `sn-a2 -> [10.111.5.0/24]`. The second route, `SubnetPrefixChanged` (`:376-381`), gets no direct ARM confirmation at all — `IsAbsenceStatus` (`:305-306`) covers only `VNetDeleted`/`SubnetDeleted` — so moving a prefix between two Azure subnets produces the same wrong output with even less friction.
+_All three of the verifier's corrections were taken. The index accumulates into `Dictionary<string, List<AzurePrefixOwner>>` rather than `ToDictionary`, because one prefix legitimately has several owners and a duplicate-key throw would turn a whole scan into "The reconcile scan failed"; `DuplicateRangesAcrossVNets_DoNotThrow` pins it with three VNets carrying the same `10.10.1.0/24`. The match is scoped to the row's own VNet via a new `AzureResourceIdentity.VNetIdOf`, because overlapping RFC1918 across unrelated VNets is the norm — `TheSameRangeAllocatedInADifferentVNet_DoesNotWithholdTheDeletion` proves an unrelated VNet's identical range does not withhold a genuine deletion. And the fail-closed half was **not** shipped alone: the owner chose warn + fail closed + re-link, so `POST /Subnet/RelinkAzureSubnet` now repairs the link in place, which is what makes withholding a correction rather than the permanent dead end correction 3 warned about._
 
-**Reproduction** — own instance port 5196, catalog `bastet_rig14_verc7`, own live fixture `rig-14-verc7-vnet` (10.111.0.0/16):
+_The re-link endpoint takes **no resource ID from the caller** — only the Bastet subnet id. It re-scans Azure, re-derives the new link from the fresh plan, accepts only a row that plan itself reports as `RangeStillAllocatedInAzure`, and re-checks the row's link under the subnet lock before writing. So neither a stale browser view nor a crafted post can point a Bastet subnet at an arbitrary Azure resource; the range that moved decides what the row links to. `TheNewLinkIsDerivedFromAzure_NotFromAnythingTheCallerSupplied` pins that with a decoy subnet in the same VNet._
 
-```
-BEFORE  GET /Subnet/Details/1 "Unallocated IP Ranges":
-        10.111.0.0 - 10.111.4.255 (1,279)  |  10.111.7.0 - 10.111.255.254 (63,743)
+_Proven by A/B against a clone of the unfixed commit `77560af`, both builds driven through the same live Azure fixture (`rec14-n1-vnet` 10.111.0.0/16, subnet `rec14-n1-sn-a` 10.111.5.0/24 deleted and recreated as `rec14-n1-sn-a2` with the same prefix — Azure has no rename). Unfixed: the scan reported `items: [(2, "SubnetDeleted")]` with no warning, `BulkDeleteStaleAzureSubnets` returned **200 `subnetsArchived: 1`**, and `/Subnet/Details/1` then advertised `10.111.0.0 - 10.111.255.255, 65,534 IP addresses` as free — up from 65,278, a difference of exactly the 256 addresses ARM still assigns. Fixed, same fixture: `items: []`, `reviewItems: [(2, "RangeStillAllocatedInAzure", "rec14-n1-sn-a2")]`, the archive attempt returned **409 with nothing deleted**, free space was unchanged, the re-link returned 200, and the following scan was completely clean — `items []`, `reviewItems []`, `warnings []`. The re-link endpoint returns 404 on the unfixed build; it did not exist._
 
-az network vnet subnet delete ... -n rig-14-verc7-sn-a
-az network vnet subnet create ... -n rig-14-verc7-sn-a2 --address-prefixes 10.111.5.0/24
+_Not done, and deliberately: nothing backfills rows already archived by this defect. `DeletedSubnets` has no restore path (round 13 established that on the record), so a row archived before this fix is recovered by re-importing it, which the re-link path does not change. The `SubnetPrefixChanged` route still takes no direct ARM read — `IsAbsenceStatus` is unchanged — because the range check now covers the case that made that gap dangerous, and widening confirmation to drift statuses would withhold every drift row permanently, which `ApplyConfirmations` documents at length as the reason it does not._
 
-POST /Azure/ReconcileScan ->
-  items: [{subnetId:2, status:2, statusName:"SubnetDeleted",
-           reason:"The Azure subnet this was imported from no longer exists."}]
-  reviewItems: []  globalErrors: []  warnings: []  canCommit: true
-
-POST /Subnet/BulkDeleteStaleAzureSubnets {"subnetIds":[2],"confirmation":"approved"}
-  -> 200 {"success":true,"targetsDeleted":1,"subnetsArchived":1,"hostIpsArchived":0}
-
-AFTER   GET /Subnet/Details/1:
-        10.111.0.0 - 10.111.5.255 (1,535)   <- grew by exactly the 256 addresses ARM still assigns
-```
-
-Route B (`SubnetPrefixChanged`, no ARM confirmation at all) archived row 3 and left `/Subnet/Details/1` showing `10.111.0.0 - 10.111.255.255, 65,534 IP addresses` while ARM held three `/24`s assigned. While a sibling Azure-linked child survives, re-import is refused by both wizards: `GET /Azure/Import/1` → 302; the VNet prefix is `Blocked`/`isSelectable=false`; a hand-built `BulkImportPreview` returns `canCommit:false`. Once **all** children were archived the prefix returned to `WillUpdateExisting` — so it is un-re-importable while a sibling remains, not permanently unrecoverable.
-
-**Fix (finder's proposal, corrected by the verifier — the original was incomplete on three counts).** Build a second index alongside `liveSubnetPrefixes` at `:64-71` mapping each live IPv4 prefix to its owning Azure subnet, and consult it before adding an item to `plan.Items`. Corrections:
-
-1. **Do not build it with `ToDictionary`.** Two VNets in one subscription can carry overlapping address space (the rig itself ships `10.10.0.0/16` and `10.10.0.0/20`), so one prefix string has several live owners. Use `Dictionary<string, List<(ResourceId, SubnetName, VNetName)>>` with indexer/`TryAdd` accumulation — exactly as `:68` already avoids `ToDictionary` for the same reason. A `ToDictionary` here turns every scan of a subscription with duplicated private CIDRs into "The reconcile scan failed."
-2. **Scope the match to the row's own VNet.** Overlapping RFC1918 across unrelated VNets is the norm; matching on the bare prefix string withholds genuinely stale rows. Parse the `/virtualNetworks/{name}/` segment out of `snapshot.AzureResourceId` (`AzureResourceIdentity` already handles these ids) and treat only a same-VNet live owner as evidence the range is still allocated — which is precisely where a rename or prefix move keeps the range.
-3. **Routing to `ReviewItems` is a dead end as the application stands.** No screen can edit or clear `Subnet.AzureResourceId`; the only writers are the two import commits. Worse, `ApplyConfirmations` adds every `ReviewItem`'s `SubnetId` to the `withheld` set at `:263`, so `WithholdTargetsWhoseCascadeIsBlocked` would permanently withhold the parent VNet-level row too. **Do not ship the fail-closed half alone.** A dedicated status is also cheap and keeps the reason honest — reusing `ReviewItems` renders these rows with the misleading existing copy "Correct or clear the link on this subnet", which no screen can do.
-
-**Interim mitigation (ship this now, under any of the three options).** One LINQ pass, ~15 lines: a `plan.Warnings` entry naming every proposed deletion whose CIDR is still live in the scanned inventory under a different Azure resource id in the same VNet — *"N subnet(s) below are proposed for deletion but their address range is still assigned in Azure to subnet 'X'; archiving them will make BASTET report an allocated range as free."* Put the same sentence on the item's own `Reason` so it appears next to the checkbox, not only in the banner. No new ARM calls, no change to what is deletable, no new stuck state.
-
-**Decision needed from you.** Fail closed, warn loudly, or fail closed plus a new "re-link this subnet to Azure subnet X" action. Fail-closed alone strands the row and its ancestors forever (see correction 3). Fail-closed plus re-link is the correct end state and also fixes the un-re-importable-sibling case; it is the largest of the three. The warning ships under all three.
-
-*Note on grading:* this is the same operator-visible output round 13 filed as High under M1. It is graded critical here because the wrong state is produced by an **irreversible archive** rather than by a display path, and because two independent routes reach it with zero warnings. If your scale caps range-misreporting at High, grade it there — but do not discount it for the rename trigger being uncommon.
+_Tests: 771 → 792. Nine in `AzureReconcilerRangeStillAllocatedTests` (four of which fail against the unfixed reconciler, and five counter-tests that a genuinely deleted range stays deletable), nine in `SubnetControllerRelinkAzureSubnetTests`, and three added automatically by `ControllerAuthorizationTests`, which enumerates controller actions by reflection and so picked the new endpoint up on its own._
 
 ---
 

--- a/src/Bastet/Controllers/AzureController.cs
+++ b/src/Bastet/Controllers/AzureController.cs
@@ -336,7 +336,10 @@ namespace Bastet.Controllers
             {
                 AzureVNetInventory inventory = await azureService.GetVNetInventory(subscriptionId);
                 IReadOnlyList<AzureLinkedSubnetSnapshot> linked = await snapshotService.GetAzureLinkedSubnetsAsync();
-                AzureReconcilePlanViewModel plan = reconciler.BuildPlan(subscriptionId, subscriptionName, inventory, linked);
+                // The whole tree, not just the linked rows: the inbound direction has to know about
+                // a range someone created by hand, which carries no Azure resource ID.
+                IReadOnlyList<ExistingSubnetSnapshot> existing = await snapshotService.GetExistingSubnetsAsync();
+                AzureReconcilePlanViewModel plan = reconciler.BuildPlan(subscriptionId, subscriptionName, inventory, linked, existing);
 
                 // The inventory is a list result and ARM filters those by RBAC, so "missing" is not
                 // the same fact as "deleted". Read each proposed row directly before offering it for

--- a/src/Bastet/Controllers/AzureController.cs
+++ b/src/Bastet/Controllers/AzureController.cs
@@ -35,12 +35,22 @@ namespace Bastet.Controllers
                 return this.RedirectToErrorPage(404, $"Subnet with ID {id} could not be found.");
             }
 
-            // Check if subnet has no children or host IPs and is not fully allocated
-            if (subnet.ChildSubnets.Count != 0 || subnet.HostIpAssignments.Count != 0 || subnet.IsFullyAllocated)
+            // A populated target used to be refused outright, which left an Azure subnet that gained
+            // a prefix after import impossible to import by any route while BASTET went on
+            // advertising the Azure-assigned range as free space. Narrowed rather than removed: a
+            // subnet that already has children may only be topped up when it is ALREADY LINKED to a
+            // VNet - i.e. an import put those children there. Adopting a hand-built subtree stays
+            // refused, because that is what re-stamps AzureResourceId on rows nobody imported.
+            // Host IPs and the fully-allocated flag are refused exactly as before.
+            bool isTopUp = subnet.ChildSubnets.Count != 0 && !string.IsNullOrEmpty(subnet.AzureResourceId);
+
+            if ((subnet.ChildSubnets.Count != 0 && !isTopUp) || subnet.HostIpAssignments.Count != 0 || subnet.IsFullyAllocated)
             {
                 TempData["ErrorMessage"] = subnet.IsFullyAllocated
                     ? "Subnet must not be marked as fully allocated"
-                    : "Subnet must not have any child subnets or host IP assignments";
+                    : subnet.HostIpAssignments.Count != 0
+                        ? "Subnet must not have any host IP assignments"
+                        : "Subnet already has child subnets and is not linked to an Azure VNet";
                 return RedirectToAction("Details", "Subnet", new { id });
             }
 
@@ -151,6 +161,19 @@ namespace Bastet.Controllers
             {
                 List<AzureSubnetViewModel> azureSubnets = await azureService.GetCompatibleSubnets(
                     vnetResourceId, subnet.NetworkAddress, subnet.Cidr);
+
+                // Offer only ranges BASTET does not already record. On a top-up the target keeps the
+                // subnets a previous import created, and re-offering them would either duplicate a
+                // row or fail the overlap check at commit - neither of which the operator asked for.
+                // Filtered server-side because the browser is not the authority on what BASTET holds.
+                HashSet<string> alreadyRecorded = new(
+                    await context.Subnets
+                        .AsNoTracking()
+                        .Select(s => s.NetworkAddress + "/" + s.Cidr)
+                        .ToListAsync(),
+                    StringComparer.OrdinalIgnoreCase);
+
+                azureSubnets = [.. azureSubnets.Where(a => !alreadyRecorded.Contains(a.AddressPrefix ?? string.Empty))];
 
                 return azureSubnets.Count == 0
                     ? Json(new

--- a/src/Bastet/Controllers/SubnetController.Azure.cs
+++ b/src/Bastet/Controllers/SubnetController.Azure.cs
@@ -244,8 +244,13 @@ public partial class SubnetController : Controller
     /// Settled server-side because the browser is not the authority: a crafted or replayed post
     /// carries whatever names it likes. A row contributing no duplicate keeps its name exactly as
     /// posted, so ordinary single-prefix imports are unchanged.
+    ///
+    /// Public as a test seam, the same way AzureService.BuildInventorySubnetRows is: the surrounding
+    /// action needs a DbContext, an antiforgery token and a live Azure credential, so the naming
+    /// rules could not otherwise be asserted directly - and one of the things that must be asserted
+    /// is that every name this produces satisfies the application's own [SafeText] input rules.
     /// </remarks>
-    private static Dictionary<int, string> ResolveImportNames(List<AzureImportSubnetViewModel> subnets)
+    public static Dictionary<int, string> ResolveImportNames(List<AzureImportSubnetViewModel> subnets)
     {
         HashSet<string> multiPrefixResourceIds = [.. subnets
             .Where(s => !s.FullyEncompassesVNetPrefix && !string.IsNullOrEmpty(s.AzureResourceId))
@@ -273,7 +278,7 @@ public partial class SubnetController : Controller
                 // {NetworkAddress, Cidr} is unique across a batch - overlap validation refuses a
                 // repeat - so a prefix-qualified name cannot collide with another one.
                 name = SubnetNaming.WithSuffix(
-                    name, $" ({subnet.NetworkAddress}/{subnet.Cidr})", MaxSubnetNameLength);
+                    name, $" ({subnet.NetworkAddress}-{subnet.Cidr})", MaxSubnetNameLength);
             }
 
             used.Add(name);

--- a/src/Bastet/Controllers/SubnetController.Azure.cs
+++ b/src/Bastet/Controllers/SubnetController.Azure.cs
@@ -252,11 +252,19 @@ public partial class SubnetController : Controller
     /// </remarks>
     public static Dictionary<int, string> ResolveImportNames(List<AzureImportSubnetViewModel> subnets)
     {
-        HashSet<string> multiPrefixResourceIds = [.. subnets
+        // new(..., comparer) and NOT a collection expression: [.. query] builds a plain
+        // HashSet<string> with EqualityComparer<string>.Default, silently discarding the
+        // OrdinalIgnoreCase on the GroupBy directly above it. ARM resource IDs are case-insensitive
+        // and GroupBy keeps only the first member's spelling as g.Key, so a sibling row spelled
+        // .../Subnets/... failed the later Contains and kept its bare Azure name while its siblings
+        // were qualified - the hardening added for crafted posts, defeated by a crafted post.
+        HashSet<string> multiPrefixResourceIds = new(
+            subnets
             .Where(s => !s.FullyEncompassesVNetPrefix && !string.IsNullOrEmpty(s.AzureResourceId))
             .GroupBy(s => s.AzureResourceId!, StringComparer.OrdinalIgnoreCase)
             .Where(g => g.Count() > 1)
-            .Select(g => g.Key)];
+            .Select(g => g.Key),
+            StringComparer.OrdinalIgnoreCase);
 
         Dictionary<int, string> names = [];
         HashSet<string> used = new(StringComparer.OrdinalIgnoreCase);

--- a/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
+++ b/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
@@ -203,4 +203,125 @@ public partial class SubnetController : Controller
             hostIpsArchived
         });
     }
+
+    /// <summary>
+    /// POST: Subnet/RelinkAzureSubnet — re-points a Bastet subnet at the Azure subnet that now holds
+    /// its range, after a rename or a prefix move left the recorded resource ID naming nothing.
+    ///
+    /// Azure has no subnet rename, so re-organising one is delete-and-recreate. Before this existed
+    /// the resulting row could only be archived — which made BASTET advertise a range Azure had
+    /// already assigned as free space — because nothing in the application could edit
+    /// <see cref="Subnet.AzureResourceId"/>. This is the repair path that makes withholding those
+    /// rows from deletion a correction rather than a dead end.
+    /// </summary>
+    /// <remarks>
+    /// The caller supplies no resource ID. We re-scan Azure and re-derive the link here, and accept
+    /// only a row the fresh plan itself reports as RangeStillAllocatedInAzure, so neither a stale
+    /// browser view nor a crafted post can point a subnet at an arbitrary resource.
+    /// </remarks>
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = "RequireAdminRole")]
+    public async Task<IActionResult> RelinkAzureSubnet(
+        [FromBody] AzureRelinkDto request,
+        [FromServices] IAzureService azureService,
+        [FromServices] IAzureReconciler reconciler,
+        [FromServices] IAzureSubnetSnapshotService snapshotService)
+    {
+        if (!AzureController.IsAzureImportEnabled())
+        {
+            return StatusCode(403, new { success = false, error = "Azure Import feature is not enabled" });
+        }
+
+        if (request is null)
+        {
+            return BadRequest(new { success = false, error = "No request was provided." });
+        }
+
+        AzureVNetInventory inventory = await azureService.GetVNetInventory(request.SubscriptionId);
+        IReadOnlyList<AzureLinkedSubnetSnapshot> linked = await snapshotService.GetAzureLinkedSubnetsAsync();
+        AzureReconcilePlanViewModel plan = reconciler.BuildPlan(request.SubscriptionId, null, inventory, linked);
+
+        if (!plan.ScanSucceeded || plan.GlobalErrors.Count > 0)
+        {
+            return BadRequest(new
+            {
+                success = false,
+                error = "Azure could not be re-checked, so nothing was changed.",
+                globalErrors = plan.GlobalErrors
+            });
+        }
+
+        AzureReconcileItem? target = plan.ReviewItems.FirstOrDefault(i =>
+            i.SubnetId == request.SubnetId
+            && i.Status == AzureReconcileStatus.RangeStillAllocatedInAzure
+            && !string.IsNullOrEmpty(i.SuggestedAzureResourceId));
+
+        if (target is null)
+        {
+            return Conflict(new
+            {
+                success = false,
+                error = "This subnet is no longer reported as holding a range that moved to another Azure subnet. "
+                        + "Nothing was changed. Re-run the scan and review the results."
+            });
+        }
+
+        try
+        {
+            IActionResult? failure = await subnetLockingService.ExecuteWithSubnetLockAsync<IActionResult?>(async () =>
+            {
+                Subnet? subnet = await context.Subnets.FindAsync(request.SubnetId);
+
+                if (subnet is null)
+                {
+                    return NotFound(new { success = false, error = "That subnet no longer exists." });
+                }
+
+                // Re-check under the lock. The plan was built before it was taken, and a concurrent
+                // import could have re-linked this row in the meantime - in which case the verdict
+                // this action rests on is about a state that no longer exists.
+                if (!string.Equals(subnet.AzureResourceId, target.AzureResourceId, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Conflict(new
+                    {
+                        success = false,
+                        error = "This subnet's Azure link changed while the scan was being reviewed. Nothing was changed."
+                    });
+                }
+
+                subnet.AzureResourceId = target.SuggestedAzureResourceId;
+                await context.SaveChangesAsync();
+                return null;
+            });
+
+            if (failure is not null)
+            {
+                return failure;
+            }
+        }
+        catch (TimeoutException)
+        {
+            return StatusCode(503, new
+            {
+                success = false,
+                error = "The operation timed out because another subnet operation is in progress. Nothing was changed. Please try again."
+            });
+        }
+
+        logger.LogInformation(
+            "Azure reconcile: re-linked subnet {SubnetId} to {AzureResourceId}",
+            request.SubnetId, target.SuggestedAzureResourceId);
+
+        TempData["SuccessMessage"] =
+            $"Re-linked '{target.Name}' to Azure subnet '{target.SuggestedAzureSubnetName}'.";
+
+        return Ok(new
+        {
+            success = true,
+            subnetId = request.SubnetId,
+            azureResourceId = target.SuggestedAzureResourceId,
+            azureSubnetName = target.SuggestedAzureSubnetName
+        });
+    }
 }

--- a/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
+++ b/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
@@ -78,6 +78,20 @@ public partial class SubnetController : Controller
         Dictionary<int, AzureReconcileItem> stillStale = plan.Items.ToDictionary(i => i.SubnetId);
         List<int> noLongerStale = [.. request.SubnetIds.Where(id => !stillStale.ContainsKey(id))];
 
+        // Set membership is not consent. Check the row is still stale FOR THE REASON THE OPERATOR
+        // SAW - the endpoint's own docstring promises "a resource that reappeared in Azure cannot
+        // cause the wrong subnets to be archived", and comparing ids alone does not deliver that.
+        // Ordered before the membership refusal only in the sense that both are computed here; the
+        // membership message is more specific, so it still wins when both apply.
+        Dictionary<int, AzureReconcileApprovedVerdict> approved =
+            (request.Statuses ?? [])
+                .GroupBy(s => s.SubnetId)
+                .ToDictionary(g => g.Key, g => g.Last());
+
+        List<int> verdictChanged = [.. request.SubnetIds
+            .Where(stillStale.ContainsKey)
+            .Where(id => !VerdictMatchesApproval(stillStale[id], approved.GetValueOrDefault(id)))];
+
         if (noLongerStale.Count > 0)
         {
             return Conflict(new
@@ -88,6 +102,22 @@ public partial class SubnetController : Controller
                 subnetIds = noLongerStale,
                 // Carries the reason a row was withheld - most usefully "Azure would not confirm it
                 // is deleted", which otherwise looks indistinguishable from an out-of-date scan.
+                warnings = plan.Warnings
+            });
+        }
+
+        if (verdictChanged.Count > 0)
+        {
+            // Deliberately not merged with the message above. "No longer reported as deleted" and
+            // "flagged for a different reason" call for different operator actions: the first means
+            // the row is fine, the second means it is still wrong but wrong in a way they have not
+            // seen and might well choose to re-import rather than archive.
+            return Conflict(new
+            {
+                success = false,
+                error = $"The reason {verdictChanged.Count} of the selected subnet(s) were flagged has changed since " +
+                        "you reviewed them. Nothing was deleted. Re-run the scan and review the results.",
+                subnetIds = verdictChanged,
                 warnings = plan.Warnings
             });
         }
@@ -202,6 +232,29 @@ public partial class SubnetController : Controller
             subnetsArchived,
             hostIpsArchived
         });
+    }
+
+    /// <summary>
+    /// True when the freshly derived verdict is the same one the operator approved.
+    /// </summary>
+    /// <remarks>
+    /// Three cases are all treated as a divergence rather than as consent:
+    /// a MISSING verdict (nothing was approved for this row, so nothing licenses archiving it),
+    /// an UNPARSEABLE status name (a caller-supplied string that names no status establishes
+    /// nothing - the same rule DescribeApprovedPlanDivergences applies to TargetType), and a
+    /// matching status whose REASON differs (same verdict, different facts: a prefix that has moved
+    /// again re-derives as SubnetPrefixChanged both times while naming a different live prefix).
+    /// </remarks>
+    private static bool VerdictMatchesApproval(AzureReconcileItem current, AzureReconcileApprovedVerdict? approvedVerdict)
+    {
+        if (approvedVerdict is null)
+        {
+            return false;
+        }
+
+        return Enum.TryParse(approvedVerdict.StatusName, ignoreCase: true, out AzureReconcileStatus approvedStatus)
+               && approvedStatus == current.Status
+               && string.Equals(approvedVerdict.Reason, current.Reason, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
+++ b/src/Bastet/Controllers/SubnetController.AzureReconcile.cs
@@ -55,7 +55,8 @@ public partial class SubnetController : Controller
         // Re-scan against live Azure and the current tree
         AzureVNetInventory inventory = await azureService.GetVNetInventory(request.SubscriptionId);
         IReadOnlyList<AzureLinkedSubnetSnapshot> linked = await snapshotService.GetAzureLinkedSubnetsAsync();
-        AzureReconcilePlanViewModel plan = reconciler.BuildPlan(request.SubscriptionId, null, inventory, linked);
+        IReadOnlyList<ExistingSubnetSnapshot> existing = await snapshotService.GetExistingSubnetsAsync();
+        AzureReconcilePlanViewModel plan = reconciler.BuildPlan(request.SubscriptionId, null, inventory, linked, existing);
 
         // A failed scan produces no items, so this also covers "Azure was unreachable"
         if (!plan.ScanSucceeded || plan.GlobalErrors.Count > 0)
@@ -293,7 +294,8 @@ public partial class SubnetController : Controller
 
         AzureVNetInventory inventory = await azureService.GetVNetInventory(request.SubscriptionId);
         IReadOnlyList<AzureLinkedSubnetSnapshot> linked = await snapshotService.GetAzureLinkedSubnetsAsync();
-        AzureReconcilePlanViewModel plan = reconciler.BuildPlan(request.SubscriptionId, null, inventory, linked);
+        IReadOnlyList<ExistingSubnetSnapshot> existing = await snapshotService.GetExistingSubnetsAsync();
+        AzureReconcilePlanViewModel plan = reconciler.BuildPlan(request.SubscriptionId, null, inventory, linked, existing);
 
         if (!plan.ScanSucceeded || plan.GlobalErrors.Count > 0)
         {

--- a/src/Bastet/Models/ViewModels/AzureReconcileViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureReconcileViewModels.cs
@@ -240,6 +240,36 @@ namespace Bastet.Models.ViewModels
 
         /// <summary>Must be "approved", matching the single-subnet delete flow.</summary>
         public string Confirmation { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The verdict the operator actually approved, one entry per selected subnet, snapshotted
+        /// when the confirmation screen was built.
+        /// </summary>
+        /// <remarks>
+        /// Set membership in the re-derived plan is not consent. A row approved under "the Azure
+        /// resource no longer exists" can still be in the plan moments later under "the prefix
+        /// changed" - a different fact, reached without any direct ARM read - and the subtree was
+        /// archived on an approval whose stated premise the server had itself disproved. Required:
+        /// a request that names no verdict is refused rather than trusted, because an omitted
+        /// verdict is exactly what a replayed or hand-built post carries.
+        /// </remarks>
+        public List<AzureReconcileApprovedVerdict> Statuses { get; set; } = [];
+    }
+
+    /// <summary>One row's verdict as it was shown to the operator on the confirmation screen.</summary>
+    public class AzureReconcileApprovedVerdict
+    {
+        public int SubnetId { get; set; }
+
+        /// <summary>The <see cref="AzureReconcileStatus"/> name, as rendered.</summary>
+        public string StatusName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The reason text shown beside the row. Compared as well as the status, because the same
+        /// status can carry different facts - a prefix that moved again re-derives as
+        /// SubnetPrefixChanged both times while naming a different live prefix.
+        /// </summary>
+        public string Reason { get; set; } = string.Empty;
     }
 
     /// <summary>

--- a/src/Bastet/Models/ViewModels/AzureReconcileViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureReconcileViewModels.cs
@@ -135,7 +135,16 @@ namespace Bastet.Models.ViewModels
         /// advertise an allocated range as free space. Correct it by re-linking the subnet to the
         /// Azure subnet that now holds the range.
         /// </summary>
-        RangeStillAllocatedInAzure
+        RangeStillAllocatedInAzure,
+
+        /// <summary>
+        /// Azure has assigned a range inside an imported VNet that no BASTET subnet records, so
+        /// BASTET is reporting an allocated range as free space.
+        /// Reported for review only and never deletable - it names no BASTET subnet, because the
+        /// absence of one IS the finding. This is the only inbound verdict: every other status
+        /// starts from a BASTET row and asks what Azure says about it.
+        /// </summary>
+        AzureRangeNotImported
     }
 
     /// <summary>

--- a/src/Bastet/Models/ViewModels/AzureReconcileViewModels.cs
+++ b/src/Bastet/Models/ViewModels/AzureReconcileViewModels.cs
@@ -125,7 +125,17 @@ namespace Bastet.Models.ViewModels
         /// group and the last path segment alone, so reading such an ID asks about a different
         /// resource entirely and its 404 would otherwise read as a confirmed deletion.
         /// </summary>
-        UnrecognisedResourceId
+        UnrecognisedResourceId,
+
+        /// <summary>
+        /// The recorded Azure resource is gone or no longer carries this prefix, but the range
+        /// itself is still assigned in the same VNet under a different Azure resource ID - which is
+        /// what a subnet rename looks like, Azure having no rename operation.
+        /// Reported for review only and never deletable: archiving the row would make BASTET
+        /// advertise an allocated range as free space. Correct it by re-linking the subnet to the
+        /// Azure subnet that now holds the range.
+        /// </summary>
+        RangeStillAllocatedInAzure
     }
 
     /// <summary>
@@ -157,6 +167,21 @@ namespace Bastet.Models.ViewModels
         /// the client avoid double-counting when an item and its ancestor are both selected.
         /// </summary>
         public IReadOnlyList<int> DescendantSubnetIds { get; set; } = [];
+
+        /// <summary>
+        /// For <see cref="AzureReconcileStatus.RangeStillAllocatedInAzure"/>: the Azure subnet that
+        /// now holds this row's range, so the operator can re-link in one click rather than typing a
+        /// resource ID. Empty for every other status.
+        /// </summary>
+        /// <remarks>
+        /// Offered by the server but never trusted from the client: the re-link endpoint re-derives
+        /// this from a fresh scan before writing, because the browser is not the authority on what
+        /// Azure holds.
+        /// </remarks>
+        public string SuggestedAzureResourceId { get; set; } = string.Empty;
+
+        /// <summary>Display name of <see cref="SuggestedAzureResourceId"/>.</summary>
+        public string SuggestedAzureSubnetName { get; set; } = string.Empty;
 
         /// <summary>The status name, so clients don't depend on the enum's ordinal.</summary>
         public string StatusName => Status.ToString();
@@ -215,5 +240,22 @@ namespace Bastet.Models.ViewModels
 
         /// <summary>Must be "approved", matching the single-subnet delete flow.</summary>
         public string Confirmation { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Re-points one Bastet subnet at the Azure subnet that now holds its range, after a rename or
+    /// a prefix move left the recorded resource ID naming something that no longer exists.
+    /// </summary>
+    /// <remarks>
+    /// Carries no resource ID on purpose. The server re-scans and derives the new link itself from
+    /// the fresh plan, so a stale browser view - or a crafted post - cannot point a subnet at an
+    /// arbitrary Azure resource. The client names the row; Azure decides what it links to.
+    /// </remarks>
+    public class AzureRelinkDto
+    {
+        public string SubscriptionId { get; set; } = string.Empty;
+
+        /// <summary>The Bastet subnet to re-link.</summary>
+        public int SubnetId { get; set; }
     }
 }

--- a/src/Bastet/Program.cs
+++ b/src/Bastet/Program.cs
@@ -458,9 +458,16 @@ if (autoMigrate)
         // startup - with nothing to say the schema was interrupted mid-flight. The reverse case is
         // worse and was reproduced against a real SQL Server: both migrations succeed, an idle
         // gateway drops the lock connection, and an unguarded release turns a completed migration
-        // into a hard startup crash. Swallowing does not strand the lock either way - it is
-        // session-owned, so if the connection died the server has already released it, and if it is
-        // alive the using block closes it here.
+        // into a hard startup crash.
+        //
+        // Swallowing alone is not enough though, and the claim that used to end this comment - "if
+        // it is alive the using block closes it here" - was false. Disposing a SqlConnection returns
+        // it to the POOL; the SQL session stays open and a Session-owned lock outlives it until that
+        // pooled connection is reused or destroyed. On the bootstrap path the connection lives in a
+        // master-catalog pool this process never touches again, so a stranded 'Bastet:Migration'
+        // lock persists for the process lifetime and later cold starts burn the full @LockTimeout
+        // before aborting with "Another replica appears to be stuck applying migrations".
+        // So a failed release discards the pooled connection, ending the session and the lock.
         //
         // Deliberately not guarded by a State != Open check: SqlClient does not poll the socket, so
         // State still reports Open after a silent failover and the guard would not fire.
@@ -475,8 +482,23 @@ if (autoMigrate)
         catch (Exception releaseException)
         {
             app.Logger.LogError(releaseException,
-                "Failed to release the 'Bastet:Migration' application lock after migration. The lock is "
-                + "session-owned and is released when the connection closes, so startup continues.");
+                "Failed to release the 'Bastet:Migration' application lock after migration; discarding the pooled "
+                + "connection so the session-owned lock is dropped rather than stranded. Startup continues.");
+
+            // Same remedy as SqlServerSubnetLockingService, and for the same reason. Deliberately
+            // NOT Pooling=false on MigrationLockConnectionString.Configured: that method's contract
+            // is the connection string returned verbatim - MigrationLockConnectionStringTests asserts
+            // exactly that - and routing it through SqlConnectionStringBuilder would also destroy its
+            // documented null-in/null-out behaviour.
+            try
+            {
+                SqlConnection.ClearPool(migrationLockConnection);
+            }
+            catch (Exception discardException)
+            {
+                app.Logger.LogError(discardException,
+                    "Failed to discard the pooled migration-lock connection after a failed release.");
+            }
         }
     }
 }

--- a/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
+++ b/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
@@ -19,6 +19,23 @@ namespace Bastet.Services.Azure
         /// </summary>
         private const int MaxSubnetNameLength = 100;
 
+        /// <summary>
+        /// True when an existing Bastet subnet is already the import target of this very VNet.
+        /// </summary>
+        /// <remarks>
+        /// This is what separates a top-up - adding the subnets an already-imported VNet has gained -
+        /// from adopting a subtree somebody built by hand. Only the former re-stamps a resource ID
+        /// the row already carries, which is a no-op; the latter would claim rows nobody imported
+        /// and pull them into a later reconcile cascade.
+        /// </remarks>
+        private static bool IsSameVNet(ExistingSubnetSnapshot existing, string? vnetResourceId) =>
+            !string.IsNullOrEmpty(existing.AzureResourceId)
+            && !string.IsNullOrEmpty(vnetResourceId)
+            && string.Equals(existing.AzureResourceId, vnetResourceId, StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsSameVNet(ExistingSubnetSnapshot existing, BulkAzureVNetViewModel vnet) =>
+            IsSameVNet(existing, vnet.ResourceId);
+
         /// <inheritdoc/>
         public BulkImportPlanViewModel BuildPlan(
             BulkImportSelectionDto selection,
@@ -193,10 +210,37 @@ namespace Bastet.Services.Azure
 
             if (exact is not null)
             {
-                // Mirrors the hard failures in BuildPlanItem for an ExactMatch target
-                if (exact.HasChildSubnets)
+                // Matching on address says nothing about which Azure resource the row came from:
+                // two VNets in one subscription may carry the same prefix, which is ordinary in
+                // hub-and-spoke and dev/prod topologies. Importing this one would replace the
+                // recorded link, after which reconcile measures the row against a VNet it was never
+                // imported from and offers it - and its subtree - for deletion when that VNet goes.
+                // Name both resources: "blocked" alone does not explain a same-prefix collision.
+                //
+                // Checked FIRST because the top-up allowance below turns on it.
+                if (!string.IsNullOrEmpty(exact.AzureResourceId)
+                    && !string.IsNullOrEmpty(vnet.ResourceId)
+                    && !string.Equals(exact.AzureResourceId, vnet.ResourceId, StringComparison.OrdinalIgnoreCase))
                 {
-                    return Blocked(result, $"Bastet subnet '{exact.Name}' already has child subnets. Already imported?");
+                    return Blocked(result,
+                        $"Bastet subnet '{exact.Name}' is already linked to Azure VNet '{exact.AzureResourceId}'. "
+                        + $"Importing '{vnet.ResourceId}' would replace that link, so it is refused.");
+                }
+
+                // TOP-UP. A populated target used to be refused outright, which left an Azure subnet
+                // that gained a prefix after import impossible to import by any route while BASTET
+                // went on advertising the Azure-assigned range as free space.
+                //
+                // Narrowed rather than removed: the allowance requires the target to be linked to
+                // THIS VNet already, so this is a continuation of an import that has happened, not
+                // the adoption of a hand-built subtree. Adoption is what re-stamps AzureResourceId
+                // on rows nobody imported and puts them inside a later reconcile cascade.
+                bool isTopUp = IsSameVNet(exact, vnet);
+
+                if (exact.HasChildSubnets && !isTopUp)
+                {
+                    return Blocked(result,
+                        $"Bastet subnet '{exact.Name}' already has child subnets and is not linked to this VNet. Already imported?");
                 }
                 if (exact.HasHostIpAssignments)
                 {
@@ -207,23 +251,12 @@ namespace Bastet.Services.Azure
                     return Blocked(result, $"Bastet subnet '{exact.Name}' is marked as fully allocated.");
                 }
 
-                // Matching on address says nothing about which Azure resource the row came from:
-                // two VNets in one subscription may carry the same prefix, which is ordinary in
-                // hub-and-spoke and dev/prod topologies. Importing this one would replace the
-                // recorded link, after which reconcile measures the row against a VNet it was never
-                // imported from and offers it - and its subtree - for deletion when that VNet goes.
-                // Name both resources: "blocked" alone does not explain a same-prefix collision.
-                if (!string.IsNullOrEmpty(exact.AzureResourceId)
-                    && !string.IsNullOrEmpty(vnet.ResourceId)
-                    && !string.Equals(exact.AzureResourceId, vnet.ResourceId, StringComparison.OrdinalIgnoreCase))
-                {
-                    return Blocked(result,
-                        $"Bastet subnet '{exact.Name}' is already linked to Azure VNet '{exact.AzureResourceId}'. "
-                        + $"Importing '{vnet.ResourceId}' would replace that link, so it is refused.");
-                }
-
                 result.Status = BulkImportAvailability.WillUpdateExisting;
-                result.Reason = $"Will import into existing Bastet subnet '{exact.Name}'.";
+                // Distinct copy: "Will import into existing Bastet subnet 'X'" reads as a first
+                // import and would be a lie about a target that already holds rows.
+                result.Reason = exact.HasChildSubnets
+                    ? $"Will add any missing subnets to existing Bastet subnet '{exact.Name}'. Subnets already imported are left untouched."
+                    : $"Will import into existing Bastet subnet '{exact.Name}'.";
                 result.IsSelectable = true;
                 return result;
             }
@@ -375,11 +408,13 @@ namespace Bastet.Services.Azure
                 item.ExistingTargetSubnetId = exact.Id;
                 item.ExistingTargetSubnetName = exact.Name;
 
-                // Hard fail (5b) if the matched Bastet subnet is non-empty.
-                if (exact.HasChildSubnets)
+                // Hard fail (5b) if the matched Bastet subnet is non-empty - EXCEPT for a top-up,
+                // where the target is already linked to this same VNet. See AnnotatePrefix for why
+                // the allowance is narrowed to that case rather than dropped.
+                if (exact.HasChildSubnets && !IsSameVNet(exact, p.Source.VNetResourceId))
                 {
                     item.Errors.Add(
-                        $"Cannot import VNet prefix {p.Source.AddressPrefix}: matched Bastet subnet '{exact.Name}' ({exact.NetworkAddress}/{exact.Cidr}) already has child subnets.");
+                        $"Cannot import VNet prefix {p.Source.AddressPrefix}: matched Bastet subnet '{exact.Name}' ({exact.NetworkAddress}/{exact.Cidr}) already has child subnets and is not linked to this VNet.");
                 }
                 if (exact.HasHostIpAssignments)
                 {
@@ -404,7 +439,10 @@ namespace Bastet.Services.Azure
                         + $"and importing '{p.Source.VNetResourceId}' would replace that link.");
                 }
 
-                if (renameMatched)
+                // Never on a top-up. Renaming a target that already holds imported rows changes a
+                // label the operator has been living with, for a run whose purpose is to add the
+                // one subnet that was missing.
+                if (renameMatched && !exact.HasChildSubnets)
                 {
                     string proposed = TargetName(p);
                     if (!string.Equals(proposed, exact.Name, StringComparison.Ordinal))
@@ -468,6 +506,21 @@ namespace Bastet.Services.Azure
                         + $"{p.PrefixNetwork}/{p.PrefixCidr}, so nothing can be created inside it, but "
                         + $"{p.Subnets.Count - 1} other subnet(s) were selected from the same prefix. "
                         + "Azure does not allow overlapping subnets in a VNet, so this selection cannot be applied.");
+                    return item;
+                }
+
+                // A target that already holds children cannot also be "fully allocated by one Azure
+                // subnet" - the two describe different states, and the commit marks the flag INSTEAD
+                // of creating children, so the existing rows would be stranded under a target
+                // claiming nothing more fits. The old blanket refusal of populated targets was
+                // preventing this incidentally; the top-up allowance makes it reachable, so it is
+                // now refused explicitly.
+                if (exact is not null && exact.HasChildSubnets)
+                {
+                    item.Errors.Add(
+                        $"Cannot import VNet prefix {p.Source.AddressPrefix}: Azure subnet "
+                        + $"'{TruncateAndSanitizeName(fullyEncompassing.Source.Name)}' covers the whole prefix, which would "
+                        + $"mark Bastet subnet '{exact.Name}' fully allocated, but it already has child subnets.");
                     return item;
                 }
 

--- a/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
+++ b/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
@@ -186,6 +186,20 @@ namespace Bastet.Services.Azure
             // so counting it would inflate the group and needlessly rename the one child that IS
             // created. (A subnet may equal one VNet prefix exactly and still hold a prefix inside
             // another, so this is reachable rather than theoretical.)
+            // Which VNets contribute MORE THAN ONE selected address prefix. BuildPlanItem runs once
+            // per prefix and TargetName returns the bare VNet name, so such a VNet persisted one
+            // Bastet subnet per prefix all carrying the identical name AND the identical VNet
+            // resource id - N6 one level up the tree, and unlike N6 it fires on every
+            // multi-address-space VNet import rather than only on a prefix-spanning subnet.
+            HashSet<string> multiPrefixVNetIds = new(
+                parsed
+                    .Where(p => !string.IsNullOrEmpty(p.Source.VNetResourceId))
+                    .GroupBy(p => p.Source.VNetResourceId!, StringComparer.OrdinalIgnoreCase)
+                    .Where(g => g.Select(x => $"{x.PrefixNetwork}/{x.PrefixCidr}")
+                                 .Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1)
+                    .Select(g => g.Key),
+                StringComparer.OrdinalIgnoreCase);
+
             HashSet<string> multiPrefixResourceIds = new(
                 parsed.SelectMany(p => p.Subnets)
                     .Where(s => !s.FullyEncompasses && !string.IsNullOrEmpty(s.Source.AzureResourceId))
@@ -197,7 +211,8 @@ namespace Bastet.Services.Azure
             foreach (ParsedPrefixSelection p in parsed)
             {
                 BulkImportPlanItem item = BuildPlanItem(
-                    p, existingSubnets, selection.RenameMatchedBastetSubnets, multiPrefixResourceIds);
+                    p, existingSubnets, selection.RenameMatchedBastetSubnets,
+                    multiPrefixResourceIds, multiPrefixVNetIds);
                 plan.Items.Add(item);
             }
 
@@ -433,7 +448,8 @@ namespace Bastet.Services.Azure
             ParsedPrefixSelection p,
             IReadOnlyList<ExistingSubnetSnapshot> existingSubnets,
             bool renameMatched,
-            IReadOnlySet<string> multiPrefixResourceIds)
+            IReadOnlySet<string> multiPrefixResourceIds,
+            IReadOnlySet<string> multiPrefixVNetIds)
         {
             BulkImportPlanItem item = new()
             {
@@ -490,7 +506,7 @@ namespace Bastet.Services.Azure
                 // one subnet that was missing.
                 if (renameMatched && !exact.HasChildSubnets)
                 {
-                    string proposed = TargetName(p);
+                    string proposed = TargetName(p, multiPrefixVNetIds);
                     if (!string.Equals(proposed, exact.Name, StringComparison.Ordinal))
                     {
                         item.WillRename = true;
@@ -508,7 +524,7 @@ namespace Bastet.Services.Azure
                     item.TargetType = BulkImportTargetType.AutoCreateChild;
                     item.AutoCreateParentSubnetId = deepest.Id;
                     item.AutoCreateParentSubnetName = deepest.Name;
-                    item.AutoCreateTargetName = TargetName(p);
+                    item.AutoCreateTargetName = TargetName(p, multiPrefixVNetIds);
 
                     // The auto-created target's parent must be eligible to receive children
                     if (deepest.HasHostIpAssignments)
@@ -525,7 +541,7 @@ namespace Bastet.Services.Azure
                 else
                 {
                     item.TargetType = BulkImportTargetType.AutoCreateTopLevel;
-                    item.AutoCreateTargetName = TargetName(p);
+                    item.AutoCreateTargetName = TargetName(p, multiPrefixVNetIds);
                 }
             }
 
@@ -827,10 +843,30 @@ namespace Bastet.Services.Azure
         /// comment about exactly this hazard ("StripHtml can empty a name outright, defeating
         /// [Required]"); this was the one write with the same sanitizer output and no equivalent guard.
         /// </summary>
-        private string TargetName(ParsedPrefixSelection prefix) =>
-            TruncateAndSanitizeName(prefix.Source.VNetName) is { Length: > 0 } name
-                ? name
+        /// <summary>
+        /// The name for the Bastet subnet a VNet address prefix imports into, qualified by the range
+        /// it holds when the same VNet contributes several selected prefixes.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately NOT routed through DisambiguateName: that appends the VNet name, which is
+        /// precisely the token that is already identical here, and its numeric fallback would give
+        /// "vnet" and "vnet (2)" - neither of which says which range the row holds. Same
+        /// "name (network-cidr)" shape the child names use, so all three naming paths stay consistent.
+        ///
+        /// The ExactMatch branch never reaches this: it adopts an existing row and names nothing.
+        /// </remarks>
+        private string TargetName(ParsedPrefixSelection prefix, IReadOnlySet<string> multiPrefixVNetIds)
+        {
+            string name = TruncateAndSanitizeName(prefix.Source.VNetName) is { Length: > 0 } sanitized
+                ? sanitized
                 : $"{prefix.PrefixNetwork}_{prefix.PrefixCidr}";
+
+            return !string.IsNullOrEmpty(prefix.Source.VNetResourceId)
+                   && multiPrefixVNetIds.Contains(prefix.Source.VNetResourceId)
+                ? SubnetNaming.WithSuffix(
+                    name, $" ({prefix.PrefixNetwork}-{prefix.PrefixCidr})", MaxSubnetNameLength)
+                : name;
+        }
 
         private string TruncateAndSanitizeName(string? rawName)
         {

--- a/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
+++ b/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
@@ -621,8 +621,15 @@ namespace Bastet.Services.Azure
                     // Name each for the range it actually holds. A subnet contributing a single
                     // selection with no persisted sibling is untouched, so ordinary imports keep the
                     // exact names they have always had.
+                    //
+                    // "-{cidr}" and NOT "/{cidr}": [SafeText] on CreateSubnetViewModel.Name forbids
+                    // "/", so a generated name carrying one is a name this application refuses on
+                    // its own Create form - and SubnetNaming.ToSafeText DELETES the character rather
+                    // than rejecting it, so the create-from-unallocated-range prefill silently turned
+                    // "(10.20.40.0/24)" into the false token "(10.20.40.024)". Same convention as
+                    // SubnetController.Create.
                     baseName = SubnetNaming.WithSuffix(
-                        baseName, $" ({sub.Network}/{sub.Cidr})", MaxSubnetNameLength);
+                        baseName, $" ({sub.Network}-{sub.Cidr})", MaxSubnetNameLength);
                 }
 
                 string finalName = DisambiguateName(baseName, usedNames, p.Source.VNetName);

--- a/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
+++ b/src/Bastet/Services/Azure/AzureBulkImportPlanner.cs
@@ -36,6 +36,30 @@ namespace Bastet.Services.Azure
         private static bool IsSameVNet(ExistingSubnetSnapshot existing, BulkAzureVNetViewModel vnet) =>
             IsSameVNet(existing, vnet.ResourceId);
 
+        /// <summary>
+        /// True when a row from the SAME Azure subnet, holding a DIFFERENT range, is already in the
+        /// tree - so this commit's row needs qualifying even though this commit only carries one
+        /// selection for that Azure subnet.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately narrow. Seeding the disambiguator from the whole existing tree instead would
+        /// rename any child whose Azure name merely matched some unrelated Bastet subnet anywhere -
+        /// a broad silent rename in the ordinary path - and would append the VNet name rather than
+        /// the range, giving a second row a different shape from the first. Keying on the Azure
+        /// resource ID fires only for the real multi-row case and keeps the one shape.
+        ///
+        /// The already-persisted first row keeps its bare name and stays unambiguous, because the
+        /// row being added is the one that gets qualified.
+        /// </remarks>
+        private static bool HasPersistedSiblingFromSameAzureSubnet(
+            ParsedSubnetSelection sub,
+            IReadOnlyList<ExistingSubnetSnapshot> existingSubnets) =>
+            !string.IsNullOrEmpty(sub.Source.AzureResourceId)
+            && existingSubnets.Any(e =>
+                string.Equals(e.AzureResourceId, sub.Source.AzureResourceId, StringComparison.OrdinalIgnoreCase)
+                && !(e.Cidr == sub.Cidr
+                     && string.Equals(e.NetworkAddress, sub.Network, StringComparison.OrdinalIgnoreCase)));
+
         /// <inheritdoc/>
         public BulkImportPlanViewModel BuildPlan(
             BulkImportSelectionDto selection,
@@ -150,9 +174,30 @@ namespace Bastet.Services.Azure
             // -------------------------------------------------------------
             // Step 3: determine target Bastet subnet for each VNet prefix and check Bastet conflicts
             // -------------------------------------------------------------
+            // Computed across the WHOLE commit, not per item. BuildPlanItem runs once per selected
+            // VNet address prefix, so a per-item grouping only ever sees that prefix's rows: an Azure
+            // subnet owning one prefix under 10.71.0.0/16 and another under 10.72.0.0/16 looked
+            // single-prefix to both items, and the qualification that exists to keep those rows
+            // distinguishable was silently skipped - two children with the same name AND the same
+            // AzureResourceId, differing only by CIDR.
+            //
+            // The FullyEncompasses / non-empty-resource-id filter is kept exactly as it was: an
+            // encompassing selection marks the target fully allocated instead of creating a child,
+            // so counting it would inflate the group and needlessly rename the one child that IS
+            // created. (A subnet may equal one VNet prefix exactly and still hold a prefix inside
+            // another, so this is reachable rather than theoretical.)
+            HashSet<string> multiPrefixResourceIds = new(
+                parsed.SelectMany(p => p.Subnets)
+                    .Where(s => !s.FullyEncompasses && !string.IsNullOrEmpty(s.Source.AzureResourceId))
+                    .GroupBy(s => s.Source.AzureResourceId!, StringComparer.OrdinalIgnoreCase)
+                    .Where(g => g.Count() > 1)
+                    .Select(g => g.Key),
+                StringComparer.OrdinalIgnoreCase);
+
             foreach (ParsedPrefixSelection p in parsed)
             {
-                BulkImportPlanItem item = BuildPlanItem(p, existingSubnets, selection.RenameMatchedBastetSubnets);
+                BulkImportPlanItem item = BuildPlanItem(
+                    p, existingSubnets, selection.RenameMatchedBastetSubnets, multiPrefixResourceIds);
                 plan.Items.Add(item);
             }
 
@@ -387,7 +432,8 @@ namespace Bastet.Services.Azure
         private BulkImportPlanItem BuildPlanItem(
             ParsedPrefixSelection p,
             IReadOnlyList<ExistingSubnetSnapshot> existingSubnets,
-            bool renameMatched)
+            bool renameMatched,
+            IReadOnlySet<string> multiPrefixResourceIds)
         {
             BulkImportPlanItem item = new()
             {
@@ -554,17 +600,6 @@ namespace Bastet.Services.Azure
                 usedNames.Add(targetAutoCreatedName);
             }
 
-            // An Azure subnet owning several IPv4 prefixes contributes one selection per prefix, and
-            // every one of them carries the same Azure name. Subnet.Name has a non-unique index, so
-            // without this they would persist as indistinguishable rows differing only by CIDR.
-            // Name each for the range it actually holds. A subnet contributing a single selection is
-            // untouched, so ordinary imports keep the exact names they have always had.
-            HashSet<string> multiPrefixResourceIds = [.. p.Subnets
-                .Where(s => !s.FullyEncompasses && !string.IsNullOrEmpty(s.Source.AzureResourceId))
-                .GroupBy(s => s.Source.AzureResourceId, StringComparer.OrdinalIgnoreCase)
-                .Where(g => g.Count() > 1)
-                .Select(g => g.Key)];
-
             foreach (ParsedSubnetSelection sub in p.Subnets)
             {
                 if (sub.FullyEncompasses)
@@ -577,8 +612,15 @@ namespace Bastet.Services.Azure
                 {
                     baseName = $"{sub.Network}_{sub.Cidr}";
                 }
-                else if (multiPrefixResourceIds.Contains(sub.Source.AzureResourceId))
+                else if (multiPrefixResourceIds.Contains(sub.Source.AzureResourceId)
+                         || HasPersistedSiblingFromSameAzureSubnet(sub, existingSubnets))
                 {
+                    // An Azure subnet owning several IPv4 prefixes contributes one selection per
+                    // prefix, all carrying the same Azure name, and Subnet.Name has a non-unique
+                    // index - so without this they persist as rows distinguishable only by CIDR.
+                    // Name each for the range it actually holds. A subnet contributing a single
+                    // selection with no persisted sibling is untouched, so ordinary imports keep the
+                    // exact names they have always had.
                     baseName = SubnetNaming.WithSuffix(
                         baseName, $" ({sub.Network}/{sub.Cidr})", MaxSubnetNameLength);
                 }

--- a/src/Bastet/Services/Azure/AzureReconciler.cs
+++ b/src/Bastet/Services/Azure/AzureReconciler.cs
@@ -54,6 +54,25 @@ namespace Bastet.Services.Azure
             // ancestor archives them all the same, so they get their own cascade guard below.
             HashSet<int> notCovered = [];
 
+            // Rows withheld because the range they record is still assigned in Azure under another
+            // resource ID. Collected so the operator gets one warning naming what holds each range,
+            // rather than only a silently shorter list.
+            List<AzurePrefixOwner> rangeStillAllocated = [];
+
+            // Which Azure subnet holds a given range, scoped to one VNet. Azure has no subnet
+            // rename, so re-organising one means delete-and-recreate: the recorded resource ID goes
+            // genuinely 404 while the range it named is still assigned under a new ID. Keyed by
+            // {vnetResourceId}|{prefix} rather than by the bare prefix because overlapping RFC1918
+            // across unrelated VNets is normal, and a bare-prefix match would withhold rows that
+            // really are stale.
+            //
+            // Accumulates into a list; never ToDictionary. One prefix legitimately has several
+            // owners even within this narrower key - a subnet can be listed twice by a paged read,
+            // and the same VNet ID can appear more than once in a malformed inventory. A duplicate
+            // key throw here turns the whole scan into "The reconcile scan failed", which is the
+            // exact failure mode the subnet-prefix index above already avoids.
+            Dictionary<string, List<AzurePrefixOwner>> livePrefixOwners = new(StringComparer.OrdinalIgnoreCase);
+
             foreach (BulkAzureVNetViewModel vnet in inventory.VNets)
             {
                 if (!string.IsNullOrEmpty(vnet.ResourceId))
@@ -66,6 +85,24 @@ namespace Bastet.Services.Azure
                     if (!string.IsNullOrEmpty(subnet.ResourceId))
                     {
                         liveSubnetPrefixes[subnet.ResourceId] = Ipv4PrefixesOf(subnet);
+                    }
+
+                    if (string.IsNullOrEmpty(vnet.ResourceId))
+                    {
+                        continue;
+                    }
+
+                    foreach (string prefix in Ipv4PrefixesOf(subnet))
+                    {
+                        string key = PrefixKey(vnet.ResourceId, prefix);
+
+                        if (!livePrefixOwners.TryGetValue(key, out List<AzurePrefixOwner>? owners))
+                        {
+                            owners = [];
+                            livePrefixOwners[key] = owners;
+                        }
+
+                        owners.Add(new AzurePrefixOwner(subnet.ResourceId ?? string.Empty, subnet.Name, vnet.Name));
                     }
                 }
             }
@@ -129,6 +166,28 @@ namespace Bastet.Services.Azure
                     continue;
                 }
 
+                // Before offering anything for deletion, ask the question the statuses above cannot:
+                // is the RANGE still assigned in Azure, even though the resource that carried it is
+                // not? A rename, or a prefix moved between two subnets, produces exactly that - and
+                // archiving on it makes the parent's Details page advertise an allocated range as
+                // free with a Create Subnet button over it. The evidence was always in hand; nothing
+                // consulted it.
+                AzurePrefixOwner? stillAllocated = FindLiveOwnerOfRange(snapshot, item, livePrefixOwners);
+
+                if (stillAllocated is not null)
+                {
+                    AzureReconcileItem review = Item(snapshot, AzureReconcileStatus.RangeStillAllocatedInAzure, item.IsVNetLevel,
+                        $"{item.Reason} The range {snapshot.NetworkAddress}/{snapshot.Cidr} is still assigned in Azure "
+                        + $"to subnet '{stillAllocated.SubnetName}' in VNet '{stillAllocated.VNetName}', so archiving this "
+                        + "subnet would make BASTET report an allocated range as free. Re-link it to that Azure subnet.");
+                    review.SuggestedAzureResourceId = stillAllocated.ResourceId;
+                    review.SuggestedAzureSubnetName = stillAllocated.SubnetName;
+
+                    plan.ReviewItems.Add(review);
+                    rangeStillAllocated.Add(stillAllocated);
+                    continue;
+                }
+
                 if (item.Status is AzureReconcileStatus.FullyAllocatingSubnetDeleted
                     or AzureReconcileStatus.UnrecognisedResourceId)
                 {
@@ -138,6 +197,15 @@ namespace Bastet.Services.Azure
                 {
                     plan.Items.Add(item);
                 }
+            }
+
+            if (rangeStillAllocated.Count > 0)
+            {
+                plan.Warnings.Add(
+                    $"{rangeStillAllocated.Count} subnet(s) were withheld from deletion because their address range is "
+                    + "still assigned in Azure under a different resource - which is what a subnet rename looks like, "
+                    + "Azure having no rename operation. Archiving them would make BASTET report an allocated range as "
+                    + $"free space: {OwnerList(rangeStillAllocated)}.");
             }
 
             WithholdTargetsWhoseCascadeIsBlocked(
@@ -304,6 +372,60 @@ namespace Bastet.Services.Azure
         /// </summary>
         public static bool IsAbsenceStatus(AzureReconcileStatus status) =>
             status is AzureReconcileStatus.VNetDeleted or AzureReconcileStatus.SubnetDeleted;
+
+        /// <summary>An Azure subnet that currently holds a given IPv4 range.</summary>
+        private sealed record AzurePrefixOwner(string ResourceId, string SubnetName, string VNetName);
+
+        /// <summary>Index key: a range is only comparable within the VNet that carries it.</summary>
+        private static string PrefixKey(string vnetResourceId, string prefix) => $"{vnetResourceId}|{prefix}";
+
+        /// <summary>
+        /// The live Azure subnet still holding this row's range under a *different* resource ID, or
+        /// null. Only asked for rows already judged stale, and only within the row's own VNet.
+        /// </summary>
+        /// <remarks>
+        /// A row whose own recorded resource still owns the range is not stale in the first place
+        /// and never reaches here, so excluding the row's own ID cannot mask a real drift; what it
+        /// does exclude is the degenerate case of a subnet reported twice by a paged read, where
+        /// treating the row as its own evidence would withhold every genuine deletion.
+        /// </remarks>
+        private static AzurePrefixOwner? FindLiveOwnerOfRange(
+            AzureLinkedSubnetSnapshot snapshot,
+            AzureReconcileItem item,
+            Dictionary<string, List<AzurePrefixOwner>> livePrefixOwners)
+        {
+            // FullyAllocatingSubnetDeleted and UnrecognisedResourceId are review-only already and
+            // delete nothing, so re-routing them would only muddy the reason they carry.
+            if (item.Status is not (AzureReconcileStatus.VNetDeleted
+                or AzureReconcileStatus.VNetPrefixRemoved
+                or AzureReconcileStatus.SubnetDeleted
+                or AzureReconcileStatus.SubnetPrefixChanged))
+            {
+                return null;
+            }
+
+            string? vnetId = AzureResourceIdentity.VNetIdOf(snapshot.AzureResourceId);
+
+            if (vnetId is null)
+            {
+                return null;
+            }
+
+            string key = PrefixKey(vnetId, $"{snapshot.NetworkAddress}/{snapshot.Cidr}");
+
+            return livePrefixOwners.TryGetValue(key, out List<AzurePrefixOwner>? owners)
+                ? owners.FirstOrDefault(o =>
+                    !string.Equals(o.ResourceId, snapshot.AzureResourceId, StringComparison.OrdinalIgnoreCase))
+                : null;
+        }
+
+        /// <summary>Comma-separated "'subnet' in VNet 'vnet'", capped so a warning stays readable.</summary>
+        private static string OwnerList(List<AzurePrefixOwner> owners)
+        {
+            const int Max = 10;
+            string names = string.Join(", ", owners.Take(Max).Select(o => $"'{o.SubnetName}' in VNet '{o.VNetName}'"));
+            return owners.Count > Max ? $"{names} and {owners.Count - Max} more" : names;
+        }
 
         /// <summary>Comma-separated subnet names, capped so a warning stays readable.</summary>
         private static string NameList(List<AzureReconcileItem> items)

--- a/src/Bastet/Services/Azure/AzureReconciler.cs
+++ b/src/Bastet/Services/Azure/AzureReconciler.cs
@@ -7,17 +7,19 @@ namespace Bastet.Services.Azure
     /// rules that decide what may be deleted can be tested exhaustively, mirroring
     /// <see cref="AzureBulkImportPlanner"/>.
     /// </summary>
-    public class AzureReconciler : IAzureReconciler
+    public class AzureReconciler(IIpUtilityService ipUtilityService) : IAzureReconciler
     {
         /// <inheritdoc/>
         public AzureReconcilePlanViewModel BuildPlan(
             string subscriptionId,
             string? subscriptionName,
             AzureVNetInventory inventory,
-            IReadOnlyList<AzureLinkedSubnetSnapshot> linkedSubnets)
+            IReadOnlyList<AzureLinkedSubnetSnapshot> linkedSubnets,
+            IReadOnlyList<ExistingSubnetSnapshot> existingSubnets)
         {
             ArgumentNullException.ThrowIfNull(inventory);
             ArgumentNullException.ThrowIfNull(linkedSubnets);
+            ArgumentNullException.ThrowIfNull(existingSubnets);
 
             AzureReconcilePlanViewModel plan = new()
             {
@@ -199,6 +201,12 @@ namespace Bastet.Services.Azure
                 }
             }
 
+            // INBOUND. Everything above walks Bastet rows and asks what Azure says about them, so
+            // every verdict starts from a row that already exists. An Azure range BASTET has no row
+            // for is invisible to all of it - the scan reports "nothing to clean up" while the
+            // parent's Details page offers the range as free with a Create Subnet button over it.
+            ReportAzureRangesNoBastetSubnetRecords(plan, inventory, existingSubnets);
+
             if (rangeStillAllocated.Count > 0)
             {
                 plan.Warnings.Add(
@@ -372,6 +380,121 @@ namespace Bastet.Services.Azure
         /// </summary>
         public static bool IsAbsenceStatus(AzureReconcileStatus status) =>
             status is AzureReconcileStatus.VNetDeleted or AzureReconcileStatus.SubnetDeleted;
+
+        /// <summary>
+        /// Reports every IPv4 range Azure has assigned inside an imported VNet that no Bastet subnet
+        /// accounts for. Report-only: these rows name no Bastet subnet, so there is nothing to
+        /// delete and nothing here is ever deletable.
+        /// </summary>
+        /// <remarks>
+        /// Two things make this correct rather than noisy, and both were wrong in the finding's
+        /// original proposal:
+        ///
+        /// CONTAINMENT, NOT EQUALITY. An IPAM routinely records a coarser allocation than Azure
+        /// carves out of it - Bastet holds 10.90.64.0/18 and Azure creates 10.90.77.0/24 inside it.
+        /// That range IS accounted for. Comparing {network, cidr} for equality would report it
+        /// forever, and an operator who cannot silence a warning stops reading warnings.
+        ///
+        /// EVERY subnet, not just linked ones. A range created by hand carries no AzureResourceId -
+        /// only the two import paths ever write that column - so matching against linked rows alone
+        /// would report a range the operator had already corrected, permanently.
+        ///
+        /// Scoped to VNets that have actually been imported, or an unimported subscription produces
+        /// an item per Azure subnet on every scan.
+        /// </remarks>
+        private void ReportAzureRangesNoBastetSubnetRecords(
+            AzureReconcilePlanViewModel plan,
+            AzureVNetInventory inventory,
+            IReadOnlyList<ExistingSubnetSnapshot> existingSubnets)
+        {
+            HashSet<string> importedVNetIds = new(
+                existingSubnets
+                    .Select(s => AzureResourceIdentity.VNetIdOf(s.AzureResourceId))
+                    .Where(id => !string.IsNullOrEmpty(id))
+                    .Select(id => id!),
+                StringComparer.OrdinalIgnoreCase);
+
+            // GetVNetInventory emits ONE ROW PER PREFIX for a multi-prefix Azure subnet, and every
+            // one of those rows carries the COMPLETE prefix list (round 13's BuildInventorySubnetRows,
+            // deliberately, so the reconciler's resource-id index is safe whichever row lands last).
+            // Walking rows x prefixes therefore visits an n-prefix subnet n^2 times, and without
+            // this set the same range is reported n times over.
+            HashSet<string> reported = new(StringComparer.OrdinalIgnoreCase);
+
+            foreach (BulkAzureVNetViewModel vnet in inventory.VNets)
+            {
+                if (string.IsNullOrEmpty(vnet.ResourceId) || !importedVNetIds.Contains(vnet.ResourceId))
+                {
+                    continue;
+                }
+
+                foreach (BulkAzureSubnetViewModel subnet in vnet.Subnets)
+                {
+                    foreach (string prefix in Ipv4PrefixesOf(subnet))
+                    {
+                        string[] parts = prefix.Split('/');
+
+                        if (parts.Length != 2 || !int.TryParse(parts[1], out int cidr))
+                        {
+                            continue;
+                        }
+
+                        if (!reported.Add($"{subnet.ResourceId}|{prefix}"))
+                        {
+                            continue;
+                        }
+
+                        if (existingSubnets.Any(e => AccountsFor(e, parts[0], cidr)))
+                        {
+                            continue;
+                        }
+
+                        plan.ReviewItems.Add(new AzureReconcileItem
+                        {
+                            // No Bastet row exists - that is the whole point of the item. Zero is
+                            // safe in the withheld set below because no real subnet has that id.
+                            SubnetId = 0,
+                            Name = subnet.Name,
+                            NetworkAddress = parts[0],
+                            Cidr = cidr,
+                            AzureResourceId = subnet.ResourceId ?? string.Empty,
+                            Status = AzureReconcileStatus.AzureRangeNotImported,
+                            Reason = $"Azure subnet '{subnet.Name}' in VNet '{vnet.Name}' owns {prefix}, "
+                                     + "which no BASTET subnet records. BASTET is reporting that range as free space.",
+                            IsVNetLevel = false
+                        });
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// True when a Bastet subnet already accounts for an Azure range - it either IS that range,
+        /// or it is a non-target subnet containing it.
+        /// </summary>
+        /// <remarks>
+        /// The exclusion of VNet-level targets from the containment arm is load-bearing, not a
+        /// detail. An import target holds the VNet's whole address prefix, so it contains every
+        /// range in the VNet by construction; counting that as "accounted for" makes the inbound
+        /// check vacuous - it can never report anything. A target represents the address space the
+        /// VNet owns, not an allocation within it, and BASTET's own free-space table agrees: it
+        /// prints the target's range minus its CHILDREN.
+        ///
+        /// Equality is still honoured for targets, because an Azure subnet covering a whole VNet
+        /// prefix is recorded by marking that very target fully allocated rather than by creating a
+        /// child - so the target genuinely is the record of that range.
+        /// </remarks>
+        private bool AccountsFor(ExistingSubnetSnapshot existing, string network, int cidr)
+        {
+            if (string.Equals(existing.NetworkAddress, network, StringComparison.OrdinalIgnoreCase)
+                && existing.Cidr == cidr)
+            {
+                return true;
+            }
+
+            return !AzureResourceIdentity.IsAzureVNet(existing.AzureResourceId)
+                   && ipUtilityService.IsSubnetContainedInParent(network, cidr, existing.NetworkAddress, existing.Cidr);
+        }
 
         /// <summary>An Azure subnet that currently holds a given IPv4 range.</summary>
         private sealed record AzurePrefixOwner(string ResourceId, string SubnetName, string VNetName);

--- a/src/Bastet/Services/Azure/AzureResourceIdentity.cs
+++ b/src/Bastet/Services/Azure/AzureResourceIdentity.cs
@@ -45,6 +45,37 @@ namespace Bastet.Services.Azure
         public static bool IsAzureVNet(string? resourceId) =>
             IsResourceType(resourceId, VNetResourceType);
 
+        /// <summary>
+        /// The VNet an ID belongs to: the parent for a subnet ID, itself for a VNet ID, null for
+        /// anything else. Used to scope a range comparison to one VNet.
+        /// </summary>
+        /// <remarks>
+        /// Scoping matters because overlapping RFC1918 space across unrelated VNets in one
+        /// subscription is the norm, not an anomaly. Comparing bare prefix strings across the whole
+        /// inventory would treat an unrelated VNet's 10.0.0.0/8 as evidence that a genuinely stale
+        /// row's range is still allocated, and withhold a deletion that ought to be offered.
+        /// </remarks>
+        public static string? VNetIdOf(string? resourceId)
+        {
+            if (string.IsNullOrWhiteSpace(resourceId)
+                || !ResourceIdentifier.TryParse(resourceId, out ResourceIdentifier? id)
+                || id is null)
+            {
+                return null;
+            }
+
+            string type = id.ResourceType.ToString();
+
+            if (string.Equals(type, VNetResourceType, StringComparison.OrdinalIgnoreCase))
+            {
+                return id.ToString();
+            }
+
+            return string.Equals(type, SubnetResourceType, StringComparison.OrdinalIgnoreCase)
+                ? id.Parent?.ToString()
+                : null;
+        }
+
         private static bool IsResourceType(string? resourceId, string resourceType) =>
             !string.IsNullOrWhiteSpace(resourceId)
             && ResourceIdentifier.TryParse(resourceId, out ResourceIdentifier? id)

--- a/src/Bastet/Services/Azure/IAzureReconciler.cs
+++ b/src/Bastet/Services/Azure/IAzureReconciler.cs
@@ -16,11 +16,18 @@ namespace Bastet.Services.Azure
         /// <param name="subscriptionName">Display name, for the report.</param>
         /// <param name="inventory">Live Azure state. If it reports failure, the plan comes back empty and cannot be committed.</param>
         /// <param name="linkedSubnets">Every Bastet subnet carrying an Azure resource ID.</param>
+        /// <param name="existingSubnets">
+        /// Every Bastet subnet, linked or not. Needed for the INBOUND direction: an Azure range that
+        /// no Bastet subnet records is reported from here, and a range created by hand carries no
+        /// Azure resource ID, so it is absent from <paramref name="linkedSubnets"/> while
+        /// legitimately accounting for the address space.
+        /// </param>
         AzureReconcilePlanViewModel BuildPlan(
             string subscriptionId,
             string? subscriptionName,
             AzureVNetInventory inventory,
-            IReadOnlyList<AzureLinkedSubnetSnapshot> linkedSubnets);
+            IReadOnlyList<AzureLinkedSubnetSnapshot> linkedSubnets,
+            IReadOnlyList<ExistingSubnetSnapshot> existingSubnets);
 
         /// <summary>
         /// Removes from <see cref="AzureReconcilePlanViewModel.Items"/> everything whose absence

--- a/src/Bastet/Services/FullyAllocatedNote.cs
+++ b/src/Bastet/Services/FullyAllocatedNote.cs
@@ -20,7 +20,25 @@ public static class FullyAllocatedNote
     private const string Suffix = "' which encompasses the entire address space.";
 
     /// <summary>The note for a given Azure subnet name.</summary>
-    public static string For(string? azureSubnetName) => $"{Prefix}{azureSubnetName}{Suffix}";
+    /// <remarks>
+    /// Line breaks in the name are collapsed to spaces, which is what makes every note single-line
+    /// BY CONSTRUCTION. <see cref="Strip"/> matches whole lines anchored at both ends - deliberately,
+    /// so operator prose that merely resembles the note is never destroyed - and a name carrying a
+    /// newline produced a note spanning two lines, neither of which satisfies both anchors. No later
+    /// Strip could remove it, so the flag could be cleared while the description went on asserting it
+    /// and every import/un-mark cycle stacked another copy.
+    ///
+    /// Fixed here rather than at the two producers: this is the single choke point both call sites go
+    /// through, and leaving the helper able to build an unstrippable note for any future caller is
+    /// the same class of latent defect. Not fixed by tightening [SafeText] either - that class is
+    /// shared with host and subnet names across the app.
+    /// </remarks>
+    public static string For(string? azureSubnetName) =>
+        $"{Prefix}{Normalise(azureSubnetName)}{Suffix}";
+
+    /// <summary>Collapses every line-break form to a space so the note cannot span lines.</summary>
+    private static string? Normalise(string? azureSubnetName) =>
+        azureSubnetName?.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ');
 
     /// <summary>
     /// <paramref name="description"/> with every fully-allocated note removed, whatever Azure subnet

--- a/src/Bastet/Services/Locking/SqlServerSubnetLockingService.cs
+++ b/src/Bastet/Services/Locking/SqlServerSubnetLockingService.cs
@@ -24,6 +24,35 @@ public class SqlServerSubnetLockingService(BastetDbContext context, ILogger<SqlS
     private const string SUBNET_OPERATIONS_LOCK = "Bastet:SubnetOperations";
 
     /// <summary>
+    /// Ends the SQL session behind the current connection, so a Session-owned application lock the
+    /// release failed to drop cannot outlive the request on a pooled connection.
+    /// </summary>
+    /// <remarks>
+    /// ClearPool empties the whole pool for this connection string, not just this connection.
+    /// Microsoft.Data.SqlClient exposes no per-connection "do not pool" switch, so this is the only
+    /// public mechanism; the cost is a burst of reconnect handshakes, paid only on a path that has
+    /// already failed. The alternative - leaving the lock held - denies every write on every replica
+    /// until something happens to reuse that one connection, which a peer replica cannot cause.
+    ///
+    /// Failure here is swallowed on purpose: this already runs inside the catch of a release that
+    /// failed, and throwing would replace the exception in flight.
+    /// </remarks>
+    private void DiscardPooledConnection()
+    {
+        try
+        {
+            if (context.Database.GetDbConnection() is SqlConnection stranded)
+            {
+                SqlConnection.ClearPool(stranded);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to discard the pooled connection after a failed lock release");
+        }
+    }
+
+    /// <summary>
     /// Caps how many requests this replica can have parked inside <c>sp_getapplock</c> at once, from
     /// unbounded to one.
     /// </summary>
@@ -88,16 +117,31 @@ public class SqlServerSubnetLockingService(BastetDbContext context, ILogger<SqlS
                     // inside operation(), so by now the work is durable: rethrowing here would report a
                     // completed operation as failed, and - because an exception raised in a finally
                     // replaces the one in flight - would also destroy the original error when the
-                    // operation itself was what failed. Swallowing does not change the lock's fate: if
-                    // the connection died the session died with it and SQL Server has already dropped
-                    // the session-scoped lock, and if it is alive the outer finally closes it anyway.
+                    // operation itself was what failed.
+                    //
+                    // But swallowing alone is NOT enough, and the comment that used to sit here was
+                    // wrong about why: "if it is alive the outer finally closes it anyway" does not
+                    // release the lock. CloseConnectionAsync returns the connection to SqlClient's
+                    // POOL; the SQL session stays open, and a Session-owned application lock is only
+                    // dropped when that pooled connection is next reused (sp_reset_connection) or
+                    // physically destroyed. Measured: the lock survived a completed request, a
+                    // disposed DbContext and a closed connection for over four minutes, during which
+                    // every subnet write on a second replica parked 30 s in sp_getapplock and failed
+                    // with "The operation timed out due to high concurrency" - which was not true.
+                    //
+                    // So on a failed release, destroy the physical connection. That ends the session,
+                    // and the lock with it.
                     try
                     {
                         await ReleaseAppLockAsync(SUBNET_OPERATIONS_LOCK);
                     }
                     catch (Exception ex)
                     {
-                        logger.LogError(ex, "Failed to release the subnet operation lock after the operation completed");
+                        logger.LogError(ex,
+                            "Failed to release the subnet operation lock; discarding the pooled connection so the "
+                            + "session-owned lock is dropped rather than stranded");
+
+                        DiscardPooledConnection();
                     }
                 }
             }

--- a/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
@@ -293,6 +293,16 @@
                 tr.append($("<td></td>").text(item.name));
                 tr.append($("<td></td>").html("<code>" + escapeHtml(item.networkAddress) + "/" + escapeHtml(item.cidr) + "</code>"));
                 tr.append($("<td></td>").text(item.reason));
+
+                // Only a range that moved to another Azure subnet has a repair; every other review
+                // status needs a human decision the application cannot make.
+                const action = $("<td></td>");
+                if (item.suggestedAzureResourceId) {
+                    action.append($('<button type="button" class="btn btn-sm btn-outline-primary rec-relink-btn"></button>')
+                        .attr("data-subnet-id", item.subnetId)
+                        .text("Re-link to '" + item.suggestedAzureSubnetName + "'"));
+                }
+                tr.append(action);
                 reviewRows.append(tr);
             });
             $("#rec-review-section").toggleClass("d-none", reviewItems.length === 0);
@@ -340,6 +350,56 @@
             $(".rec-item-checkbox").prop("checked", $(this).is(":checked"));
             updateGoConfirmBtn();
             invalidateConfirmation();
+        });
+
+        // Repairs the Azure link of a row whose range moved to another Azure subnet. Delegated
+        // because the review rows are rebuilt on every scan. The server re-derives which Azure
+        // subnet to link to, so nothing but the row id is sent, and a re-scan follows so the
+        // screen never keeps showing a verdict that has just been acted on.
+        let relinking = false;
+        $("#rec-review-rows").on("click", ".rec-relink-btn", function () {
+            if (relinking) {
+                return;
+            }
+
+            const btn = $(this);
+            const subnetId = btn.data("subnet-id");
+
+            $.ajax({
+                url: "@Url.Action("RelinkAzureSubnet", "Subnet")",
+                type: "POST",
+                contentType: "application/json",
+                dataType: "json",
+                headers: { "RequestVerificationToken": getAntiForgeryToken() },
+                data: JSON.stringify({ subscriptionId: selectedSubscriptionId, subnetId: subnetId }),
+                beforeSend: function () {
+                    relinking = true;
+                    $(".rec-relink-btn").prop("disabled", true);
+                    btn.text("Re-linking...");
+                },
+                success: function (result) {
+                    if (result && result.success) {
+                        // Re-scan rather than patching the row: the repair can change other rows'
+                        // verdicts too, and a stale table is what makes an archive click wrong.
+                        runScan();
+                        return;
+                    }
+                    showScanError((result && result.error) || "The re-link failed.");
+                },
+                error: function (xhr) {
+                    let message = "The re-link failed.";
+                    if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
+                        message = xhr.responseJSON.error;
+                    }
+                    showScanError(message);
+                },
+                complete: function () {
+                    // Re-enable unconditionally: a failed re-link must stay retryable, and runScan
+                    // rebuilds these rows from scratch on the success path anyway.
+                    relinking = false;
+                    $(".rec-relink-btn").prop("disabled", false);
+                }
+            });
         });
 
         $("#rec-back-to-subscription-btn").on("click", function () {

--- a/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_ReconcileScripts.cshtml
@@ -12,6 +12,9 @@
         // whatever the review checkboxes hold at click time, so it can only ever delete what the
         // confirmation screen listed.
         let confirmedIds = null;
+        // The verdict each confirmed row was shown under. Sent with the delete so the server
+        // can refuse a batch whose reasons have changed since the operator read them.
+        let confirmedVerdicts = null;
         // True while a delete POST is in flight. Without it, anything that calls
         // refreshDeleteButton re-arms the button mid-delete - one keystroke plus Backspace in the
         // confirmation box is enough - and the second POST's ARM re-scan starts before the first
@@ -61,6 +64,7 @@
         // clickable once visited.
         function invalidateConfirmation() {
             confirmedIds = null;
+            confirmedVerdicts = null;
             $("#rec-step3-tab").addClass("disabled");
             refreshDeleteButton();
 
@@ -420,6 +424,10 @@
 
             // The deletion is submitted for every selected id; the server dedupes by subtree.
             confirmedIds = chosen.map(function (i) { return i.subnetId; });
+            // Snapshotted here, beside confirmedIds, so both describe the same reviewed plan.
+            confirmedVerdicts = chosen.map(function (i) {
+                return { subnetId: i.subnetId, statusName: i.statusName, reason: i.reason || "" };
+            });
 
             // The counts are subtree-inclusive, so an item selected together with one of its
             // ancestors is already inside the ancestor's numbers - same rule the server applies
@@ -498,7 +506,8 @@
                 data: JSON.stringify({
                     subscriptionId: selectedSubscriptionId,
                     subnetIds: ids,
-                    confirmation: $("#rec-confirmation").val()
+                    confirmation: $("#rec-confirmation").val(),
+                    statuses: confirmedVerdicts || []
                 }),
                 beforeSend: function () {
                     deleting = true;

--- a/src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml
+++ b/src/Bastet/Views/Azure/Reconcile/_StepReview.cshtml
@@ -75,6 +75,7 @@
         <div class="alert alert-secondary">
             Nothing here can be fixed by deleting anything, so these are listed without checkboxes.
             The reason column says what is wrong with each one. BASTET will not change them automatically.
+            Where a range has moved to another Azure subnet, a Re-link button repairs the link in place.
         </div>
 
         <div class="table-responsive">
@@ -84,6 +85,7 @@
                         <th scope="col">Subnet</th>
                         <th scope="col">Network</th>
                         <th scope="col">Reason</th>
+                        <th scope="col">Action</th>
                     </tr>
                 </thead>
                 <tbody id="rec-review-rows"></tbody>

--- a/src/Bastet/Views/Subnet/Details/_UnallocatedRanges.cshtml
+++ b/src/Bastet/Views/Subnet/Details/_UnallocatedRanges.cshtml
@@ -8,6 +8,29 @@
             <h5 class="mb-0">Unallocated IP Ranges</h5>
         </div>
         <div class="card-body">
+            @*
+                This table is BASTET's answer to "what is free?", and for an Azure-linked subnet that
+                answer is only as current as the last import. Azure can assign a range inside this
+                subnet at any time - adding a prefix to an existing Azure subnet does exactly that -
+                and nothing here would know. Azure Reconcile is what establishes it.
+
+                Deliberately a static note rather than a live check: BASTET is self-hosted and must
+                keep working with no outbound internet, so rendering this page must never depend on
+                reaching ARM.
+            *@
+            @if (!string.IsNullOrEmpty(Model.AzureResourceId))
+            {
+                <div class="alert alert-warning d-flex align-items-start" role="alert">
+                    <i class="bi bi-exclamation-triangle-fill me-2"></i>
+                    <div>
+                        This subnet is linked to Azure. Ranges listed here are free
+                        <strong>according to what BASTET has imported</strong> — if Azure has assigned
+                        address space that was never imported, it will still be listed below.
+                        <a asp-controller="Azure" asp-action="Reconcile">Run Azure Reconcile</a>
+                        to check before allocating from these ranges.
+                    </div>
+                </div>
+            }
             <div class="table-responsive">
                 <table class="table table-hover">
                     <thead>

--- a/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureBulkImportPlannerTests.cs
@@ -350,10 +350,13 @@ public class AzureBulkImportPlannerTests
         Assert.Contains(plan.Items, i => i.PrefixNetworkAddress == "10.0.0.0" && i.PrefixCidr == 16);
         Assert.Contains(plan.Items, i => i.PrefixNetworkAddress == "10.1.0.0" && i.PrefixCidr == 16);
 
-        // Both auto-created targets keep the unmodified VNet name (intentional — Bastet
-        // allows duplicate Subnet.Name; only NetworkAddress+Cidr is unique). If a future
-        // change introduces auto-disambiguation of these names, this assertion will catch it.
-        Assert.All(plan.Items, i => Assert.Equal("vnet-multi", i.AutoCreateTargetName));
+        // Each auto-created target is named for the range it holds. This assertion previously
+        // pinned the opposite - both targets keeping the bare VNet name - with a comment saying a
+        // future change introducing auto-disambiguation would be caught here. It was: two Bastet
+        // subnets with the identical name AND the identical VNet resource id, distinguishable only
+        // by network address, on every multi-address-space VNet import. Changed deliberately.
+        Assert.Contains(plan.Items, i => i.AutoCreateTargetName == "vnet-multi (10.0.0.0-16)");
+        Assert.Contains(plan.Items, i => i.AutoCreateTargetName == "vnet-multi (10.1.0.0-16)");
     }
 
 

--- a/test/Bastet.Tests/Azure/AzureBulkImportSpanningNameTests.cs
+++ b/test/Bastet.Tests/Azure/AzureBulkImportSpanningNameTests.cs
@@ -1,0 +1,157 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Security;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// Round 13 made an Azure subnet owning several IPv4 prefixes name each child for the range it
+/// holds, because Subnet.Name is non-unique and the rows would otherwise differ only by CIDR. The
+/// grouping that decided "several" was computed per plan item, and BuildPlanItem runs once per
+/// selected VNet address prefix - so a subnet spanning two VNet prefixes looked single-prefix to
+/// both items and the qualification was silently skipped.
+/// </summary>
+public class AzureBulkImportSpanningNameTests
+{
+    private const string VNetA = "/subscriptions/test/providers/Microsoft.Network/virtualNetworks/vnet-a";
+    private const string SpanningSubnet = $"{VNetA}/subnets/sn-span";
+
+    private readonly AzureBulkImportPlanner _planner =
+        new(new IpUtilityService(), new InputSanitizationService());
+
+    private static BulkImportSelectedVNetPrefixDto Prefix(string prefix, params BulkImportSelectedSubnetDto[] subs) =>
+        new()
+        {
+            VNetName = "vnet-a",
+            VNetResourceId = VNetA,
+            AddressPrefix = prefix,
+            Subnets = [.. subs]
+        };
+
+    private static BulkImportSelectedSubnetDto Sub(string name, string prefix, string resourceId) =>
+        new() { Name = name, AddressPrefix = prefix, AzureResourceId = resourceId };
+
+    private BulkImportPlanViewModel Plan(
+        IReadOnlyList<ExistingSubnetSnapshot> existing, params BulkImportSelectedVNetPrefixDto[] prefixes) =>
+        _planner.BuildPlan(
+            new BulkImportSelectionDto
+            {
+                SubscriptionId = "sub-1",
+                SubscriptionName = "Test Sub",
+                VNetPrefixes = [.. prefixes]
+            },
+            existing);
+
+    private static List<string> ChildNames(BulkImportPlanViewModel plan) =>
+        [.. plan.Items.SelectMany(i => i.ChildSubnets).Select(c => c.Name)];
+
+    /// <summary>
+    /// The defect. One Azure subnet, one prefix under each of the VNet's two address prefixes: two
+    /// plan items, each seeing one row, so neither qualified the name. Both rows persisted as
+    /// "sn-span" carrying the same AzureResourceId.
+    /// </summary>
+    [Fact]
+    public void AnAzureSubnetSpanningTwoVNetPrefixes_HasBothChildrenQualified()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [],
+            Prefix("10.71.0.0/16", Sub("sn-span", "10.71.5.0/24", SpanningSubnet)),
+            Prefix("10.72.0.0/16", Sub("sn-span", "10.72.5.0/24", SpanningSubnet)));
+
+        List<string> names = ChildNames(plan);
+
+        Assert.Equal(2, names.Count);
+        Assert.Contains("sn-span (10.71.5.0/24)", names);
+        Assert.Contains("sn-span (10.72.5.0/24)", names);
+        Assert.Distinct(names);
+    }
+
+    /// <summary>
+    /// The cross-session route: this commit carries one selection for the Azure subnet, but a row
+    /// from that same Azure subnet holding a different range is already in the tree.
+    /// </summary>
+    [Fact]
+    public void ASelectionWhoseAzureSubnetAlreadyHasAPersistedSibling_IsQualified()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [
+                new ExistingSubnetSnapshot
+                {
+                    Id = 2, Name = "sn-span", NetworkAddress = "10.71.5.0", Cidr = 24,
+                    AzureResourceId = SpanningSubnet
+                }
+            ],
+            Prefix("10.72.0.0/16", Sub("sn-span", "10.72.5.0/24", SpanningSubnet)));
+
+        Assert.Equal("sn-span (10.72.5.0/24)", Assert.Single(ChildNames(plan)));
+    }
+
+    /// <summary>
+    /// The narrowing that keeps the ordinary path untouched. Seeding from the whole tree instead
+    /// would rename any child whose Azure name merely matched some unrelated Bastet subnet.
+    /// </summary>
+    [Fact]
+    public void AnUnrelatedBastetSubnetWithTheSameName_DoesNotCauseARename()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [
+                new ExistingSubnetSnapshot
+                {
+                    Id = 2, Name = "sn-span", NetworkAddress = "192.168.0.0", Cidr = 24,
+                    AzureResourceId = null
+                }
+            ],
+            Prefix("10.72.0.0/16", Sub("sn-span", "10.72.5.0/24", SpanningSubnet)));
+
+        Assert.Equal("sn-span", Assert.Single(ChildNames(plan)));
+    }
+
+    /// <summary>Re-importing the very same range is not a sibling, so no qualification.</summary>
+    [Fact]
+    public void ThePersistedRowForTheSameRange_IsNotTreatedAsASibling()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [
+                new ExistingSubnetSnapshot
+                {
+                    Id = 2, Name = "sn-span", NetworkAddress = "10.72.5.0", Cidr = 24,
+                    AzureResourceId = SpanningSubnet
+                }
+            ],
+            Prefix("10.72.0.0/16", Sub("sn-span", "10.72.5.0/24", SpanningSubnet)));
+
+        Assert.Equal("sn-span", Assert.Single(ChildNames(plan)));
+    }
+
+    /// <summary>An ordinary single-prefix import keeps the exact name it has always had.</summary>
+    [Fact]
+    public void AnOrdinarySingleSubnetImport_KeepsItsBareAzureName()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [],
+            Prefix("10.71.0.0/16", Sub("sn-plain", "10.71.5.0/24", $"{VNetA}/subnets/sn-plain")));
+
+        Assert.Equal("sn-plain", Assert.Single(ChildNames(plan)));
+    }
+
+    /// <summary>
+    /// The filter the verifier said to keep. An encompassing selection marks the target fully
+    /// allocated instead of creating a child, so counting it would inflate the group and needlessly
+    /// rename the one child that IS created. Reachable because a subnet may equal one VNet prefix
+    /// exactly and still hold a prefix inside another.
+    /// </summary>
+    [Fact]
+    public void AnEncompassingSelectionDoesNotInflateTheGroup()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [],
+            // sn-span covers the whole of 10.71.0.0/16...
+            Prefix("10.71.0.0/16", Sub("sn-span", "10.71.0.0/16", SpanningSubnet)),
+            // ...and also holds a prefix inside the VNet's other address space
+            Prefix("10.72.0.0/16", Sub("sn-span", "10.72.5.0/24", SpanningSubnet)));
+
+        // Only one child is created; it must not be renamed on the strength of the encompassing row.
+        Assert.Equal("sn-span", Assert.Single(ChildNames(plan)));
+    }
+}

--- a/test/Bastet.Tests/Azure/AzureBulkImportSpanningNameTests.cs
+++ b/test/Bastet.Tests/Azure/AzureBulkImportSpanningNameTests.cs
@@ -62,8 +62,8 @@ public class AzureBulkImportSpanningNameTests
         List<string> names = ChildNames(plan);
 
         Assert.Equal(2, names.Count);
-        Assert.Contains("sn-span (10.71.5.0/24)", names);
-        Assert.Contains("sn-span (10.72.5.0/24)", names);
+        Assert.Contains("sn-span (10.71.5.0-24)", names);
+        Assert.Contains("sn-span (10.72.5.0-24)", names);
         Assert.Distinct(names);
     }
 
@@ -84,7 +84,7 @@ public class AzureBulkImportSpanningNameTests
             ],
             Prefix("10.72.0.0/16", Sub("sn-span", "10.72.5.0/24", SpanningSubnet)));
 
-        Assert.Equal("sn-span (10.72.5.0/24)", Assert.Single(ChildNames(plan)));
+        Assert.Equal("sn-span (10.72.5.0-24)", Assert.Single(ChildNames(plan)));
     }
 
     /// <summary>

--- a/test/Bastet.Tests/Azure/AzureBulkImportTargetNameTests.cs
+++ b/test/Bastet.Tests/Azure/AzureBulkImportTargetNameTests.cs
@@ -1,0 +1,140 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Security;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// N6 one level up the tree. BuildPlanItem runs once per selected VNet address prefix and TargetName
+/// returned the sanitised VNet name and nothing else, so a VNet with two address prefixes persisted
+/// two top-level Bastet subnets with the identical name and the identical VNet resource id,
+/// distinguishable only by network address.
+///
+/// Unlike N6 this fires on EVERY multi-address-space VNet import, not only on a subnet that spans
+/// two prefixes - one click of "Select all", no crafted payload.
+/// </summary>
+public class AzureBulkImportTargetNameTests
+{
+    private const string VNetA = "/subscriptions/test/providers/Microsoft.Network/virtualNetworks/vnet-a";
+    private const string VNetB = "/subscriptions/test/providers/Microsoft.Network/virtualNetworks/vnet-b";
+
+    private readonly AzureBulkImportPlanner _planner =
+        new(new IpUtilityService(), new InputSanitizationService());
+
+    private static BulkImportSelectedVNetPrefixDto Prefix(
+        string vnetName, string vnetResourceId, string prefix, params BulkImportSelectedSubnetDto[] subs) =>
+        new()
+        {
+            VNetName = vnetName,
+            VNetResourceId = vnetResourceId,
+            AddressPrefix = prefix,
+            Subnets = [.. subs]
+        };
+
+    private BulkImportPlanViewModel Plan(
+        IReadOnlyList<ExistingSubnetSnapshot> existing, params BulkImportSelectedVNetPrefixDto[] prefixes) =>
+        _planner.BuildPlan(
+            new BulkImportSelectionDto { SubscriptionId = "sub-1", VNetPrefixes = [.. prefixes] },
+            existing);
+
+    private static List<string?> TargetNames(BulkImportPlanViewModel plan) =>
+        [.. plan.Items.Select(i => i.AutoCreateTargetName)];
+
+    /// <summary>The defect, as persisted in the audit's own reproduction.</summary>
+    [Fact]
+    public void AVNetWithTwoAddressPrefixes_NamesEachTargetForTheRangeItHolds()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [],
+            Prefix("vnet-a", VNetA, "10.71.0.0/16"),
+            Prefix("vnet-a", VNetA, "10.72.0.0/16"));
+
+        List<string?> names = TargetNames(plan);
+
+        Assert.Equal(2, names.Count);
+        Assert.Contains("vnet-a (10.71.0.0-16)", names);
+        Assert.Contains("vnet-a (10.72.0.0-16)", names);
+        Assert.Distinct(names);
+    }
+
+    /// <summary>A VNet contributing one prefix keeps the bare name it has always had.</summary>
+    [Fact]
+    public void AVNetContributingASinglePrefix_KeepsItsBareName()
+    {
+        BulkImportPlanViewModel plan = Plan([], Prefix("vnet-a", VNetA, "10.71.0.0/16"));
+
+        Assert.Equal("vnet-a", Assert.Single(TargetNames(plan)));
+    }
+
+    /// <summary>
+    /// Two different VNets that happen to be selected together are not the same VNet, so neither is
+    /// qualified - the grouping is by resource id, not by how many prefixes the commit carries.
+    /// </summary>
+    [Fact]
+    public void TwoDifferentVNetsEachContributingOnePrefix_AreBothLeftBare()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [],
+            Prefix("vnet-a", VNetA, "10.71.0.0/16"),
+            Prefix("vnet-b", VNetB, "10.72.0.0/16"));
+
+        List<string?> names = TargetNames(plan);
+
+        Assert.Contains("vnet-a", names);
+        Assert.Contains("vnet-b", names);
+    }
+
+    /// <summary>
+    /// The same prefix listed twice is one prefix, not two - a duplicated selection must not trigger
+    /// qualification. (The overlap check refuses the commit; the naming must not misreport either.)
+    /// </summary>
+    [Fact]
+    public void TheSamePrefixSelectedTwice_IsNotTreatedAsTwoPrefixes()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [],
+            Prefix("vnet-a", VNetA, "10.71.0.0/16"),
+            Prefix("vnet-a", VNetA, "10.71.0.0/16"));
+
+        Assert.All(TargetNames(plan), n => Assert.Equal("vnet-a", n));
+    }
+
+    /// <summary>
+    /// The ExactMatch branch adopts an existing row and names nothing, so a matched target is never
+    /// renamed by this - the qualification applies only to targets the import creates.
+    /// </summary>
+    [Fact]
+    public void AnExactMatchTargetIsNotRenamedByTheQualification()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [
+                new ExistingSubnetSnapshot
+                {
+                    Id = 1, Name = "already-here", NetworkAddress = "10.71.0.0", Cidr = 16,
+                    AzureResourceId = VNetA
+                }
+            ],
+            Prefix("vnet-a", VNetA, "10.71.0.0/16"),
+            Prefix("vnet-a", VNetA, "10.72.0.0/16"));
+
+        BulkImportPlanItem matched = plan.Items.Single(i => i.TargetType == BulkImportTargetType.ExactMatch);
+
+        Assert.Equal("already-here", matched.ExistingTargetSubnetName);
+        Assert.False(matched.WillRename);
+    }
+
+    /// <summary>Generated target names must satisfy the app's own input rules, same as child names.</summary>
+    [Fact]
+    public void TheQualifiedTargetNameSatisfiesTheAppsOwnInputRules()
+    {
+        BulkImportPlanViewModel plan = Plan(
+            [],
+            Prefix("vnet-a", VNetA, "10.71.0.0/16"),
+            Prefix("vnet-a", VNetA, "10.72.0.0/16"));
+
+        IInputSanitizationService sanitizer = new InputSanitizationService();
+
+        Assert.All(TargetNames(plan), n => Assert.True(sanitizer.IsSafeText(n!)));
+    }
+}

--- a/test/Bastet.Tests/Azure/AzureBulkImportTopUpTests.cs
+++ b/test/Bastet.Tests/Azure/AzureBulkImportTopUpTests.cs
@@ -1,0 +1,228 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Security;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// Top-up import. A populated target used to be refused outright, which left an Azure subnet that
+/// gained a prefix after import impossible to import by any route - while BASTET went on advertising
+/// the Azure-assigned range as free space with a Create Subnet button over it.
+///
+/// The allowance is deliberately narrow: the target must already be linked to THIS VNet. That
+/// separates a top-up from adopting a subtree somebody built by hand, which is what re-stamps
+/// AzureResourceId on rows nobody imported and pulls them into a later reconcile cascade. The
+/// refusal tests below are the fix as much as the permission tests are.
+/// </summary>
+public class AzureBulkImportTopUpTests
+{
+    private const string VNetA = "/subscriptions/test/providers/Microsoft.Network/virtualNetworks/vnet-a";
+    private const string VNetB = "/subscriptions/test/providers/Microsoft.Network/virtualNetworks/vnet-b";
+
+    private readonly AzureBulkImportPlanner _planner =
+        new(new IpUtilityService(), new InputSanitizationService());
+
+    private static BulkImportSelectedSubnetDto Sub(string name, string prefix, string? resourceId = null) =>
+        new() { Name = name, AddressPrefix = prefix, AzureResourceId = resourceId ?? $"{VNetA}/subnets/{name}" };
+
+    private static BulkImportSelectionDto Selection(bool rename = false, params BulkImportSelectedSubnetDto[] subs) =>
+        new()
+        {
+            SubscriptionId = "sub-1",
+            SubscriptionName = "Test Sub",
+            RenameMatchedBastetSubnets = rename,
+            VNetPrefixes =
+            [
+                new BulkImportSelectedVNetPrefixDto
+                {
+                    VNetName = "vnet-a",
+                    VNetResourceId = VNetA,
+                    AddressPrefix = "10.90.0.0/16",
+                    Subnets = [.. subs]
+                }
+            ]
+        };
+
+    private static ExistingSubnetSnapshot Target(
+        string? linkedTo, bool hasChildren = true, bool hasHostIps = false, bool fullyAllocated = false) =>
+        new()
+        {
+            Id = 1,
+            Name = "vnet-a",
+            NetworkAddress = "10.90.0.0",
+            Cidr = 16,
+            AzureResourceId = linkedTo,
+            HasChildSubnets = hasChildren,
+            HasHostIpAssignments = hasHostIps,
+            IsFullyAllocated = fullyAllocated
+        };
+
+    private BulkImportPlanItem Plan(BulkImportSelectionDto selection, params ExistingSubnetSnapshot[] existing) =>
+        _planner.BuildPlan(selection, existing).Items[0];
+
+    // -------------------------------------------------------------------------
+    // The allowance
+    // -------------------------------------------------------------------------
+
+    /// <summary>The defect: the one genuinely-new subnet could not be imported by any route.</summary>
+    [Fact]
+    public void ATargetAlreadyLinkedToThisVNet_AcceptsTheMissingSubnet()
+    {
+        BulkImportPlanItem item = Plan(
+            Selection(false, Sub("sn-new", "10.90.77.0/24")),
+            Target(linkedTo: VNetA));
+
+        Assert.Empty(item.Errors);
+        Assert.Equal(BulkImportTargetType.ExactMatch, item.TargetType);
+        Assert.Single(item.ChildSubnets);
+    }
+
+    // -------------------------------------------------------------------------
+    // The refusals - each one is a way the allowance could have gone wrong
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Adoption. A populated target with no Azure link was built by hand; claiming it would stamp
+    /// this VNet's id on rows nobody imported, after which a reconcile cascade can archive them.
+    /// </summary>
+    [Fact]
+    public void APopulatedTargetWithNoAzureLink_IsStillRefused()
+    {
+        BulkImportPlanItem item = Plan(
+            Selection(false, Sub("sn-new", "10.90.77.0/24")),
+            Target(linkedTo: null));
+
+        Assert.Contains(item.Errors, e => e.Contains("already has child subnets"));
+    }
+
+    [Fact]
+    public void APopulatedTargetLinkedToADifferentVNet_IsStillRefused()
+    {
+        BulkImportPlanItem item = Plan(
+            Selection(false, Sub("sn-new", "10.90.77.0/24")),
+            Target(linkedTo: VNetB));
+
+        Assert.Contains(item.Errors, e => e.Contains("already linked to Azure VNet"));
+    }
+
+    [Fact]
+    public void ATargetWithHostIpAssignments_IsStillRefused()
+    {
+        BulkImportPlanItem item = Plan(
+            Selection(false, Sub("sn-new", "10.90.77.0/24")),
+            Target(linkedTo: VNetA, hasHostIps: true));
+
+        Assert.Contains(item.Errors, e => e.Contains("host IP assignments"));
+    }
+
+    [Fact]
+    public void ATargetMarkedFullyAllocated_IsStillRefused()
+    {
+        BulkImportPlanItem item = Plan(
+            Selection(false, Sub("sn-new", "10.90.77.0/24")),
+            Target(linkedTo: VNetA, fullyAllocated: true));
+
+        Assert.Contains(item.Errors, e => e.Contains("fully allocated"));
+    }
+
+    /// <summary>
+    /// The gap the verifier named. The commit marks the target fully allocated INSTEAD of creating
+    /// children, so a populated target would be left claiming nothing more fits while already
+    /// holding rows. The old blanket refusal was preventing this incidentally.
+    /// </summary>
+    [Fact]
+    public void ATopUpCannotMarkAPopulatedTargetFullyAllocated()
+    {
+        BulkImportPlanItem item = Plan(
+            // An Azure subnet covering the whole VNet prefix
+            Selection(false, Sub("sn-whole", "10.90.0.0/16")),
+            Target(linkedTo: VNetA));
+
+        Assert.Contains(item.Errors, e => e.Contains("already has child subnets"));
+        Assert.False(item.WillMarkFullyAllocated);
+    }
+
+    /// <summary>
+    /// Renaming a target that already holds imported rows changes a label the operator has been
+    /// living with, for a run whose purpose is to add the one subnet that was missing.
+    /// </summary>
+    [Fact]
+    public void ATopUpNeverRenamesThePopulatedTarget()
+    {
+        BulkImportPlanItem item = Plan(
+            Selection(rename: true, Sub("sn-new", "10.90.77.0/24")),
+            Target(linkedTo: VNetA));
+
+        Assert.False(item.WillRename);
+        Assert.Empty(item.Errors);
+    }
+
+    /// <summary>An empty target is still renamed when asked - the top-up guard must not disable it.</summary>
+    [Fact]
+    public void AnEmptyTargetIsStillRenamedWhenRequested()
+    {
+        BulkImportPlanItem item = Plan(
+            Selection(rename: true, Sub("sn-new", "10.90.77.0/24")),
+            new ExistingSubnetSnapshot
+            {
+                Id = 1,
+                Name = "some-old-name",
+                NetworkAddress = "10.90.0.0",
+                Cidr = 16,
+                AzureResourceId = VNetA,
+                HasChildSubnets = false
+            });
+
+        Assert.True(item.WillRename);
+        Assert.Equal("vnet-a", item.NewName);
+    }
+
+    // -------------------------------------------------------------------------
+    // The preview must not describe a top-up as a first import
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ThePreviewSaysItIsAddingToAnExistingSubnet_NotImportingIntoIt()
+    {
+        BulkAzureVNetViewModel vnet = new()
+        {
+            ResourceId = VNetA,
+            Name = "vnet-a",
+            Ipv4AddressPrefixes = ["10.90.0.0/16"],
+            Subnets =
+            [
+                new BulkAzureSubnetViewModel
+                {
+                    ResourceId = $"{VNetA}/subnets/sn-new",
+                    Name = "sn-new",
+                    AddressPrefix = "10.90.77.0/24",
+                    Ipv4AddressPrefixes = ["10.90.77.0/24"]
+                }
+            ]
+        };
+
+        _planner.AnnotateAvailability([vnet], [Target(linkedTo: VNetA)]);
+
+        BulkAzurePrefixViewModel prefix = vnet.Prefixes[0];
+        Assert.True(prefix.IsSelectable);
+        Assert.Equal(BulkImportAvailability.WillUpdateExisting, prefix.Status);
+        Assert.Contains("add any missing subnets", prefix.Reason);
+    }
+
+    [Fact]
+    public void AnEmptyTargetKeepsTheFirstImportWording()
+    {
+        BulkAzureVNetViewModel vnet = new()
+        {
+            ResourceId = VNetA,
+            Name = "vnet-a",
+            Ipv4AddressPrefixes = ["10.90.0.0/16"],
+            Subnets = []
+        };
+
+        _planner.AnnotateAvailability([vnet], [Target(linkedTo: VNetA, hasChildren: false)]);
+
+        Assert.Contains("Will import into existing", vnet.Prefixes[0].Reason);
+    }
+}

--- a/test/Bastet.Tests/Azure/AzureMultiPrefixImportCommitTests.cs
+++ b/test/Bastet.Tests/Azure/AzureMultiPrefixImportCommitTests.cs
@@ -121,8 +121,8 @@ public class AzureMultiPrefixImportCommitTests : IDisposable
 
         // The names must differ, and each must name its own range.
         Assert.Equal(2, created.Select(s => s.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count());
-        Assert.Equal("sn-multi (10.31.0.0/24)", created[0].Name);
-        Assert.Equal("sn-multi (10.31.1.0/24)", created[1].Name);
+        Assert.Equal("sn-multi (10.31.0.0-24)", created[0].Name);
+        Assert.Equal("sn-multi (10.31.1.0-24)", created[1].Name);
 
         // Both stay linked to the one Azure subnet they came from.
         Assert.All(created, s => Assert.Equal(SubnetResourceId, s.AzureResourceId));

--- a/test/Bastet.Tests/Azure/AzureMultiPrefixSubnetTests.cs
+++ b/test/Bastet.Tests/Azure/AzureMultiPrefixSubnetTests.cs
@@ -275,7 +275,7 @@ public class AzureMultiPrefixSubnetTests
         ];
 
         AzureReconcilePlanViewModel plan =
-            new AzureReconciler().BuildPlan(SubId, "Test Sub", inventory, linked);
+            new AzureReconciler(new IpUtilityService()).BuildPlan(SubId, "Test Sub", inventory, linked, []);
 
         Assert.Empty(plan.Items);
     }
@@ -306,7 +306,7 @@ public class AzureMultiPrefixSubnetTests
         ];
 
         AzureReconcilePlanViewModel plan =
-            new AzureReconciler().BuildPlan(SubId, "Test Sub", inventory, linked);
+            new AzureReconciler(new IpUtilityService()).BuildPlan(SubId, "Test Sub", inventory, linked, []);
 
         Assert.Equal(AzureReconcileStatus.SubnetPrefixChanged, Assert.Single(plan.Items).Status);
     }

--- a/test/Bastet.Tests/Azure/AzureMultiPrefixSubnetTests.cs
+++ b/test/Bastet.Tests/Azure/AzureMultiPrefixSubnetTests.cs
@@ -139,7 +139,7 @@ public class AzureMultiPrefixSubnetTests
         Assert.Equal(2, item.ChildSubnets.Count);
 
         Assert.Equal(
-            ["sn-multi (10.31.0.0/24)", "sn-multi (10.31.1.0/24)"],
+            ["sn-multi (10.31.0.0-24)", "sn-multi (10.31.1.0-24)"],
             item.ChildSubnets.Select(c => c.Name).Order());
 
         // Both keep the true Azure name and the true Azure resource id.
@@ -204,7 +204,7 @@ public class AzureMultiPrefixSubnetTests
         // 10.31.0.0/24 has already been imported from this very Azure subnet.
         List<ExistingSubnetSnapshot> existing =
         [
-            new() { Id = 7, Name = "sn-multi (10.31.0.0/24)", NetworkAddress = "10.31.0.0", Cidr = 24, AzureResourceId = id }
+            new() { Id = 7, Name = "sn-multi (10.31.0.0-24)", NetworkAddress = "10.31.0.0", Cidr = 24, AzureResourceId = id }
         ];
 
         _planner.AnnotateAvailability([InventoryVNet([.. rows])], existing);
@@ -267,7 +267,7 @@ public class AzureMultiPrefixSubnetTests
             new()
             {
                 Id = 7,
-                Name = "sn-multi (10.31.1.0/24)",
+                Name = "sn-multi (10.31.1.0-24)",
                 NetworkAddress = "10.31.1.0",
                 Cidr = 24,
                 AzureResourceId = id

--- a/test/Bastet.Tests/Azure/AzureReconcilerInboundTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerInboundTests.cs
@@ -1,0 +1,283 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// The inbound direction. Every other reconcile verdict starts from a BASTET row and asks what Azure
+/// says about it, so a range Azure has assigned that BASTET has no row for was invisible to all of
+/// them: the scan reported nothing while the parent's Details page offered the range as free space
+/// with a Create Subnet button over it.
+///
+/// The false-positive tests carry as much weight as the positive one. An inbound report that fires
+/// on ranges BASTET legitimately accounts for is a warning operators learn to ignore, which is worse
+/// than no warning at all.
+/// </summary>
+public class AzureReconcilerInboundTests
+{
+    private const string SubId = "11111111-1111-1111-1111-111111111111";
+
+    private readonly AzureReconciler _reconciler = new(new IpUtilityService());
+
+    private static string VNetId(string name) =>
+        $"/subscriptions/{SubId}/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/{name}";
+
+    private static string SubnetId(string vnetName, string subnetName) =>
+        $"{VNetId(vnetName)}/subnets/{subnetName}";
+
+    private static BulkAzureSubnetViewModel AzSubnet(string vnetName, string name, params string[] prefixes) =>
+        new()
+        {
+            ResourceId = SubnetId(vnetName, name),
+            Name = name,
+            AddressPrefix = prefixes[0],
+            Ipv4AddressPrefixes = [.. prefixes]
+        };
+
+    private static BulkAzureVNetViewModel VNet(string name, string[] prefixes, params BulkAzureSubnetViewModel[] subnets) =>
+        new()
+        {
+            ResourceId = VNetId(name),
+            Name = name,
+            Ipv4AddressPrefixes = [.. prefixes],
+            Subnets = [.. subnets]
+        };
+
+    private static AzureVNetInventory Live(params BulkAzureVNetViewModel[] vnets) =>
+        new() { Success = true, VNets = [.. vnets] };
+
+    private static ExistingSubnetSnapshot Existing(
+        int id, string network, int cidr, string? azureResourceId = null) =>
+        new()
+        {
+            Id = id,
+            Name = $"subnet-{id}",
+            NetworkAddress = network,
+            Cidr = cidr,
+            AzureResourceId = azureResourceId
+        };
+
+    /// <summary>The target row an import creates, which is what marks a VNet as imported.</summary>
+    private static ExistingSubnetSnapshot Target(int id, string network, int cidr, string vnetName) =>
+        Existing(id, network, cidr, VNetId(vnetName));
+
+    private AzureReconcilePlanViewModel Build(
+        AzureVNetInventory inventory,
+        IReadOnlyList<ExistingSubnetSnapshot> existing,
+        params AzureLinkedSubnetSnapshot[] linked) =>
+        _reconciler.BuildPlan(SubId, "Test Sub", inventory, linked, existing);
+
+    private static List<AzureReconcileItem> Inbound(AzureReconcilePlanViewModel plan) =>
+        [.. plan.ReviewItems.Where(i => i.Status == AzureReconcileStatus.AzureRangeNotImported)];
+
+    // -------------------------------------------------------------------------
+    // The defect
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Azure adds a prefix to a subnet in an imported VNet - routine since multi-prefix subnets went
+    /// GA. Nothing in BASTET records it, so the free-space table hands it out.
+    /// </summary>
+    [Fact]
+    public void ARangeAzureAssignedThatNoBastetSubnetRecords_IsReported()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"],
+                AzSubnet("vnet-a", "sn-multi", "10.90.200.0/25", "10.90.77.0/24"))),
+            [Target(1, "10.90.0.0", 16, "vnet-a"), Existing(2, "10.90.200.0", 25, SubnetId("vnet-a", "sn-multi"))]);
+
+        AzureReconcileItem item = Assert.Single(Inbound(plan));
+        Assert.Equal("10.90.77.0", item.NetworkAddress);
+        Assert.Equal(24, item.Cidr);
+        Assert.Contains("no BASTET subnet records", item.Reason);
+        Assert.Contains("free space", item.Reason);
+    }
+
+    /// <summary>Report-only. There is no BASTET row to delete, and nothing here may ever be one.</summary>
+    [Fact]
+    public void AnInboundReportIsNeverOfferedForDeletion()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"], AzSubnet("vnet-a", "sn-new", "10.90.77.0/24"))),
+            [Target(1, "10.90.0.0", 16, "vnet-a")]);
+
+        Assert.Single(Inbound(plan));
+        Assert.Empty(plan.Items);
+        Assert.Equal(0, Assert.Single(Inbound(plan)).SubnetId);
+    }
+
+    /// <summary>
+    /// The scan can no longer claim a clean bill while an Azure range is unaccounted for - the
+    /// review list is one of the things the "nothing to clean up" banner is gated on.
+    /// </summary>
+    [Fact]
+    public void AnInboundReportMeansTheScanHasSomethingToReport()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"], AzSubnet("vnet-a", "sn-new", "10.90.77.0/24"))),
+            [Target(1, "10.90.0.0", 16, "vnet-a")]);
+
+        Assert.NotEmpty(plan.ReviewItems);
+    }
+
+    // -------------------------------------------------------------------------
+    // False positives - each of these would make the report worthless
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// An IPAM routinely records a coarser allocation than Azure carves out of it. Bastet holds
+    /// 10.90.64.0/18; Azure creates 10.90.77.0/24 inside it. That range IS accounted for.
+    /// Equality matching would report it forever.
+    /// </summary>
+    [Fact]
+    public void ARangeContainedByACoarserBastetSubnet_IsNotReported()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"], AzSubnet("vnet-a", "sn-new", "10.90.77.0/24"))),
+            [Target(1, "10.90.0.0", 16, "vnet-a"), Existing(2, "10.90.64.0", 18)]);
+
+        Assert.Empty(Inbound(plan));
+    }
+
+    /// <summary>
+    /// The correction that killed the finder's original proposal: only the two import paths ever
+    /// write AzureResourceId, so a range the operator created by hand is absent from the linked
+    /// rows. Matching against linked subnets alone would report it forever, after they had already
+    /// done exactly what the report asked for.
+    /// </summary>
+    [Fact]
+    public void ARangeCreatedByHandCarryingNoAzureLink_IsNotReported()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"], AzSubnet("vnet-a", "sn-new", "10.90.77.0/24"))),
+            [Target(1, "10.90.0.0", 16, "vnet-a"), Existing(2, "10.90.77.0", 24, azureResourceId: null)]);
+
+        Assert.Empty(Inbound(plan));
+    }
+
+    [Fact]
+    public void ARangeRecordedExactly_IsNotReported()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"], AzSubnet("vnet-a", "sn-a", "10.90.1.0/24"))),
+            [Target(1, "10.90.0.0", 16, "vnet-a"), Existing(2, "10.90.1.0", 24, SubnetId("vnet-a", "sn-a"))]);
+
+        Assert.Empty(Inbound(plan));
+    }
+
+    /// <summary>
+    /// Scoping. Without it, pointing the scan at a subscription BASTET has never imported produces
+    /// an item per Azure subnet on every scan - noise that buries the real reports.
+    /// </summary>
+    [Fact]
+    public void AVNetThatWasNeverImported_ProducesNoInboundReports()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(
+                VNet("vnet-imported", ["10.90.0.0/16"], AzSubnet("vnet-imported", "sn-a", "10.90.1.0/24")),
+                VNet("vnet-untouched", ["10.99.0.0/16"],
+                    AzSubnet("vnet-untouched", "sn-x", "10.99.1.0/24"),
+                    AzSubnet("vnet-untouched", "sn-y", "10.99.2.0/24"))),
+            [Target(1, "10.90.0.0", 16, "vnet-imported"), Existing(2, "10.90.1.0", 24, SubnetId("vnet-imported", "sn-a"))]);
+
+        Assert.Empty(Inbound(plan));
+    }
+
+    /// <summary>Only the unaccounted prefix of a multi-prefix subnet is reported, not the whole subnet.</summary>
+    [Fact]
+    public void OnlyTheUnaccountedPrefixOfAMultiPrefixSubnetIsReported()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"],
+                AzSubnet("vnet-a", "sn-multi", "10.90.1.0/24", "10.90.2.0/24", "10.90.3.0/24"))),
+            [
+                Target(1, "10.90.0.0", 16, "vnet-a"),
+                Existing(2, "10.90.1.0", 24, SubnetId("vnet-a", "sn-multi")),
+                Existing(3, "10.90.2.0", 24, SubnetId("vnet-a", "sn-multi"))
+            ]);
+
+        AzureReconcileItem item = Assert.Single(Inbound(plan));
+        Assert.Equal("10.90.3.0", item.NetworkAddress);
+    }
+
+    /// <summary>
+    /// An Azure subnet covering a whole VNet prefix is recorded by marking the TARGET fully
+    /// allocated, not by creating a child - so the target genuinely is the record of that range and
+    /// an exact match against it must count, even though a target's containment does not.
+    /// </summary>
+    [Fact]
+    public void AnAzureSubnetCoveringTheWholeVNetPrefix_IsAccountedForByTheTargetItself()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"], AzSubnet("vnet-a", "sn-whole", "10.90.0.0/16"))),
+            [Target(1, "10.90.0.0", 16, "vnet-a")]);
+
+        Assert.Empty(Inbound(plan));
+    }
+
+    /// <summary>
+    /// The counterpart, and the reason a target's containment cannot count: the target holds the
+    /// whole VNet prefix, so if containment by a target were enough, nothing inside any imported
+    /// VNet could ever be reported and this whole check would be vacuous.
+    /// </summary>
+    [Fact]
+    public void ATargetContainingTheRangeIsNotEnough_OrTheCheckWouldBeVacuous()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"], AzSubnet("vnet-a", "sn-new", "10.90.77.0/24"))),
+            // The target contains 10.90.77.0/24 by construction. Nothing else records it.
+            [Target(1, "10.90.0.0", 16, "vnet-a")]);
+
+        Assert.Single(Inbound(plan));
+    }
+
+    /// <summary>
+    /// The real inventory shape, which a hand-built fixture hides. GetVNetInventory emits one row
+    /// per prefix for a multi-prefix Azure subnet and every row carries the COMPLETE prefix list, so
+    /// walking rows x prefixes visits an n-prefix subnet n^2 times. Caught live: a three-prefix
+    /// subnet reported its one unaccounted range three times.
+    /// </summary>
+    [Fact]
+    public void TheRealMultiPrefixInventoryShape_ReportsEachRangeExactlyOnce()
+    {
+        // Three rows for one Azure subnet, each carrying all three prefixes - exactly what
+        // AzureService.BuildInventorySubnetRows produces.
+        string[] all = ["10.90.200.0/25", "10.90.200.128/25", "10.90.77.0/24"];
+        BulkAzureSubnetViewModel Row(string primary) => new()
+        {
+            ResourceId = SubnetId("vnet-a", "sn-multi"),
+            Name = "sn-multi",
+            AddressPrefix = primary,
+            Ipv4AddressPrefixes = [.. all]
+        };
+
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.90.0.0/16"], Row(all[0]), Row(all[1]), Row(all[2]))),
+            [
+                Target(1, "10.90.0.0", 16, "vnet-a"),
+                Existing(2, "10.90.200.0", 25, SubnetId("vnet-a", "sn-multi")),
+                Existing(3, "10.90.200.128", 25, SubnetId("vnet-a", "sn-multi"))
+            ]);
+
+        AzureReconcileItem item = Assert.Single(Inbound(plan));
+        Assert.Equal("10.90.77.0", item.NetworkAddress);
+    }
+
+    /// <summary>
+    /// A failed scan establishes nothing about Azure, so it must not produce inbound reports either -
+    /// the same fail-closed rule the deletion path has always had.
+    /// </summary>
+    [Fact]
+    public void AFailedScan_ProducesNoInboundReports()
+    {
+        AzureReconcilePlanViewModel plan = _reconciler.BuildPlan(
+            SubId, "Test Sub",
+            new AzureVNetInventory { Success = false, ErrorMessage = "boom" },
+            [],
+            [Target(1, "10.90.0.0", 16, "vnet-a")]);
+
+        Assert.Empty(plan.ReviewItems);
+        Assert.Empty(plan.Items);
+    }
+}

--- a/test/Bastet.Tests/Azure/AzureReconcilerRangeStillAllocatedTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerRangeStillAllocatedTests.cs
@@ -1,4 +1,5 @@
 using Bastet.Models.ViewModels;
+using Bastet.Services;
 using Bastet.Services.Azure;
 
 namespace Bastet.Tests.Azure;
@@ -17,7 +18,7 @@ public class AzureReconcilerRangeStillAllocatedTests
 {
     private const string SubId = "11111111-1111-1111-1111-111111111111";
 
-    private readonly AzureReconciler _reconciler = new();
+    private readonly AzureReconciler _reconciler = new(new IpUtilityService());
 
     private static string VNetId(string name) =>
         $"/subscriptions/{SubId}/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/{name}";
@@ -61,7 +62,7 @@ public class AzureReconcilerRangeStillAllocatedTests
 
     private AzureReconcilePlanViewModel Build(
         AzureVNetInventory inventory, params AzureLinkedSubnetSnapshot[] linked) =>
-        _reconciler.BuildPlan(SubId, "Test Sub", inventory, linked);
+        _reconciler.BuildPlan(SubId, "Test Sub", inventory, linked, []);
 
     // -------------------------------------------------------------------------
     // The defect - a range still assigned in Azure must never be offered for deletion

--- a/test/Bastet.Tests/Azure/AzureReconcilerRangeStillAllocatedTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerRangeStillAllocatedTests.cs
@@ -1,0 +1,218 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services.Azure;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// Azure has no subnet rename, so re-organising one means delete-and-recreate. The reconciler keys
+/// only on the recorded ARM resource id, so the Bastet row goes stale while the range it records is
+/// still assigned in Azure under a new id - and archiving it makes BASTET advertise an allocated
+/// range as free space with a Create Subnet button over it.
+///
+/// The counter-tests matter as much as the positives: a genuinely deleted resource must STILL be
+/// offered and deletable, and overlapping RFC1918 space in another VNet must not withhold anything.
+/// An over-blocking reconciler is a different defect, not a fix.
+/// </summary>
+public class AzureReconcilerRangeStillAllocatedTests
+{
+    private const string SubId = "11111111-1111-1111-1111-111111111111";
+
+    private readonly AzureReconciler _reconciler = new();
+
+    private static string VNetId(string name) =>
+        $"/subscriptions/{SubId}/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/{name}";
+
+    private static string SubnetId(string vnetName, string subnetName) =>
+        $"{VNetId(vnetName)}/subnets/{subnetName}";
+
+    private static BulkAzureSubnetViewModel AzSubnet(string vnetName, string name, params string[] prefixes) =>
+        new()
+        {
+            ResourceId = SubnetId(vnetName, name),
+            Name = name,
+            AddressPrefix = prefixes[0],
+            Ipv4AddressPrefixes = [.. prefixes]
+        };
+
+    private static BulkAzureVNetViewModel VNet(string name, string[] prefixes, params BulkAzureSubnetViewModel[] subnets) =>
+        new()
+        {
+            ResourceId = VNetId(name),
+            Name = name,
+            Ipv4AddressPrefixes = [.. prefixes],
+            Subnets = [.. subnets]
+        };
+
+    private static AzureVNetInventory Live(params BulkAzureVNetViewModel[] vnets) =>
+        new() { Success = true, VNets = [.. vnets] };
+
+    private static AzureLinkedSubnetSnapshot Linked(
+        int id, string name, string network, int cidr, string azureResourceId,
+        int[]? descendantIds = null) =>
+        new()
+        {
+            Id = id,
+            Name = name,
+            NetworkAddress = network,
+            Cidr = cidr,
+            AzureResourceId = azureResourceId,
+            DescendantSubnetIds = descendantIds ?? []
+        };
+
+    private AzureReconcilePlanViewModel Build(
+        AzureVNetInventory inventory, params AzureLinkedSubnetSnapshot[] linked) =>
+        _reconciler.BuildPlan(SubId, "Test Sub", inventory, linked);
+
+    // -------------------------------------------------------------------------
+    // The defect - a range still assigned in Azure must never be offered for deletion
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Route A: sn-a deleted and recreated as sn-a2 carrying the same prefix. The resource id is
+    /// genuinely gone, so SubnetDeleted is literally true - but the /24 is still assigned.
+    /// </summary>
+    [Fact]
+    public void SubnetDeleted_ButTheRangeIsStillAssignedInTheSameVNet_IsWithheldAndReviewable()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.111.0.0/16"], AzSubnet("vnet-a", "sn-a2", "10.111.5.0/24"))),
+            Linked(2, "app", "10.111.5.0", 24, SubnetId("vnet-a", "sn-a")));
+
+        Assert.Empty(plan.Items);
+
+        AzureReconcileItem review = Assert.Single(plan.ReviewItems);
+        Assert.Equal(AzureReconcileStatus.RangeStillAllocatedInAzure, review.Status);
+        Assert.Contains("sn-a2", review.Reason);
+        Assert.Contains("10.111.5.0/24", review.Reason);
+    }
+
+    /// <summary>Route B: the prefix moved to a different Azure subnet. No ARM read stands behind
+    /// this status at all, so it reaches the same wrong output with even less friction.</summary>
+    [Fact]
+    public void SubnetPrefixChanged_ButTheRangeMovedToAnotherAzureSubnet_IsWithheldAndReviewable()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.111.0.0/16"],
+                AzSubnet("vnet-a", "sn-a", "10.111.9.0/24"),
+                AzSubnet("vnet-a", "sn-b", "10.111.5.0/24"))),
+            Linked(2, "app", "10.111.5.0", 24, SubnetId("vnet-a", "sn-a")));
+
+        Assert.Empty(plan.Items);
+        Assert.Equal(AzureReconcileStatus.RangeStillAllocatedInAzure, Assert.Single(plan.ReviewItems).Status);
+    }
+
+    /// <summary>The operator must be told, not just silently denied the deletion.</summary>
+    [Fact]
+    public void AWithheldRange_ProducesAWarningNamingTheAzureSubnetThatHoldsIt()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.111.0.0/16"], AzSubnet("vnet-a", "sn-a2", "10.111.5.0/24"))),
+            Linked(2, "app", "10.111.5.0", 24, SubnetId("vnet-a", "sn-a")));
+
+        Assert.Contains(plan.Warnings, w =>
+            w.Contains("still assigned in Azure") && w.Contains("sn-a2"));
+    }
+
+    /// <summary>A VNet-level target whose prefix is still carved up in Azure is the same defect one
+    /// level up: the VNet address prefix is gone, but a subnet still holds the exact range.</summary>
+    [Fact]
+    public void VNetPrefixRemoved_ButTheRangeIsStillAssignedToASubnet_IsWithheld()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.200.0.0/16"], AzSubnet("vnet-a", "sn-x", "10.111.0.0/16"))),
+            Linked(1, "target", "10.111.0.0", 16, VNetId("vnet-a")));
+
+        Assert.Empty(plan.Items);
+        Assert.Equal(AzureReconcileStatus.RangeStillAllocatedInAzure, Assert.Single(plan.ReviewItems).Status);
+    }
+
+    // -------------------------------------------------------------------------
+    // Counter-tests - the reconciler must still DISCRIMINATE, not merely block
+    // -------------------------------------------------------------------------
+
+    /// <summary>The whole point of the feature. A genuinely deleted subnet whose range nothing in
+    /// Azure holds any more must still be offered for deletion.</summary>
+    [Fact]
+    public void SubnetDeleted_AndTheRangeIsAssignedNowhere_IsStillOfferedForDeletion()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.111.0.0/16"], AzSubnet("vnet-a", "other", "10.111.9.0/24"))),
+            Linked(2, "app", "10.111.5.0", 24, SubnetId("vnet-a", "sn-a")));
+
+        AzureReconcileItem item = Assert.Single(plan.Items);
+        Assert.Equal(AzureReconcileStatus.SubnetDeleted, item.Status);
+        Assert.Empty(plan.ReviewItems);
+    }
+
+    /// <summary>
+    /// Overlapping RFC1918 across unrelated VNets is the norm - the audit rig itself ships
+    /// 10.10.0.0/16 and 10.10.0.0/20 in one subscription. Matching on the bare prefix string would
+    /// withhold genuinely stale rows on the strength of an unrelated VNet's address space.
+    /// </summary>
+    [Fact]
+    public void TheSameRangeAllocatedInADifferentVNet_DoesNotWithholdTheDeletion()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(
+                VNet("vnet-a", ["10.111.0.0/16"]),
+                VNet("vnet-b", ["10.111.0.0/16"], AzSubnet("vnet-b", "sn-elsewhere", "10.111.5.0/24"))),
+            Linked(2, "app", "10.111.5.0", 24, SubnetId("vnet-a", "sn-a")));
+
+        Assert.Equal(AzureReconcileStatus.SubnetDeleted, Assert.Single(plan.Items).Status);
+        Assert.Empty(plan.ReviewItems);
+    }
+
+    /// <summary>
+    /// The index must accumulate, never ToDictionary: one prefix string legitimately has several
+    /// owners across a subscription. A duplicate-key throw here turns every scan of a subscription
+    /// with duplicated private space into "The reconcile scan failed" - the failure mode
+    /// AzureReconciler.cs already avoids at the subnet-prefix index for exactly this reason.
+    /// </summary>
+    [Fact]
+    public void DuplicateRangesAcrossVNets_DoNotThrow()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(
+                VNet("vnet-a", ["10.10.0.0/16"], AzSubnet("vnet-a", "sn-1", "10.10.1.0/24")),
+                VNet("vnet-b", ["10.10.0.0/20"], AzSubnet("vnet-b", "sn-2", "10.10.1.0/24")),
+                VNet("vnet-c", ["10.10.0.0/16"], AzSubnet("vnet-c", "sn-3", "10.10.1.0/24"))),
+            Linked(5, "unrelated", "192.168.0.0", 24, SubnetId("vnet-a", "gone")));
+
+        Assert.True(plan.ScanSucceeded);
+        Assert.Empty(plan.GlobalErrors);
+    }
+
+    /// <summary>A live row is still live - the new index must not turn a healthy subnet into an item.</summary>
+    [Fact]
+    public void ASubnetThatStillExistsWithItsRecordedPrefix_IsReportedNowhere()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.111.0.0/16"], AzSubnet("vnet-a", "sn-a", "10.111.5.0/24"))),
+            Linked(2, "app", "10.111.5.0", 24, SubnetId("vnet-a", "sn-a")));
+
+        Assert.Empty(plan.Items);
+        Assert.Empty(plan.ReviewItems);
+        Assert.Empty(plan.Warnings);
+    }
+
+    /// <summary>
+    /// A withheld row must also protect its ancestors: approving a target archives the whole
+    /// subtree, so an ancestor whose cascade would take a still-allocated row must come off the
+    /// list too. This is what ApplyConfirmations' withheld set already does for ReviewItems.
+    /// </summary>
+    [Fact]
+    public void AnAncestorWhoseCascadeWouldArchiveAWithheldRow_IsAlsoWithheld()
+    {
+        AzureReconcilePlanViewModel plan = Build(
+            Live(VNet("vnet-a", ["10.111.0.0/16"], AzSubnet("vnet-a", "sn-a2", "10.111.5.0/24"))),
+            // the target: its VNet prefix is gone from Azure, so it is genuinely stale...
+            Linked(1, "target", "10.99.0.0", 16, VNetId("vnet-a"), descendantIds: [2]),
+            // ...but archiving it would take the child whose range Azure still holds
+            Linked(2, "app", "10.111.5.0", 24, SubnetId("vnet-a", "sn-a")));
+
+        _reconciler.ApplyConfirmations(plan, new Dictionary<string, AzureResourceConfirmation>());
+
+        Assert.Empty(plan.Items);
+        Assert.Contains(plan.Warnings, w => w.Contains("withheld from deletion"));
+    }
+}

--- a/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
+++ b/test/Bastet.Tests/Azure/AzureReconcilerTests.cs
@@ -1,4 +1,5 @@
 using Bastet.Models.ViewModels;
+using Bastet.Services;
 using Bastet.Services.Azure;
 
 namespace Bastet.Tests.Azure;
@@ -15,7 +16,7 @@ public class AzureReconcilerTests
 
     private readonly AzureReconciler _reconciler;
 
-    public AzureReconcilerTests() => _reconciler = new AzureReconciler();
+    public AzureReconcilerTests() => _reconciler = new AzureReconciler(new IpUtilityService());
 
     // -------------------------------------------------------------------------
     // Builders
@@ -74,7 +75,7 @@ public class AzureReconcilerTests
 
     private AzureReconcilePlanViewModel Build(
         AzureVNetInventory inventory, params AzureLinkedSubnetSnapshot[] linked) =>
-        _reconciler.BuildPlan(SubId, "Test Sub", inventory, linked);
+        _reconciler.BuildPlan(SubId, "Test Sub", inventory, linked, []);
 
     // -------------------------------------------------------------------------
     // Fail closed - the safety property the whole feature rests on
@@ -655,7 +656,7 @@ public class AzureReconcilerTests
     public void NoSubscriptionSpecified_HardFails()
     {
         AzureReconcilePlanViewModel plan = _reconciler.BuildPlan(
-            string.Empty, null, Live(), [Linked(1, "vnet-a", "10.0.0.0", 16, VNetId("vnet-a"))]);
+            string.Empty, null, Live(), [Linked(1, "vnet-a", "10.0.0.0", 16, VNetId("vnet-a"))], []);
 
         Assert.False(plan.CanCommit);
         Assert.Contains(plan.GlobalErrors, e => e.Contains("No subscription"));

--- a/test/Bastet.Tests/Azure/GeneratedNameSafeTextTests.cs
+++ b/test/Bastet.Tests/Azure/GeneratedNameSafeTextTests.cs
@@ -1,0 +1,118 @@
+using Bastet.Controllers;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Security;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// The guard that was missing. `SubnetNamingSafeTextTests` pins `ToSafeText` character by character,
+/// but nothing asserted that a name the application GENERATES satisfies the application's own input
+/// rules - which is exactly how round 13 reintroduced the "/" that round 4 removed.
+///
+/// The consequence was not cosmetic: the Details page's Create Subnet button prefills the child name
+/// from its parent through `SubnetNaming.ToSafeText`, which DELETES a forbidden character rather than
+/// rejecting it, so "(10.20.40.0/24)" silently became the false token "(10.20.40.024)" and an
+/// operator accepting the default persisted it.
+/// </summary>
+public class GeneratedNameSafeTextTests
+{
+    private const string VNetA = "/subscriptions/test/providers/Microsoft.Network/virtualNetworks/vnet-a";
+    private const string MultiPrefixSubnet = $"{VNetA}/subnets/sn-multi";
+
+    private readonly IInputSanitizationService _sanitizer = new InputSanitizationService();
+
+    private static BulkImportSelectedSubnetDto Sub(string name, string prefix) =>
+        new() { Name = name, AddressPrefix = prefix, AzureResourceId = MultiPrefixSubnet };
+
+    /// <summary>
+    /// Every child name the bulk planner produces must be a name the Create form would accept.
+    /// This is the assertion whose absence let the character back in.
+    /// </summary>
+    [Fact]
+    public void EveryNameTheBulkPlannerGenerates_SatisfiesTheAppsOwnInputRules()
+    {
+        AzureBulkImportPlanner planner = new(new IpUtilityService(), _sanitizer);
+
+        BulkImportPlanViewModel plan = planner.BuildPlan(
+            new BulkImportSelectionDto
+            {
+                SubscriptionId = "sub-1",
+                VNetPrefixes =
+                [
+                    new BulkImportSelectedVNetPrefixDto
+                    {
+                        VNetName = "vnet-a",
+                        VNetResourceId = VNetA,
+                        AddressPrefix = "10.20.0.0/16",
+                        Subnets =
+                        [
+                            Sub("sn-multi", "10.20.40.0/24"),
+                            Sub("sn-multi", "10.20.5.0/24"),
+                            Sub("sn-multi", "10.20.20.0/24")
+                        ]
+                    }
+                ]
+            },
+            []);
+
+        List<string> generated =
+        [
+            .. plan.Items.SelectMany(i => i.ChildSubnets).Select(c => c.Name),
+            .. plan.Items.Select(i => i.AutoCreateTargetName).Where(n => !string.IsNullOrEmpty(n)).Select(n => n!)
+        ];
+
+        Assert.NotEmpty(generated);
+
+        foreach (string name in generated)
+        {
+            Assert.True(_sanitizer.IsSafeText(name),
+                $"The planner generated '{name}', which the app's own [SafeText] rules reject.");
+        }
+    }
+
+    /// <summary>The same guard over the single-VNet wizard's server-side name resolution.</summary>
+    [Fact]
+    public void EveryNameResolveImportNamesGenerates_SatisfiesTheAppsOwnInputRules()
+    {
+        List<AzureImportSubnetViewModel> subnets =
+        [
+            new() { Name = "sn-multi", NetworkAddress = "10.20.40.0", Cidr = 24, AzureResourceId = MultiPrefixSubnet },
+            new() { Name = "sn-multi", NetworkAddress = "10.20.5.0", Cidr = 24, AzureResourceId = MultiPrefixSubnet },
+            new() { Name = "sn-multi", NetworkAddress = "10.20.20.0", Cidr = 24, AzureResourceId = MultiPrefixSubnet }
+        ];
+
+        Dictionary<int, string> names = SubnetController.ResolveImportNames(subnets);
+
+        Assert.Equal(3, names.Count);
+
+        foreach (string name in names.Values)
+        {
+            Assert.True(_sanitizer.IsSafeText(name),
+                $"ResolveImportNames generated '{name}', which the app's own [SafeText] rules reject.");
+        }
+    }
+
+    /// <summary>
+    /// The prefill an operator actually sees. It composes the parent's name through ToSafeText, so a
+    /// generated parent name carrying a forbidden character loses it silently rather than being
+    /// rejected - which is what produced "(10.20.40.024)".
+    /// </summary>
+    [Theory]
+    [InlineData("sn-multi (10.20.40.0-24)")]
+    [InlineData("vnet-a (10.71.0.0-16)")]
+    public void AGeneratedParentNameSurvivesThePrefillIntact(string generatedParentName)
+    {
+        Assert.True(_sanitizer.IsSafeText(generatedParentName));
+        Assert.Equal(generatedParentName, SubnetNaming.ToSafeText(generatedParentName));
+    }
+
+    /// <summary>The character that caused it, pinned so its return is a test failure.</summary>
+    [Fact]
+    public void TheForwardSlashIsStillForbidden_SoTheSeparatorMayNotGoBack()
+    {
+        Assert.False(_sanitizer.IsSafeText("sn-multi (10.20.40.0/24)"));
+        Assert.Equal("sn-multi (10.20.40.024)", SubnetNaming.ToSafeText("sn-multi (10.20.40.0/24)"));
+    }
+}

--- a/test/Bastet.Tests/Azure/MultiPrefixResourceIdCasingTests.cs
+++ b/test/Bastet.Tests/Azure/MultiPrefixResourceIdCasingTests.cs
@@ -1,0 +1,99 @@
+using Bastet.Controllers;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Security;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// Both multi-prefix groupings key on an ARM resource ID with StringComparer.OrdinalIgnoreCase, then
+/// collected the result into a set built by a collection expression - which constructs a plain
+/// HashSet&lt;string&gt; with the DEFAULT comparer, silently discarding the case-insensitivity one line
+/// above. GroupBy keeps only the first member's spelling as its key, so a sibling row spelled
+/// ".../Subnets/..." failed the later Contains and kept its bare Azure name while its siblings were
+/// qualified for the range they hold.
+///
+/// ARM resource IDs are case-insensitive, so the differing spellings are legitimate; the trigger is a
+/// crafted or replayed post, which is precisely the case this naming code says it exists to handle.
+/// </summary>
+public class MultiPrefixResourceIdCasingTests
+{
+    private const string VNet = "/subscriptions/test/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet-a";
+    private const string Lower = $"{VNet}/subnets/sn-multi";
+    private static readonly string Upper = Lower.Replace("/subnets/", "/Subnets/");
+
+    // -------------------------------------------------------------------------
+    // The single-VNet wizard's server-side resolution
+    // -------------------------------------------------------------------------
+
+    private static AzureImportSubnetViewModel Row(string network, int cidr, string resourceId) =>
+        new() { Name = "sn-multi", NetworkAddress = network, Cidr = cidr, AzureResourceId = resourceId };
+
+    [Fact]
+    public void ResolveImportNames_QualifiesEveryRowWhateverTheResourceIdCasing()
+    {
+        Dictionary<int, string> names = SubnetController.ResolveImportNames(
+        [
+            Row("10.20.40.0", 24, Lower),
+            Row("10.20.5.0", 24, Upper),
+            Row("10.20.20.0", 24, Upper)
+        ]);
+
+        // Every row names the range it holds. Before the fix the rows spelled with the other casing
+        // fell out of the set: one kept the bare Azure name, and a later one was disambiguated by
+        // VNet name instead of by range - actively misleading about why it had been renamed.
+        Assert.Equal("sn-multi (10.20.40.0-24)", names[0]);
+        Assert.Equal("sn-multi (10.20.5.0-24)", names[1]);
+        Assert.Equal("sn-multi (10.20.20.0-24)", names[2]);
+    }
+
+    [Fact]
+    public void ResolveImportNames_IsUnaffectedWhenEverySpellingMatches()
+    {
+        Dictionary<int, string> names = SubnetController.ResolveImportNames(
+        [
+            Row("10.20.40.0", 24, Lower),
+            Row("10.20.5.0", 24, Lower)
+        ]);
+
+        Assert.Equal("sn-multi (10.20.40.0-24)", names[0]);
+        Assert.Equal("sn-multi (10.20.5.0-24)", names[1]);
+    }
+
+    // -------------------------------------------------------------------------
+    // The bulk planner's equivalent
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void TheBulkPlanner_QualifiesEveryChildWhateverTheResourceIdCasing()
+    {
+        AzureBulkImportPlanner planner = new(new IpUtilityService(), new InputSanitizationService());
+
+        BulkImportPlanViewModel plan = planner.BuildPlan(
+            new BulkImportSelectionDto
+            {
+                SubscriptionId = "sub-1",
+                VNetPrefixes =
+                [
+                    new BulkImportSelectedVNetPrefixDto
+                    {
+                        VNetName = "vnet-a",
+                        VNetResourceId = VNet,
+                        AddressPrefix = "10.20.0.0/16",
+                        Subnets =
+                        [
+                            new BulkImportSelectedSubnetDto { Name = "sn-multi", AddressPrefix = "10.20.40.0/24", AzureResourceId = Lower },
+                            new BulkImportSelectedSubnetDto { Name = "sn-multi", AddressPrefix = "10.20.5.0/24", AzureResourceId = Upper }
+                        ]
+                    }
+                ]
+            },
+            []);
+
+        List<string> names = [.. plan.Items.SelectMany(i => i.ChildSubnets).Select(c => c.Name)];
+
+        Assert.Contains("sn-multi (10.20.40.0-24)", names);
+        Assert.Contains("sn-multi (10.20.5.0-24)", names);
+    }
+}

--- a/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileScalingTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileScalingTests.cs
@@ -184,16 +184,20 @@ public class SubnetControllerAzureReconcileScalingTests : IDisposable
 
         await context.SaveChangesAsync(TestContext.Current.CancellationToken);
 
+        MockAzureService azure = new();
+        AzureSubnetSnapshotService snapshots = new(context);
+
         IActionResult result = await controller.BulkDeleteStaleAzureSubnets(
             new AzureReconcileDeleteDto
             {
                 SubscriptionId = SubId,
                 SubnetIds = targets,
-                Confirmation = "approved"
+                Confirmation = "approved",
+                Statuses = await AzureReconcileApproval.ForAsync(azure, snapshots, SubId, targets)
             },
-            new MockAzureService(),
+            azure,
             new AzureReconciler(),
-            new AzureSubnetSnapshotService(context));
+            snapshots);
 
         // An empty-but-successful Azure inventory means every VNet really is gone, so all of them
         // are archived. Asserted here so a failure inside the loop is not read as a scaling result.

--- a/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileScalingTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileScalingTests.cs
@@ -196,7 +196,7 @@ public class SubnetControllerAzureReconcileScalingTests : IDisposable
                 Statuses = await AzureReconcileApproval.ForAsync(azure, snapshots, SubId, targets)
             },
             azure,
-            new AzureReconciler(),
+            new AzureReconciler(new IpUtilityService()),
             snapshots);
 
         // An empty-but-successful Azure inventory means every VNet really is gone, so all of them

--- a/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileTests.cs
@@ -30,7 +30,7 @@ public class SubnetControllerAzureReconcileTests : IDisposable
 
     private readonly BastetDbContext _context;
     private readonly SubnetController _controller;
-    private readonly IAzureReconciler _reconciler = new AzureReconciler();
+    private readonly IAzureReconciler _reconciler = new AzureReconciler(new IpUtilityService());
     private readonly AzureSubnetSnapshotService _snapshotService;
 
     public SubnetControllerAzureReconcileTests()

--- a/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerAzureReconcileTests.cs
@@ -246,7 +246,13 @@ public class SubnetControllerAzureReconcileTests : IDisposable
     public async Task BulkDeleteStaleAzureSubnets_StaleSubnetCorrectlyConfirmed_DeletesAndArchives()
     {
         // An empty-but-successful inventory means the VNet really is gone.
-        IActionResult result = await Delete(Request("approved", 1), new MockAzureService());
+        MockAzureService azure = new();
+        AzureReconcileDeleteDto request = Request("approved", 1);
+        // Approve exactly what a scan reports, as the wizard does - the verdict is now part of the
+        // request and a batch that names none is refused.
+        request.Statuses = await AzureReconcileApproval.ForAsync(azure, _snapshotService, SubId, [1]);
+
+        IActionResult result = await Delete(request, azure);
 
         _ = Assert.IsType<OkObjectResult>(result);
 

--- a/test/Bastet.Tests/Azure/SubnetControllerReconcileApprovedVerdictTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerReconcileApprovedVerdictTests.cs
@@ -1,0 +1,250 @@
+using Bastet.Controllers;
+using Bastet.Data;
+using Bastet.Models;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Validation;
+using Bastet.Tests.TestHelpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// The reconcile commit re-derives Azure verdicts and archives whatever is still stale. Testing set
+/// membership is not the same as testing consent: a row approved under "the Azure resource no longer
+/// exists" can still be in the plan moments later under "the prefix changed" - a different fact,
+/// reached with no direct ARM read - and the subtree was archived on an approval whose stated
+/// premise the server had itself disproved.
+///
+/// The endpoint's own docstring promises "a resource that reappeared in Azure cannot cause the wrong
+/// subnets to be archived". These tests are that promise.
+/// </summary>
+[Collection(AzureFeatureFlagCollection.Name)]
+public class SubnetControllerReconcileApprovedVerdictTests : IDisposable
+{
+    private const string SubId = "11111111-1111-1111-1111-111111111111";
+    private const string VNetId =
+        $"/subscriptions/{SubId}/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet-a";
+
+    private readonly BastetDbContext _context;
+    private readonly SubnetController _controller;
+    private readonly IAzureReconciler _reconciler = new AzureReconciler();
+    private readonly AzureSubnetSnapshotService _snapshotService;
+
+    public SubnetControllerReconcileApprovedVerdictTests()
+    {
+        DbContextOptions<BastetDbContext> options = new DbContextOptionsBuilder<BastetDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        _context = new BastetDbContext(options);
+        _context.Database.OpenConnection();
+        _context.Database.EnsureCreated();
+
+        IIpUtilityService ipUtilityService = new IpUtilityService();
+        _snapshotService = new AzureSubnetSnapshotService(_context);
+
+        _controller = new SubnetController(
+            _context,
+            ipUtilityService,
+            new SubnetValidationService(ipUtilityService),
+            new HostIpValidationService(ipUtilityService, _context),
+            ControllerTestHelper.CreateMockUserContextService(),
+            ControllerTestHelper.CreateMockSubnetLockingService(),
+            NullLogger<SubnetController>.Instance);
+        ControllerTestHelper.SetupController(_controller);
+        _controller.Url = Mock.Of<IUrlHelper>();
+
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "true");
+
+        // The import target, plus a hand-created child and a host IP carrying no Azure provenance
+        // at all - the rows an archive on a disproved premise takes with it.
+        _context.Subnets.Add(new Subnet
+        {
+            Id = 1,
+            Name = "vnet-a",
+            NetworkAddress = "10.111.0.0",
+            Cidr = 16,
+            AzureResourceId = VNetId,
+            CreatedAt = DateTime.UtcNow
+        });
+        _context.Subnets.Add(new Subnet
+        {
+            Id = 2,
+            Name = "prod-app-tier",
+            NetworkAddress = "10.111.1.0",
+            Cidr = 24,
+            ParentSubnetId = 1,
+            CreatedAt = DateTime.UtcNow
+        });
+        _context.SaveChanges();
+        _context.HostIpAssignments.Add(new HostIpAssignment
+        {
+            SubnetId = 2,
+            IP = "10.111.1.10",
+            Name = "web01",
+            CreatedAt = DateTime.UtcNow
+        });
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", null);
+        _context.Database.CloseConnection();
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// The VNet is back at the same ARM id (ids are path-based, so an IaC destroy/apply recreates
+    /// the same id) but with a different prefix. The row is still stale - as VNetPrefixRemoved, a
+    /// drift verdict taken off the listing with no direct ARM read - not as VNetDeleted.
+    /// </summary>
+    private static MockAzureService VNetBackWithADifferentPrefix() =>
+        new(true,
+            vnets: [new AzureVNetViewModel { ResourceId = VNetId, Name = "vnet-a", AddressPrefixes = ["10.112.0.0/16"] }]);
+
+    private Task<IActionResult> Delete(AzureReconcileDeleteDto request, IAzureService azure) =>
+        _controller.BulkDeleteStaleAzureSubnets(request, azure, _reconciler, _snapshotService);
+
+    private static AzureReconcileDeleteDto Request(params AzureReconcileApprovedVerdict[] verdicts) =>
+        new()
+        {
+            SubscriptionId = SubId,
+            SubnetIds = [1],
+            Confirmation = "approved",
+            Statuses = [.. verdicts]
+        };
+
+    private async Task AssertNothingArchived()
+    {
+        Assert.NotNull(await _context.Subnets.FindAsync([1], TestContext.Current.CancellationToken));
+        Assert.NotNull(await _context.Subnets.FindAsync([2], TestContext.Current.CancellationToken));
+        Assert.Equal(1, await _context.HostIpAssignments.CountAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _context.DeletedSubnets.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    // -------------------------------------------------------------------------
+    // The defect
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Approved as "the VNet no longer exists"; by commit time the server itself says it does exist
+    /// and merely changed prefix. The id is still in the plan, so the existing membership check
+    /// passes it straight through.
+    /// </summary>
+    [Fact]
+    public async Task ApprovedAsDeleted_ButReDerivedAsDrift_IsRefusedAndArchivesNothing()
+    {
+        IActionResult result = await Delete(
+            Request(new AzureReconcileApprovedVerdict
+            {
+                SubnetId = 1,
+                StatusName = nameof(AzureReconcileStatus.VNetDeleted),
+                Reason = "The VNet this subnet was imported from no longer exists in Azure, or no longer has any IPv4 address space."
+            }),
+            VNetBackWithADifferentPrefix());
+
+        ConflictObjectResult conflict = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Contains("has changed since", conflict.Value?.ToString());
+        await AssertNothingArchived();
+    }
+
+    /// <summary>
+    /// Same status, different facts. Comparing the status alone would let this through, which is why
+    /// the reason is compared too.
+    /// </summary>
+    [Fact]
+    public async Task ApprovedWithTheSameStatusButADifferentReason_IsRefused()
+    {
+        IActionResult result = await Delete(
+            Request(new AzureReconcileApprovedVerdict
+            {
+                SubnetId = 1,
+                StatusName = nameof(AzureReconcileStatus.VNetPrefixRemoved),
+                Reason = "VNet 'vnet-a' still exists but no longer has the address prefix 10.99.0.0/16."
+            }),
+            VNetBackWithADifferentPrefix());
+
+        _ = Assert.IsType<ConflictObjectResult>(result);
+        await AssertNothingArchived();
+    }
+
+    // -------------------------------------------------------------------------
+    // Mandatory: an omitted or unusable verdict is not consent
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ARequestNamingNoVerdictAtAll_IsRefused()
+    {
+        _ = Assert.IsType<ConflictObjectResult>(await Delete(Request(), VNetBackWithADifferentPrefix()));
+        await AssertNothingArchived();
+    }
+
+    [Fact]
+    public async Task AVerdictForADifferentRow_DoesNotApproveThisOne()
+    {
+        IActionResult result = await Delete(
+            Request(new AzureReconcileApprovedVerdict
+            {
+                SubnetId = 99,
+                StatusName = nameof(AzureReconcileStatus.VNetPrefixRemoved),
+                Reason = "VNet 'vnet-a' still exists but no longer has the address prefix 10.111.0.0/16."
+            }),
+            VNetBackWithADifferentPrefix());
+
+        _ = Assert.IsType<ConflictObjectResult>(result);
+        await AssertNothingArchived();
+    }
+
+    /// <summary>
+    /// A status name that parses to nothing establishes nothing, so it is a divergence rather than
+    /// "unverified" - the same rule the bulk import commit applies to an unparseable TargetType.
+    /// </summary>
+    [Theory]
+    [InlineData("NotAStatus")]
+    [InlineData("")]
+    [InlineData("42")]
+    public async Task AnUnparseableStatusName_IsTreatedAsADivergence(string statusName)
+    {
+        IActionResult result = await Delete(
+            Request(new AzureReconcileApprovedVerdict
+            {
+                SubnetId = 1,
+                StatusName = statusName,
+                Reason = "VNet 'vnet-a' still exists but no longer has the address prefix 10.111.0.0/16."
+            }),
+            VNetBackWithADifferentPrefix());
+
+        _ = Assert.IsType<ConflictObjectResult>(result);
+        await AssertNothingArchived();
+    }
+
+    // -------------------------------------------------------------------------
+    // Counter-test - a matching verdict must still archive, or the feature is dead
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task AVerdictThatStillMatches_ArchivesNormally()
+    {
+        MockAzureService azure = VNetBackWithADifferentPrefix();
+
+        AzureReconcileDeleteDto request = Request();
+        request.Statuses = await AzureReconcileApproval.ForAsync(azure, _snapshotService, SubId, [1]);
+
+        // Sanity: the scan really did produce a verdict to approve.
+        Assert.Single(request.Statuses);
+        Assert.Equal(nameof(AzureReconcileStatus.VNetPrefixRemoved), request.Statuses[0].StatusName);
+
+        IActionResult result = await Delete(request, azure);
+
+        _ = Assert.IsType<OkObjectResult>(result);
+        Assert.Null(await _context.Subnets.FindAsync([1], TestContext.Current.CancellationToken));
+        Assert.Null(await _context.Subnets.FindAsync([2], TestContext.Current.CancellationToken));
+    }
+}

--- a/test/Bastet.Tests/Azure/SubnetControllerReconcileApprovedVerdictTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerReconcileApprovedVerdictTests.cs
@@ -32,7 +32,7 @@ public class SubnetControllerReconcileApprovedVerdictTests : IDisposable
 
     private readonly BastetDbContext _context;
     private readonly SubnetController _controller;
-    private readonly IAzureReconciler _reconciler = new AzureReconciler();
+    private readonly IAzureReconciler _reconciler = new AzureReconciler(new IpUtilityService());
     private readonly AzureSubnetSnapshotService _snapshotService;
 
     public SubnetControllerReconcileApprovedVerdictTests()

--- a/test/Bastet.Tests/Azure/SubnetControllerRelinkAzureSubnetTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerRelinkAzureSubnetTests.cs
@@ -1,0 +1,233 @@
+using Bastet.Controllers;
+using Bastet.Data;
+using Bastet.Models;
+using Bastet.Models.ViewModels;
+using Bastet.Services;
+using Bastet.Services.Azure;
+using Bastet.Services.Validation;
+using Bastet.Tests.TestHelpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Bastet.Tests.Azure;
+
+/// <summary>
+/// The repair path for a subnet whose Azure range moved under a new resource ID. Before it existed
+/// such a row could only be archived, which made BASTET advertise a range Azure had already
+/// assigned as free space.
+///
+/// The guard that matters most: the caller supplies no resource ID at all. The server re-scans and
+/// re-derives the link, so a stale browser view or a crafted post cannot point a Bastet subnet at an
+/// arbitrary Azure resource.
+/// </summary>
+[Collection(AzureFeatureFlagCollection.Name)]
+public class SubnetControllerRelinkAzureSubnetTests : IDisposable
+{
+    private const string SubId = "11111111-1111-1111-1111-111111111111";
+    private const string VNetId =
+        $"/subscriptions/{SubId}/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet-a";
+    private const string OldSubnetId = $"{VNetId}/subnets/sn-a";
+    private const string NewSubnetId = $"{VNetId}/subnets/sn-a2";
+
+    private readonly BastetDbContext _context;
+    private readonly SubnetController _controller;
+    private readonly IAzureReconciler _reconciler = new AzureReconciler();
+    private readonly AzureSubnetSnapshotService _snapshotService;
+
+    public SubnetControllerRelinkAzureSubnetTests()
+    {
+        DbContextOptions<BastetDbContext> options = new DbContextOptionsBuilder<BastetDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        _context = new BastetDbContext(options);
+        _context.Database.OpenConnection();
+        _context.Database.EnsureCreated();
+
+        IIpUtilityService ipUtilityService = new IpUtilityService();
+        _snapshotService = new AzureSubnetSnapshotService(_context);
+
+        _controller = new SubnetController(
+            _context,
+            ipUtilityService,
+            new SubnetValidationService(ipUtilityService),
+            new HostIpValidationService(ipUtilityService, _context),
+            ControllerTestHelper.CreateMockUserContextService(),
+            ControllerTestHelper.CreateMockSubnetLockingService(),
+            NullLogger<SubnetController>.Instance);
+        ControllerTestHelper.SetupController(_controller);
+        _controller.Url = Mock.Of<IUrlHelper>();
+
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "true");
+
+        // A Bastet subnet linked to sn-a, which Azure no longer has.
+        _context.Subnets.Add(new Subnet
+        {
+            Id = 1,
+            Name = "app",
+            NetworkAddress = "10.111.5.0",
+            Cidr = 24,
+            AzureResourceId = OldSubnetId,
+            CreatedAt = DateTime.UtcNow
+        });
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", null);
+        _context.Database.CloseConnection();
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Azure as it is after the rename: sn-a is gone, sn-a2 carries the same /24.</summary>
+    private static MockAzureService AzureAfterRename() =>
+        new(true,
+            vnets:
+            [
+                new AzureVNetViewModel { ResourceId = VNetId, Name = "vnet-a", AddressPrefixes = ["10.111.0.0/16"] }
+            ],
+            subnets:
+            [
+                new AzureSubnetViewModel { ResourceId = NewSubnetId, Name = "sn-a2", AddressPrefix = "10.111.5.0/24" }
+            ]);
+
+    /// <summary>Azure where the range is genuinely gone - nothing holds 10.111.5.0/24 any more.</summary>
+    private static MockAzureService AzureAfterGenuineDeletion() =>
+        new(true,
+            vnets:
+            [
+                new AzureVNetViewModel { ResourceId = VNetId, Name = "vnet-a", AddressPrefixes = ["10.111.0.0/16"] }
+            ],
+            subnets:
+            [
+                new AzureSubnetViewModel { ResourceId = $"{VNetId}/subnets/other", Name = "other", AddressPrefix = "10.111.9.0/24" }
+            ]);
+
+    private Task<IActionResult> Relink(int subnetId, IAzureService azureService) =>
+        _controller.RelinkAzureSubnet(
+            new AzureRelinkDto { SubscriptionId = SubId, SubnetId = subnetId },
+            azureService, _reconciler, _snapshotService);
+
+    private async Task<string?> LinkOf(int id) =>
+        (await _context.Subnets.FindAsync([id], TestContext.Current.CancellationToken))?.AzureResourceId;
+
+    // -------------------------------------------------------------------------
+    // The repair itself
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task ARangeThatMovedToANewAzureSubnet_IsRelinkedToIt()
+    {
+        IActionResult result = await Relink(1, AzureAfterRename());
+
+        _ = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(NewSubnetId, await LinkOf(1));
+    }
+
+    [Fact]
+    public async Task TheRepairIsIdempotent_ASecondAttemptIsRefusedBecauseThereIsNothingLeftToFix()
+    {
+        MockAzureService azure = AzureAfterRename();
+
+        _ = Assert.IsType<OkObjectResult>(await Relink(1, azure));
+        // Now linked correctly, so the row is no longer reported at all.
+        _ = Assert.IsType<ConflictObjectResult>(await Relink(1, azure));
+        Assert.Equal(NewSubnetId, await LinkOf(1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Guards - the endpoint must never write a link Azure does not justify
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// The counter-test to the repair: a genuinely deleted range has no new owner, so there is
+    /// nothing to re-link to and the row must be left exactly as it is - still deletable.
+    /// </summary>
+    [Fact]
+    public async Task ARangeThatIsGenuinelyGone_IsNotRelinked()
+    {
+        IActionResult result = await Relink(1, AzureAfterGenuineDeletion());
+
+        _ = Assert.IsType<ConflictObjectResult>(result);
+        Assert.Equal(OldSubnetId, await LinkOf(1));
+    }
+
+    /// <summary>A subnet that is perfectly healthy is not a repair candidate.</summary>
+    [Fact]
+    public async Task ASubnetWhoseLinkIsStillLive_IsRefused()
+    {
+        MockAzureService azure = new(true,
+            vnets: [new AzureVNetViewModel { ResourceId = VNetId, Name = "vnet-a", AddressPrefixes = ["10.111.0.0/16"] }],
+            subnets: [new AzureSubnetViewModel { ResourceId = OldSubnetId, Name = "sn-a", AddressPrefix = "10.111.5.0/24" }]);
+
+        _ = Assert.IsType<ConflictObjectResult>(await Relink(1, azure));
+        Assert.Equal(OldSubnetId, await LinkOf(1));
+    }
+
+    /// <summary>
+    /// Fail closed. A scan that could not read Azure establishes nothing, so it must not be the
+    /// basis for rewriting a link any more than for deleting a row.
+    /// </summary>
+    [Fact]
+    public async Task WhenAzureCannotBeRead_NothingIsChanged()
+    {
+        IActionResult result = await Relink(1, new MockAzureService(credentialValid: false));
+
+        _ = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(OldSubnetId, await LinkOf(1));
+    }
+
+    [Fact]
+    public async Task AnUnknownSubnetId_ChangesNothing()
+    {
+        _ = Assert.IsType<ConflictObjectResult>(await Relink(999, AzureAfterRename()));
+        Assert.Equal(OldSubnetId, await LinkOf(1));
+    }
+
+    [Fact]
+    public async Task WithTheFeatureFlagOff_TheEndpointIsUnavailable()
+    {
+        Environment.SetEnvironmentVariable("BASTET_AZURE_IMPORT", "false");
+
+        ObjectResult result = Assert.IsType<ObjectResult>(await Relink(1, AzureAfterRename()));
+
+        Assert.Equal(403, result.StatusCode);
+        Assert.Equal(OldSubnetId, await LinkOf(1));
+    }
+
+    [Fact]
+    public async Task ANullRequest_IsRejected()
+    {
+        IActionResult result = await _controller.RelinkAzureSubnet(
+            null!, AzureAfterRename(), _reconciler, _snapshotService);
+
+        _ = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(OldSubnetId, await LinkOf(1));
+    }
+
+    /// <summary>
+    /// The point of deriving the link server-side: the range that moved decides what the row links
+    /// to, and the client has no say in it. A different subnet in the same VNet holding a different
+    /// range is never a candidate, so no request shape can select it.
+    /// </summary>
+    [Fact]
+    public async Task TheNewLinkIsDerivedFromAzure_NotFromAnythingTheCallerSupplied()
+    {
+        MockAzureService azure = new(true,
+            vnets: [new AzureVNetViewModel { ResourceId = VNetId, Name = "vnet-a", AddressPrefixes = ["10.111.0.0/16"] }],
+            subnets:
+            [
+                new AzureSubnetViewModel { ResourceId = NewSubnetId, Name = "sn-a2", AddressPrefix = "10.111.5.0/24" },
+                new AzureSubnetViewModel { ResourceId = $"{VNetId}/subnets/decoy", Name = "decoy", AddressPrefix = "10.111.6.0/24" }
+            ]);
+
+        _ = Assert.IsType<OkObjectResult>(await Relink(1, azure));
+
+        // The subnet holding THIS row's range, never the other one.
+        Assert.Equal(NewSubnetId, await LinkOf(1));
+    }
+}

--- a/test/Bastet.Tests/Azure/SubnetControllerRelinkAzureSubnetTests.cs
+++ b/test/Bastet.Tests/Azure/SubnetControllerRelinkAzureSubnetTests.cs
@@ -33,7 +33,7 @@ public class SubnetControllerRelinkAzureSubnetTests : IDisposable
 
     private readonly BastetDbContext _context;
     private readonly SubnetController _controller;
-    private readonly IAzureReconciler _reconciler = new AzureReconciler();
+    private readonly IAzureReconciler _reconciler = new AzureReconciler(new IpUtilityService());
     private readonly AzureSubnetSnapshotService _snapshotService;
 
     public SubnetControllerRelinkAzureSubnetTests()

--- a/test/Bastet.Tests/Services/FullyAllocatedNoteTests.cs
+++ b/test/Bastet.Tests/Services/FullyAllocatedNoteTests.cs
@@ -169,4 +169,44 @@ public class FullyAllocatedNoteTests
     [Fact]
     public void FirstImport_WritesTheNoteAlone()
         => Assert.Equal(Note("sn"), FullyAllocatedNote.Append(null, "sn", Max));
+
+    // -------------------------------------------------------------------------
+    // A note must be single-line BY CONSTRUCTION, or Strip's anchoring cannot reach it
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// The defect: Strip matches whole lines anchored at both ends, so a name carrying a newline
+    /// built a note spanning two lines that no later Strip could remove. The flag could then be
+    /// cleared while the description went on asserting it, and every cycle stacked another copy.
+    /// </summary>
+    [Theory]
+    [InlineData("sn-A\nsn-B")]
+    [InlineData("sn-A\r\nsn-B")]
+    [InlineData("sn-A\rsn-B")]
+    public void ANameCarryingALineBreak_StillProducesAStrippableNote(string name)
+    {
+        string note = FullyAllocatedNote.Append(null, name, Max);
+
+        Assert.Single(note.Split('\n'));
+        Assert.Equal(string.Empty, FullyAllocatedNote.Strip(note));
+    }
+
+    /// <summary>And the stacking that followed from it: four cycles must still leave exactly one.</summary>
+    [Fact]
+    public void RepeatedAppendsWithALineBrokenName_StillLeaveExactlyOneNote()
+    {
+        string d = FullyAllocatedNote.Append("Ops owns this range", "sn-A\nsn-B", Max);
+        for (int i = 0; i < 3; i++)
+        {
+            d = FullyAllocatedNote.Append(d, "sn-A\nsn-B", Max);
+        }
+
+        Assert.Equal(2, d.Split('\n').Length);
+        Assert.Equal("Ops owns this range", FullyAllocatedNote.Strip(d));
+    }
+
+    /// <summary>The name is still readable - collapsed to a space, not deleted.</summary>
+    [Fact]
+    public void TheNameSurvivesWithItsLineBreakCollapsedToASpace()
+        => Assert.Equal(Note("sn-A sn-B"), FullyAllocatedNote.For("sn-A\nsn-B"));
 }

--- a/test/Bastet.Tests/TestHelpers/AzureReconcileApproval.cs
+++ b/test/Bastet.Tests/TestHelpers/AzureReconcileApproval.cs
@@ -1,0 +1,41 @@
+using Bastet.Models.ViewModels;
+using Bastet.Services.Azure;
+
+namespace Bastet.Tests.TestHelpers;
+
+/// <summary>
+/// Builds the approved-verdict snapshot the reconcile delete now requires, the same way the wizard
+/// does: scan first, then approve exactly the verdicts that scan showed.
+/// </summary>
+/// <remarks>
+/// Deliberately derived from a real plan rather than hand-written. A test that hardcodes the status
+/// it expects would keep passing if the reconciler started reporting something else, which is the
+/// very drift the check exists to catch.
+/// </remarks>
+public static class AzureReconcileApproval
+{
+    public static async Task<List<AzureReconcileApprovedVerdict>> ForAsync(
+        IAzureService azureService,
+        IAzureSubnetSnapshotService snapshotService,
+        string subscriptionId,
+        IEnumerable<int> subnetIds)
+    {
+        AzureVNetInventory inventory = await azureService.GetVNetInventory(subscriptionId);
+        IReadOnlyList<AzureLinkedSubnetSnapshot> linked = await snapshotService.GetAzureLinkedSubnetsAsync();
+        AzureReconcilePlanViewModel plan = new AzureReconciler().BuildPlan(subscriptionId, null, inventory, linked);
+
+        HashSet<int> wanted = [.. subnetIds];
+
+        return
+        [
+            .. plan.Items
+                .Where(i => wanted.Contains(i.SubnetId))
+                .Select(i => new AzureReconcileApprovedVerdict
+                {
+                    SubnetId = i.SubnetId,
+                    StatusName = i.StatusName,
+                    Reason = i.Reason
+                })
+        ];
+    }
+}

--- a/test/Bastet.Tests/TestHelpers/AzureReconcileApproval.cs
+++ b/test/Bastet.Tests/TestHelpers/AzureReconcileApproval.cs
@@ -1,4 +1,5 @@
 using Bastet.Models.ViewModels;
+using Bastet.Services;
 using Bastet.Services.Azure;
 
 namespace Bastet.Tests.TestHelpers;
@@ -22,7 +23,7 @@ public static class AzureReconcileApproval
     {
         AzureVNetInventory inventory = await azureService.GetVNetInventory(subscriptionId);
         IReadOnlyList<AzureLinkedSubnetSnapshot> linked = await snapshotService.GetAzureLinkedSubnetsAsync();
-        AzureReconcilePlanViewModel plan = new AzureReconciler().BuildPlan(subscriptionId, null, inventory, linked);
+        AzureReconcilePlanViewModel plan = new AzureReconciler(new IpUtilityService()).BuildPlan(subscriptionId, null, inventory, linked, []);
 
         HashSet<int> wanted = [.. subnetIds];
 


### PR DESCRIPTION
### New Features
- **Azure Reconcile now checks both directions.** It previously only asked whether things BASTET had imported still existed in Azure; it now also reports ranges Azure has assigned that no BASTET subnet records, so a scan can no longer come back clean while the free-space table hands out an allocated range
- **Top-up import** — a VNet that has gained subnets since it was imported can be imported again to pick up just the new ones. Existing subnets are left untouched, and the preview says so
- **Re-link a subnet to a renamed Azure subnet.** Azure has no rename, so renaming means delete-and-recreate; the reconcile review list now offers a one-click repair for a subnet whose range moved to a new Azure resource

### Improvements
- Azure-linked subnets now carry a note above **Unallocated IP Ranges** saying those ranges are free according to what BASTET has imported, with a link to Azure Reconcile — no outbound call is made to render it, so air-gapped installs are unaffected

### Bug Fixes
- Azure Reconcile could **archive a subnet whose address range is still assigned in Azure**, after which BASTET advertised that range as free with a *Create Subnet* button over it. It happened whenever an Azure subnet was renamed or its prefix moved to a different subnet, with no warning at any point, and the archive has no undo. Such rows are now withheld, explained, and repairable
- Reconcile could **archive a subtree on a reason it had already disproved** — a resource that came back in Azure between the confirmation screen and the click was still deleted, because the commit only re-checked *whether* a row was stale, never *why*. The batch is now refused with the rows that changed named
- With more than one replica, a failed lock release **left every subnet write failing for minutes with "The operation timed out due to high concurrency"** — which was untrue, and which no other replica could clear. Closing a connection returns it to the pool without ending the SQL session, so a session-owned lock outlived the request
- Importing an Azure subnet that owns several IP ranges could **create BASTET subnets with identical names**, distinguishable only by address — when the ranges fell under different VNet prefixes, when the same VNet contributed several prefixes, or when an Azure resource ID differed only in capitalisation. Each row is now named for the range it holds
- Imported subnet names could contain `/`, **a character BASTET's own Create form rejects** — and the *Create Subnet* prefill silently deleted it, turning `(10.20.40.0/24)` into the meaningless `(10.20.40.024)` for anyone who accepted the default. Generated names now use `-` and are checked against the app's own input rules
- An Azure subnet name containing a line break produced a **"fully allocated" note that could never be removed** — it survived clearing the flag, so the description kept asserting a state the subnet no longer had, and every re-import stacked another copy
